### PR TITLE
chore: add communique config

### DIFF
--- a/communique.toml
+++ b/communique.toml
@@ -1,0 +1,4 @@
+context = "pklr is a pure Rust parser and evaluator for Apple's Pkl configuration language. It requires no external binary or CLI."
+
+[defaults]
+emoji = false


### PR DESCRIPTION
Adds `communique.toml` with context about pklr for AI-generated release notes, matching the pattern used in jdx/hk, jdx/fnox, and jdx/mise.

*This PR was created by Claude Code.*