### PR TITLE
chore: add release-plz workflow and config

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -1,0 +1,71 @@
+name: Release-plz
+
+permissions:
+  pull-requests: write
+  contents: write
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  release-plz-release:
+    name: Release
+    runs-on: ubuntu-latest
+    if: ${{ github.repository_owner == 'jdx' }}
+    outputs:
+      tag: ${{ steps.release-plz.outputs.releases && fromJSON(steps.release-plz.outputs.releases)[0].tag || '' }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+      - name: Run release-plz
+        id: release-plz
+        uses: release-plz/action@1528104d2ca23787631a1c1f022abb64b34c1e11 # v0.5
+        with:
+          command: release
+        env:
+          GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
+  enhance-release:
+    name: Enhance release notes
+    needs: release-plz-release
+    if: ${{ needs.release-plz-release.outputs.tag != '' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 0
+      - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2
+      - run: communique generate "${{ needs.release-plz-release.outputs.tag }}" --github-release
+        env:
+          GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+
+  release-plz-pr:
+    name: Release PR
+    runs-on: ubuntu-latest
+    if: ${{ github.repository_owner == 'jdx' }}
+    concurrency:
+      group: release-plz-${{ github.ref }}
+      cancel-in-progress: false
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.RELEASE_PLZ_TOKEN }}
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+      - name: Run release-plz
+        uses: release-plz/action@1528104d2ca23787631a1c1f022abb64b34c1e11 # v0.5
+        with:
+          command: release-pr
+        env:
+          GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -43,8 +43,9 @@ jobs:
         with:
           fetch-depth: 0
       - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2
-      - run: communique generate "${{ needs.release-plz-release.outputs.tag }}" --github-release
+      - run: communique generate "$RELEASE_TAG" --github-release
         env:
+          RELEASE_TAG: ${{ needs.release-plz-release.outputs.tag }}
           GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
 

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,0 +1,9 @@
+[workspace]
+# Create git tags for releases
+git_tag_enable = true
+# Create GitHub releases
+git_release_enable = true
+# Create as draft so release notes can be enhanced before publishing
+git_release_draft = true
+# pklr is a library — keep semver check enabled
+semver_check = true


### PR DESCRIPTION
Adds the official `release-plz/action` workflow (matching jdx/pitchfork, not the custom mise task used in hk/fnox/mise) with three jobs:

- **Release**: runs `release-plz release` on push to main, publishes to crates.io and creates a draft GitHub release
- **Enhance release notes**: runs `communique generate` to write AI release notes into the GitHub release
- **Release PR**: runs `release-plz release-pr` to keep a version-bump PR open

`release-plz.toml` keeps `semver_check = true` since pklr is a library (unlike pitchfork which is a binary).

Requires secrets: `RELEASE_PLZ_TOKEN`, `CARGO_REGISTRY_TOKEN`, `ANTHROPIC_API_KEY`.

*This PR was created by Claude Code.*