### PR TITLE
fix(eval): guard integer div/mod against zero, remove unreachable Value::Mapping

### DIFF
--- a/src/eval.rs
+++ b/src/eval.rs
@@ -111,11 +111,6 @@ impl Evaluator {
                     let val = self.eval_expr(expr, &child_scope, depth)?;
                     match val {
                         Value::Object(m) => map.extend(m),
-                        Value::Mapping(pairs) => {
-                            for (k, v) in pairs {
-                                map.insert(value_to_key(&k)?, v);
-                            }
-                        }
                         _ => {}
                     }
                 }
@@ -339,10 +334,14 @@ impl Evaluator {
         let r = self.eval_expr(right, scope, depth + 1)?;
         match op {
             BinOp::Add => add_values(l, r),
-            BinOp::Sub => arithmetic(l, r, |a, b| a - b, |a, b| a - b),
-            BinOp::Mul => arithmetic(l, r, |a, b| a * b, |a, b| a * b),
-            BinOp::Div => arithmetic(l, r, |a, b| a / b, |a, b| a / b),
-            BinOp::Mod => arithmetic(l, r, |a, b| a % b, |a, b| a % b),
+            BinOp::Sub => arithmetic(l, r, |a, b| Ok(a - b), |a, b| Ok(a - b)),
+            BinOp::Mul => arithmetic(l, r, |a, b| Ok(a * b), |a, b| Ok(a * b)),
+            BinOp::Div => arithmetic(l, r,
+                |a, b| if b == 0 { Err(Error::Eval("division by zero".into())) } else { Ok(a / b) },
+                |a, b| Ok(a / b)),
+            BinOp::Mod => arithmetic(l, r,
+                |a, b| if b == 0 { Err(Error::Eval("modulo by zero".into())) } else { Ok(a % b) },
+                |a, b| Ok(a % b)),
             BinOp::Eq  => Ok(Value::Bool(values_eq(&l, &r))),
             BinOp::Ne  => Ok(Value::Bool(!values_eq(&l, &r))),
             BinOp::Lt  => compare(l, r, std::cmp::Ordering::Less),
@@ -473,12 +472,12 @@ fn add_values(l: Value, r: Value) -> Result<Value> {
     }
 }
 
-fn arithmetic(l: Value, r: Value, fi: impl Fn(i64, i64) -> i64, ff: impl Fn(f64, f64) -> f64) -> Result<Value> {
+fn arithmetic(l: Value, r: Value, fi: impl Fn(i64, i64) -> Result<i64>, ff: impl Fn(f64, f64) -> Result<f64>) -> Result<Value> {
     match (l, r) {
-        (Value::Int(a), Value::Int(b))     => Ok(Value::Int(fi(a, b))),
-        (Value::Float(a), Value::Float(b)) => Ok(Value::Float(ff(a, b))),
-        (Value::Int(a), Value::Float(b))   => Ok(Value::Float(ff(a as f64, b))),
-        (Value::Float(a), Value::Int(b))   => Ok(Value::Float(ff(a, b as f64))),
+        (Value::Int(a), Value::Int(b))     => Ok(Value::Int(fi(a, b)?)),
+        (Value::Float(a), Value::Float(b)) => Ok(Value::Float(ff(a, b)?)),
+        (Value::Int(a), Value::Float(b))   => Ok(Value::Float(ff(a as f64, b)?)),
+        (Value::Float(a), Value::Int(b))   => Ok(Value::Float(ff(a, b as f64)?)),
         (l, r) => Err(Error::Eval(format!("arithmetic type mismatch: {:?} vs {:?}", l, r))),
     }
 }
@@ -521,7 +520,6 @@ fn collection_to_items(v: Value) -> Vec<(Value, Value)> {
         Value::Object(map) => map.into_iter()
             .map(|(k, v)| (Value::String(k), v))
             .collect(),
-        Value::Mapping(pairs) => pairs,
         _ => vec![],
     }
 }

--- a/src/value.rs
+++ b/src/value.rs
@@ -2,6 +2,10 @@ use indexmap::IndexMap;
 use serde_json::json;
 
 /// A pkl runtime value.
+///
+/// Pkl's `Mapping` type (arbitrary key→value) is represented as `Object` when
+/// keys are strings — which is the only case supported by JSON output. All
+/// `new Mapping { ["key"] = ... }` expressions therefore produce `Object`.
 #[derive(Debug, Clone, PartialEq)]
 pub enum Value {
     Null,
@@ -9,39 +13,30 @@ pub enum Value {
     Int(i64),
     Float(f64),
     String(String),
-    /// Object (mapping of string keys to values), ordered
+    /// Object (ordered string-keyed map). Represents both pkl objects and
+    /// string-keyed Mappings.
     Object(IndexMap<String, Value>),
-    /// Listing (ordered list)
+    /// Listing (ordered list).
     List(Vec<Value>),
-    /// Mapping (arbitrary key->value)
-    Mapping(Vec<(Value, Value)>),
 }
 
 impl Value {
     pub fn to_json(&self) -> serde_json::Value {
         match self {
-            Value::Null           => serde_json::Value::Null,
-            Value::Bool(b)        => json!(b),
-            Value::Int(n)         => json!(n),
-            Value::Float(f)       => json!(f),
-            Value::String(s)      => json!(s),
-            Value::Object(map)    => {
+            Value::Null        => serde_json::Value::Null,
+            Value::Bool(b)     => json!(b),
+            Value::Int(n)      => json!(n),
+            Value::Float(f)    => json!(f),
+            Value::String(s)   => json!(s),
+            Value::Object(map) => {
                 let mut obj = serde_json::Map::new();
                 for (k, v) in map {
                     obj.insert(k.clone(), v.to_json());
                 }
                 serde_json::Value::Object(obj)
             }
-            Value::List(items)    => {
+            Value::List(items) => {
                 serde_json::Value::Array(items.iter().map(|v| v.to_json()).collect())
-            }
-            Value::Mapping(pairs) => {
-                // Mapping with non-string keys: serialize as array of [k, v] pairs
-                serde_json::Value::Array(
-                    pairs.iter()
-                        .map(|(k, v)| json!([k.to_json(), v.to_json()]))
-                        .collect()
-                )
             }
         }
     }


### PR DESCRIPTION
Addresses feedback from Greptile on #1.

- **Division/modulo by zero** now returns `Error::Eval` instead of panicking. The `arithmetic` helper was updated to accept fallible closures so the check is enforced at the type level.
- **`Value::Mapping` removed** — it was unreachable via the normal parse path. `new Mapping { ["key"] = ... }` correctly produces `Value::Object` since our JSON output only supports string keys. The doc comment on `Value` explains the design decision.

*This PR was created by Claude Code.*