### PR TITLE
docs: add CLAUDE.md and document supported pkl subset in README

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,52 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project
+
+pklr is a pure Rust parser and evaluator for Apple's Pkl configuration language. It evaluates `.pkl` files to `serde_json::Value` with no external binary or CLI required.
+
+## Commands
+
+```bash
+cargo build                                    # Build
+cargo test                                     # Run all tests
+cargo test --test pkl_features                 # Run feature tests only
+cargo test --test integration                  # Run integration tests only
+cargo test test_name                           # Run a single test by name
+cargo clippy --all-targets -- -D warnings      # Lint (warnings are errors)
+cargo fmt --check                              # Check formatting
+cargo fmt                                      # Auto-format
+```
+
+CI runs tests, clippy, and fmt check on all PRs.
+
+## Architecture
+
+Classic three-stage interpreter: **Lexer → Parser → Evaluator**
+
+```
+Source (.pkl) → lexer.rs (tokens) → parser.rs (AST) → eval.rs (Value) → value.rs (JSON)
+```
+
+- **`src/lib.rs`** — Public API: `eval_to_json(path)` and `analyze_imports(path)`
+- **`src/lexer.rs`** — Tokenizer. `TokenKind` enum with 80+ variants. Handles string literals (single-quote, triple-quote multiline), number formats (decimal, hex, octal, binary), comments, all Pkl operators
+- **`src/parser.rs`** — Builds AST from tokens. Key types: `Module` (top-level file), `Entry` (property/generator/spread), `Expr` (all expression types), `Property` (named field with modifiers). Also has `collect_imports()` for fast import extraction without full parse
+- **`src/eval.rs`** — Runtime evaluator with scope chain. Two-pass evaluation: collects `local` variables first, then evaluates non-local entries. Max recursion depth of 32. Built-in functions: `List()`, `Map()`, `Set()`
+- **`src/value.rs`** — `Value` enum (Null, Bool, Int, Float, String, Object, List). Uses `IndexMap` for ordered object keys. Converts to/from `serde_json::Value`
+- **`src/error.rs`** — Error types using `miette` for pretty diagnostics with source context
+
+## Testing
+
+- **`tests/integration.rs`** — Basic lexer/parser/evaluator tests
+- **`tests/pkl_features.rs`** — Comprehensive feature tests by category (primitives, objects, operators, control flow, generators, type expressions)
+- **`tests/fixtures/`** — Real-world `.pkl` files
+- Helper functions: `eval(src)` returns `serde_json::Value`, `eval_fails(src)` returns error string, `lex_kinds(src)` returns token kinds
+- Tests marked `#[ignore]` document unimplemented features
+
+## Conventions
+
+- No emoji in commits or code (per communique.toml)
+- Conventional commits for changelog generation (git-cliff)
+- Dependencies: `indexmap` (ordered maps), `miette` (error diagnostics), `serde_json` (JSON output), `thiserror` (error derive)
+- Property modifiers (Local, Const, Fixed, Hidden, etc.) are parsed but only `Local` affects evaluation currently

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,7 +30,7 @@ Source (.pkl) → lexer.rs (tokens) → parser.rs (AST) → eval.rs (Value) → 
 ```
 
 - **`src/lib.rs`** — Public API: `eval_to_json(path)` and `analyze_imports(path)`
-- **`src/lexer.rs`** — Tokenizer. `TokenKind` enum with 80+ variants. Handles string literals (single-quote, triple-quote multiline), number formats (decimal, hex, octal, binary), comments, all Pkl operators
+- **`src/lexer.rs`** — Tokenizer. `TokenKind` enum with 80+ variants. Handles string literals (double-quoted, triple-quote multiline, custom delimiters `#"..."#`), number formats (decimal, hex, octal, binary), comments, all Pkl operators
 - **`src/parser.rs`** — Builds AST from tokens. Key types: `Module` (top-level file), `Entry` (property/generator/spread), `Expr` (all expression types), `Property` (named field with modifiers). Also has `collect_imports()` for fast import extraction without full parse
 - **`src/eval.rs`** — Runtime evaluator with scope chain. Two-pass evaluation: collects `local` variables first, then evaluates non-local entries. Max recursion depth of 32. Built-in functions: `List()`, `Map()`, `Set()`. Supports string interpolation, lambda expressions, method calls on values, import/amends resolution, and null-safe access
 - **`src/value.rs`** — `Value` enum (Null, Bool, Int, Float, String, Object, List). Uses `IndexMap` for ordered object keys. Converts to/from `serde_json::Value`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,7 +32,7 @@ Source (.pkl) → lexer.rs (tokens) → parser.rs (AST) → eval.rs (Value) → 
 - **`src/lib.rs`** — Public API: `eval_to_json(path)` and `analyze_imports(path)`
 - **`src/lexer.rs`** — Tokenizer. `TokenKind` enum with 80+ variants. Handles string literals (single-quote, triple-quote multiline), number formats (decimal, hex, octal, binary), comments, all Pkl operators
 - **`src/parser.rs`** — Builds AST from tokens. Key types: `Module` (top-level file), `Entry` (property/generator/spread), `Expr` (all expression types), `Property` (named field with modifiers). Also has `collect_imports()` for fast import extraction without full parse
-- **`src/eval.rs`** — Runtime evaluator with scope chain. Two-pass evaluation: collects `local` variables first, then evaluates non-local entries. Max recursion depth of 32. Built-in functions: `List()`, `Map()`, `Set()`
+- **`src/eval.rs`** — Runtime evaluator with scope chain. Two-pass evaluation: collects `local` variables first, then evaluates non-local entries. Max recursion depth of 32. Built-in functions: `List()`, `Map()`, `Set()`. Supports string interpolation, lambda expressions, method calls on values, import/amends resolution, and null-safe access
 - **`src/value.rs`** — `Value` enum (Null, Bool, Int, Float, String, Object, List). Uses `IndexMap` for ordered object keys. Converts to/from `serde_json::Value`
 - **`src/error.rs`** — Error types using `miette` for pretty diagnostics with source context
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ pklr implements a subset of the [Pkl language](https://pkl-lang.org/main/current
 | Strings (double-quoted, escape sequences `\t \n \r \" \\`) | Supported |
 | Multiline strings (`"""`) | Supported |
 | String interpolation (`\(expr)`) | Supported |
-| Custom string delimiters (`#"..."#`) | Not yet supported |
+| Custom string delimiters (`#"..."#`) | Supported |
 | Unicode escape sequences (`\u{...}`) | Not yet supported |
 | Durations (`5.min`, `3.s`, etc.) | Not supported |
 | Data sizes (`5.mb`, `3.gb`, etc.) | Not supported |
@@ -133,7 +133,6 @@ Planned features, roughly in priority order:
 
 Nice-to-have:
 
-- Custom string delimiters (`#"..."#`)
 - More stdlib methods (`.map()`, `.filter()`, `.fold()`, etc.)
 - `import*` glob imports
 - Package URI imports (`package://...`)

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ pklr implements a subset of the [Pkl language](https://pkl-lang.org/main/current
 | Null | Supported |
 | Strings (double-quoted, escape sequences `\t \n \r \" \\`) | Supported |
 | Multiline strings (`"""`) | Supported |
-| String interpolation (`\(expr)`) | Not yet supported |
+| String interpolation (`\(expr)`) | Supported |
 | Custom string delimiters (`#"..."#`) | Not yet supported |
 | Unicode escape sequences (`\u{...}`) | Not yet supported |
 | Durations (`5.min`, `3.s`, etc.) | Not supported |
@@ -43,7 +43,7 @@ pklr implements a subset of the [Pkl language](https://pkl-lang.org/main/current
 | String concatenation (`+`) | Supported |
 | List concatenation (`+`) | Supported |
 | Object merging (`+`) | Supported |
-| Null propagation (`?.`) | Not yet supported |
+| Null propagation (`?.`) | Supported |
 | Non-null assertion (`!!`) | Not supported |
 | Pipe operator (`\|>`) | Not supported |
 
@@ -57,7 +57,7 @@ pklr implements a subset of the [Pkl language](https://pkl-lang.org/main/current
 | `new Mapping { ... }` | Supported |
 | `Map(k1, v1, k2, v2)` | Supported |
 | `List(...)` / `Listing(...)` | Supported |
-| `new Listing { ... }` body syntax | Not yet supported |
+| `new Listing { ... }` body syntax | Supported |
 | `Set(...)` | Parsed (treated as List) |
 | Object amendment (`(base) { overrides }`) | Not yet supported |
 | Spread operator (`...expr`) | Supported |
@@ -89,8 +89,8 @@ pklr implements a subset of the [Pkl language](https://pkl-lang.org/main/current
 
 | Feature | Status |
 |---|---|
-| `import` / `amends` parsing | Parsed |
-| Import resolution & evaluation | Not yet supported |
+| `import` / `amends` | Supported (local files) |
+| Import resolution & evaluation | Supported (local files) |
 | `import*` (globbed imports) | Not supported |
 | `extends` | Not supported |
 | `module` keyword | Not supported |
@@ -101,8 +101,8 @@ pklr implements a subset of the [Pkl language](https://pkl-lang.org/main/current
 |---|---|
 | Class definitions (`class Foo { ... }`) | Not yet supported |
 | Class inheritance | Not supported |
-| Methods and member access (`.length`, `.isEmpty`) | Not yet supported |
-| Anonymous functions / lambdas (`(x) -> x * 2`) | Not yet supported |
+| Methods and member access (`.length`, `.isEmpty`, `.contains()`, etc.) | Supported |
+| Anonymous functions / lambdas (`(x) -> x * 2`) | Supported |
 | `this` / `outer` keywords | Not yet supported |
 | `super` keyword | Not supported |
 
@@ -125,23 +125,18 @@ The following Pkl features are not currently implemented:
 
 Planned features, roughly in priority order:
 
-1. String interpolation (`\(expr)`)
-2. Import resolution and evaluation
-3. `new Listing { ... }` body syntax
-4. Object amendment (`(base) { overrides }`)
-5. Method calls on values (`.length`, `.isEmpty`, etc.)
-6. `this` / `outer` keywords
-7. Class definitions with defaults (`class Foo { name: String = "default" }`)
-8. Null-safe access (`?.`)
-9. Module header — parse and skip gracefully
-10. Annotations (`@Foo`) — parse and skip
+1. Object amendment (`(base) { overrides }`)
+2. `this` / `outer` keywords
+3. Class definitions with defaults (`class Foo { name: String = "default" }`)
+4. Module header — parse and skip gracefully
+5. Annotations (`@Foo`) — parse and skip
 
 Nice-to-have:
 
-- Anonymous functions / lambdas (`(x) -> x * 2`)
 - Custom string delimiters (`#"..."#`)
 - More stdlib methods (`.map()`, `.filter()`, `.fold()`, etc.)
 - `import*` glob imports
+- Package URI imports (`package://...`)
 - Type checking / validation
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -8,7 +8,128 @@ No external binary or CLI required.
 - Lexer, parser, and evaluator written entirely in Rust
 - Evaluates `.pkl` files to `serde_json::Value`
 - Import analysis for cache invalidation
-- Supports: objects, mappings, listings, local variables, spread (`...`), `for`/`when` generators, all primitive types
+
+## Supported Pkl Subset
+
+pklr implements a subset of the [Pkl language](https://pkl-lang.org/main/current/language-reference/). The tables below show what is and isn't supported relative to the full language specification.
+
+### Types & Literals
+
+| Feature | Status |
+|---|---|
+| Int (decimal, hex, octal, binary, underscores) | Supported |
+| Float (decimal, exponent notation) | Supported |
+| Boolean (`true`, `false`) | Supported |
+| Null | Supported |
+| Strings (double-quoted, escape sequences `\t \n \r \" \\`) | Supported |
+| Multiline strings (`"""`) | Supported |
+| String interpolation (`\(expr)`) | Not yet supported |
+| Custom string delimiters (`#"..."#`) | Not yet supported |
+| Unicode escape sequences (`\u{...}`) | Not yet supported |
+| Durations (`5.min`, `3.s`, etc.) | Not supported |
+| Data sizes (`5.mb`, `3.gb`, etc.) | Not supported |
+| NaN, Infinity | Not supported |
+
+### Operators
+
+| Feature | Status |
+|---|---|
+| Arithmetic (`+`, `-`, `*`, `/`, `%`) | Supported |
+| Integer division (`~/`) | Not supported |
+| Exponentiation (`**`) | Not supported |
+| Comparison (`==`, `!=`, `<`, `>`, `<=`, `>=`) | Supported |
+| Logical (`&&`, `\|\|`, `!`) | Supported |
+| Null coalescing (`??`) | Supported |
+| String concatenation (`+`) | Supported |
+| List concatenation (`+`) | Supported |
+| Object merging (`+`) | Supported |
+| Null propagation (`?.`) | Not yet supported |
+| Non-null assertion (`!!`) | Not supported |
+| Pipe operator (`\|>`) | Not supported |
+
+### Objects, Listings & Mappings
+
+| Feature | Status |
+|---|---|
+| Object literals (`{ key = value }`) | Supported |
+| Nested objects | Supported |
+| Dynamic keys (`["key"] = value`) | Supported |
+| `new Mapping { ... }` | Supported |
+| `Map(k1, v1, k2, v2)` | Supported |
+| `List(...)` / `Listing(...)` | Supported |
+| `new Listing { ... }` body syntax | Not yet supported |
+| `Set(...)` | Parsed (treated as List) |
+| Object amendment (`(base) { overrides }`) | Not yet supported |
+| Spread operator (`...expr`) | Supported |
+| Late binding | Not supported |
+| Default elements/values | Not supported |
+
+### Control Flow & Expressions
+
+| Feature | Status |
+|---|---|
+| `if (cond) expr else expr` | Supported |
+| `let (name = val) expr` | Supported |
+| `for (k, v in collection) { ... }` | Supported |
+| `when (cond) { ... } else { ... }` | Supported |
+| `throw(msg)` | Supported |
+| `trace(expr)` | Supported |
+| `read(uri)` | Parsed (returns error at runtime) |
+| `is` / `as` type operators | Parsed (type checks not enforced) |
+
+### Variables & Scope
+
+| Feature | Status |
+|---|---|
+| `local` variables | Supported |
+| Scope chain with parent lookup | Supported |
+| Property modifiers (`const`, `fixed`, `hidden`, `abstract`, `open`, `external`) | Parsed but not enforced |
+
+### Modules & Imports
+
+| Feature | Status |
+|---|---|
+| `import` / `amends` parsing | Parsed |
+| Import resolution & evaluation | Not yet supported |
+| `import*` (globbed imports) | Not supported |
+| `extends` | Not supported |
+| `module` keyword | Not supported |
+
+### Not Yet Supported
+
+The following Pkl features are not currently implemented:
+
+- **Methods** and method calls on values (e.g., `"foo".length`, `list.isEmpty`)
+- **Anonymous functions / lambdas** (`(x) -> x * 2`)
+- **Type aliases** and **type constraints**
+- **Type annotations** (parsed but not validated)
+- **Member predicates** (`[[...]]`)
+- **`super`** keyword
+- **Regular expressions** (`Regex`)
+- **Packages** and **projects**
+- **Standard library** modules
+- **Resource readers** (`read()`)
+- **Doc comments** (`///`)
+- **Quoted identifiers** (`` `my-name` ``)
+
+### Roadmap
+
+Planned features, roughly in priority order:
+
+1. String interpolation (`\(expr)`)
+2. Import resolution and evaluation
+3. `new Listing { ... }` body syntax
+4. Object amendment (`(base) { overrides }`)
+5. `this` / `outer` references
+6. Class definitions with defaults (`class Foo { name: String = "default" }`)
+7. Module header — parse and skip gracefully
+8. Annotations (`@Foo`) — parse and skip
+
+Nice-to-have:
+
+- More stdlib methods (`.map()`, `.filter()`, `.fold()`, etc.)
+- `import*` glob imports
+- Type checking / validation
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -95,16 +95,25 @@ pklr implements a subset of the [Pkl language](https://pkl-lang.org/main/current
 | `extends` | Not supported |
 | `module` keyword | Not supported |
 
+### Classes & Methods
+
+| Feature | Status |
+|---|---|
+| Class definitions (`class Foo { ... }`) | Not yet supported |
+| Class inheritance | Not supported |
+| Methods and member access (`.length`, `.isEmpty`) | Not yet supported |
+| Anonymous functions / lambdas (`(x) -> x * 2`) | Not yet supported |
+| `this` / `outer` keywords | Not yet supported |
+| `super` keyword | Not supported |
+
 ### Not Yet Supported
 
 The following Pkl features are not currently implemented:
 
-- **Methods** and method calls on values (e.g., `"foo".length`, `list.isEmpty`)
-- **Anonymous functions / lambdas** (`(x) -> x * 2`)
 - **Type aliases** and **type constraints**
 - **Type annotations** (parsed but not validated)
 - **Member predicates** (`[[...]]`)
-- **`super`** keyword
+- **Annotations** (`@Deprecated`, `@ModuleInfo`, etc.)
 - **Regular expressions** (`Regex`)
 - **Packages** and **projects**
 - **Standard library** modules
@@ -120,13 +129,17 @@ Planned features, roughly in priority order:
 2. Import resolution and evaluation
 3. `new Listing { ... }` body syntax
 4. Object amendment (`(base) { overrides }`)
-5. `this` / `outer` references
-6. Class definitions with defaults (`class Foo { name: String = "default" }`)
-7. Module header — parse and skip gracefully
-8. Annotations (`@Foo`) — parse and skip
+5. Method calls on values (`.length`, `.isEmpty`, etc.)
+6. `this` / `outer` keywords
+7. Class definitions with defaults (`class Foo { name: String = "default" }`)
+8. Null-safe access (`?.`)
+9. Module header — parse and skip gracefully
+10. Annotations (`@Foo`) — parse and skip
 
 Nice-to-have:
 
+- Anonymous functions / lambdas (`(x) -> x * 2`)
+- Custom string delimiters (`#"..."#`)
 - More stdlib methods (`.map()`, `.filter()`, `.fold()`, etc.)
 - `import*` glob imports
 - Type checking / validation


### PR DESCRIPTION
## Summary
- Add `CLAUDE.md` with build commands, architecture overview, and conventions for Claude Code
- Update `README.md` with comprehensive tables showing supported/unsupported Pkl language features relative to the official spec
- Add a roadmap section with planned features in priority order

## Test plan
- [ ] Verify README renders correctly on GitHub
- [ ] Verify CLAUDE.md content matches actual project state

🤖 Generated with [Claude Code](https://claude.com/claude-code)