### PR TITLE
feat: v1 language features

### DIFF
--- a/src/eval.rs
+++ b/src/eval.rs
@@ -377,7 +377,8 @@ impl Evaluator {
                         .cloned()
                         .ok_or_else(|| Error::Eval(format!("field not found: {field}"))),
                     _ => Err(Error::Eval(format!(
-                        "cannot access field '{field}' on non-object"
+                        "cannot access field '{field}' on {}",
+                        value_type_name(&obj)
                     ))),
                 }
             }
@@ -387,7 +388,8 @@ impl Evaluator {
                     Value::Null => Ok(Value::Null),
                     Value::Object(map) => Ok(map.get(field).cloned().unwrap_or(Value::Null)),
                     _ => Err(Error::Eval(format!(
-                        "cannot access field '{field}' on non-object"
+                        "cannot access field '{field}' on {}",
+                        value_type_name(&obj)
                     ))),
                 }
             }
@@ -784,6 +786,19 @@ impl Scope {
 }
 
 // --- Helpers ---
+
+fn value_type_name(v: &Value) -> &'static str {
+    match v {
+        Value::Null => "Null",
+        Value::Bool(_) => "Boolean",
+        Value::Int(_) => "Int",
+        Value::Float(_) => "Float",
+        Value::String(_) => "String",
+        Value::Object(_) => "Object",
+        Value::List(_) => "List",
+        Value::Lambda(..) => "Function",
+    }
+}
 
 fn value_to_key(v: &Value) -> Result<String> {
     match v {

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -60,7 +60,10 @@ impl Evaluator {
                 let base = path.parent().unwrap_or(Path::new("."));
                 base.join(uri)
             };
-            if import_path.exists() {
+            if !import_path.exists() {
+                return Err(Error::ImportNotFound(import_path.display().to_string()));
+            }
+            {
                 let source = std::fs::read_to_string(&import_path)
                     .map_err(|e| Error::Io(import_path.clone(), e))?;
                 let imported_val = {
@@ -92,7 +95,9 @@ impl Evaluator {
                     let base = path.parent().unwrap_or(Path::new("."));
                     base.join(uri)
                 };
-                if amends_path.exists() {
+                if !amends_path.exists() {
+                    // Amends file may be a schema reference that doesn't exist locally — skip
+                } else {
                     let source = std::fs::read_to_string(&amends_path)
                         .map_err(|e| Error::Io(amends_path.clone(), e))?;
                     let name = amends_path.display().to_string();
@@ -350,7 +355,9 @@ impl Evaluator {
                             .cloned()
                             .ok_or_else(|| Error::Eval("empty list".into()));
                     }
-                    (Value::String(s), "length") => return Ok(Value::Int(s.len() as i64)),
+                    (Value::String(s), "length") => {
+                        return Ok(Value::Int(s.chars().count() as i64));
+                    }
                     (Value::String(s), "isEmpty") => return Ok(Value::Bool(s.is_empty())),
                     (Value::Object(map), "length") => return Ok(Value::Int(map.len() as i64)),
                     (Value::Object(map), "isEmpty") => return Ok(Value::Bool(map.is_empty())),
@@ -611,6 +618,18 @@ impl Evaluator {
             (Value::Int(n), "toString") => Ok(Some(Value::String(n.to_string()))),
             (Value::Float(f), "toString") => Ok(Some(Value::String(f.to_string()))),
             (Value::Bool(b), "toString") => Ok(Some(Value::String(b.to_string()))),
+
+            // Lambda.apply()
+            (Value::Lambda(params, body, captured), "apply") => {
+                let mut call_scope = Scope::default();
+                for (k, v) in captured {
+                    call_scope.set(k.clone(), v.clone());
+                }
+                for (param, arg) in params.iter().zip(args.iter()) {
+                    call_scope.set(param.clone(), arg.clone());
+                }
+                Ok(Some(self.eval_expr(body, &call_scope, 0)?))
+            }
 
             _ => Ok(None), // not a known method
         }

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -38,8 +38,73 @@ impl Evaluator {
         self.eval_module(&module, path, 0)
     }
 
-    fn eval_module(&mut self, module: &Module, _path: &Path, depth: usize) -> Result<Value> {
+    fn eval_module(&mut self, module: &Module, path: &Path, depth: usize) -> Result<Value> {
+        if depth > self.max_depth {
+            return Err(Error::Eval(format!(
+                "max import depth {} exceeded",
+                self.max_depth
+            )));
+        }
         let mut scope = Scope::default();
+
+        // Process imports
+        for import in &module.imports {
+            let uri = &import.uri;
+            // Skip package URIs and non-local imports
+            if uri.contains("://") && !uri.starts_with("file://") {
+                continue;
+            }
+            let import_path = if let Some(rel) = uri.strip_prefix("file://") {
+                PathBuf::from(rel)
+            } else {
+                let base = path.parent().unwrap_or(Path::new("."));
+                base.join(uri)
+            };
+            if import_path.exists() {
+                let source = std::fs::read_to_string(&import_path)
+                    .map_err(|e| Error::Io(import_path.clone(), e))?;
+                let imported_val = {
+                    let name = import_path.display().to_string();
+                    let tokens = lexer::lex_named(&source, &name)?;
+                    let imp_module = parser::parse_named(&tokens, &source, &name)?;
+                    self.eval_module(&imp_module, &import_path, depth + 1)?
+                };
+                // Determine the binding name: alias or filename stem
+                let alias = import.alias.clone().unwrap_or_else(|| {
+                    import_path
+                        .file_stem()
+                        .unwrap_or_default()
+                        .to_string_lossy()
+                        .to_string()
+                });
+                scope.set(alias, imported_val);
+            }
+        }
+
+        // Process amends: load base module as starting values
+        let mut base_obj = IndexMap::new();
+        if let Some(uri) = &module.amends {
+            // Skip package URIs
+            if !uri.contains("://") || uri.starts_with("file://") {
+                let amends_path = if let Some(rel) = uri.strip_prefix("file://") {
+                    PathBuf::from(rel)
+                } else {
+                    let base = path.parent().unwrap_or(Path::new("."));
+                    base.join(uri)
+                };
+                if amends_path.exists() {
+                    let source = std::fs::read_to_string(&amends_path)
+                        .map_err(|e| Error::Io(amends_path.clone(), e))?;
+                    let name = amends_path.display().to_string();
+                    let tokens = lexer::lex_named(&source, &name)?;
+                    let base_module = parser::parse_named(&tokens, &source, &name)?;
+                    let base_val = self.eval_module(&base_module, &amends_path, depth + 1)?;
+                    if let Value::Object(m) = base_val {
+                        base_obj = m;
+                    }
+                }
+            }
+        }
 
         // First pass: collect all `local` variable definitions into scope
         for entry in &module.body {
@@ -56,7 +121,7 @@ impl Evaluator {
         }
 
         // Second pass: evaluate non-local entries into output object
-        let mut out = IndexMap::new();
+        let mut out = base_obj;
         for entry in &module.body {
             if let Entry::Property(prop) = entry {
                 if prop
@@ -165,6 +230,7 @@ impl Evaluator {
                         }
                     }
                 }
+                Entry::Elem(_) => {} // bare elements only valid in Listing bodies
             }
         }
         Ok(Value::Object(map))
@@ -197,12 +263,20 @@ impl Evaluator {
                 .get(name)
                 .cloned()
                 .ok_or_else(|| Error::Eval(format!("undefined variable: {name}"))),
+            Expr::Lambda(params, body) => {
+                // Capture current scope values
+                let captured = scope.flatten();
+                Ok(Value::Lambda(params.clone(), (**body).clone(), captured))
+            }
             Expr::New(type_name, entries) => {
                 match type_name.as_deref() {
                     Some("Listing") => {
                         let mut items = Vec::new();
                         for entry in entries {
                             match entry {
+                                Entry::Elem(e) => {
+                                    items.push(self.eval_expr(e, scope, depth + 1)?);
+                                }
                                 Entry::Property(p) if p.value.is_some() => {
                                     items.push(self.eval_expr(
                                         p.value.as_ref().unwrap(),
@@ -216,6 +290,29 @@ impl Evaluator {
                                         Value::List(l) => items.extend(l),
                                         Value::Object(m) => items.extend(m.into_values()),
                                         other => items.push(other),
+                                    }
+                                }
+                                Entry::ForGenerator(fgen) => {
+                                    let collection =
+                                        self.eval_expr(&fgen.collection, scope, depth + 1)?;
+                                    for (_k, v) in collection_to_items(collection) {
+                                        let mut iter_scope = scope.child();
+                                        iter_scope.set(fgen.val_var.clone(), v);
+                                        if let Some(key_var) = &fgen.key_var {
+                                            iter_scope.set(
+                                                key_var.clone(),
+                                                Value::Int(items.len() as i64),
+                                            );
+                                        }
+                                        for sub in &fgen.body {
+                                            if let Entry::Elem(e) = sub {
+                                                items.push(self.eval_expr(
+                                                    e,
+                                                    &iter_scope,
+                                                    depth + 1,
+                                                )?);
+                                            }
+                                        }
                                     }
                                 }
                                 _ => {}
@@ -237,11 +334,51 @@ impl Evaluator {
             Expr::ObjectBody(entries) => self.eval_entries(entries, scope, depth + 1),
             Expr::Field(obj_expr, field) => {
                 let obj = self.eval_expr(obj_expr, scope, depth + 1)?;
+                // Built-in properties
+                match (&obj, field.as_str()) {
+                    (Value::List(items), "length") => return Ok(Value::Int(items.len() as i64)),
+                    (Value::List(items), "isEmpty") => return Ok(Value::Bool(items.is_empty())),
+                    (Value::List(items), "first") => {
+                        return items
+                            .first()
+                            .cloned()
+                            .ok_or_else(|| Error::Eval("empty list".into()));
+                    }
+                    (Value::List(items), "last") => {
+                        return items
+                            .last()
+                            .cloned()
+                            .ok_or_else(|| Error::Eval("empty list".into()));
+                    }
+                    (Value::String(s), "length") => return Ok(Value::Int(s.len() as i64)),
+                    (Value::String(s), "isEmpty") => return Ok(Value::Bool(s.is_empty())),
+                    (Value::Object(map), "length") => return Ok(Value::Int(map.len() as i64)),
+                    (Value::Object(map), "isEmpty") => return Ok(Value::Bool(map.is_empty())),
+                    (Value::Object(map), "keys") => {
+                        return Ok(Value::List(
+                            map.keys().map(|k| Value::String(k.clone())).collect(),
+                        ));
+                    }
+                    (Value::Object(map), "values") => {
+                        return Ok(Value::List(map.values().cloned().collect()));
+                    }
+                    _ => {}
+                }
                 match &obj {
                     Value::Object(map) => map
                         .get(field)
                         .cloned()
                         .ok_or_else(|| Error::Eval(format!("field not found: {field}"))),
+                    _ => Err(Error::Eval(format!(
+                        "cannot access field '{field}' on non-object"
+                    ))),
+                }
+            }
+            Expr::NullSafeField(obj_expr, field) => {
+                let obj = self.eval_expr(obj_expr, scope, depth + 1)?;
+                match &obj {
+                    Value::Null => Ok(Value::Null),
+                    Value::Object(map) => Ok(map.get(field).cloned().unwrap_or(Value::Null)),
                     _ => Err(Error::Eval(format!(
                         "cannot access field '{field}' on non-object"
                     ))),
@@ -317,6 +454,19 @@ impl Evaluator {
         scope: &Scope,
         depth: usize,
     ) -> Result<Value> {
+        // Handle method calls: obj.method(args)
+        if let Expr::Field(obj_expr, method) = func_expr {
+            let obj = self.eval_expr(obj_expr, scope, depth + 1)?;
+            let evaled_args: Result<Vec<_>> = args
+                .iter()
+                .map(|a| self.eval_expr(a, scope, depth + 1))
+                .collect();
+            let evaled_args = evaled_args?;
+            if let Some(result) = self.eval_method_call(&obj, method, &evaled_args)? {
+                return Ok(result);
+            }
+        }
+
         // Handle built-in functions: List(), Listing(), Map()
         if let Expr::Ident(name) = func_expr {
             match name.as_str() {
@@ -353,14 +503,117 @@ impl Evaluator {
             }
         }
 
-        // Object amendment: `(Base) { overrides }` is parsed as Binop(Add, base, ObjectBody)
-        // Handle as a call on an object-returning expression
+        // Evaluate the function expression
         let func_val = self.eval_expr(func_expr, scope, depth + 1)?;
-        // If it's a plain call with no args on an object, return the object
+
+        // Lambda call
+        if let Value::Lambda(params, body, captured) = func_val {
+            let mut call_scope = Scope::default();
+            // Restore captured scope
+            for (k, v) in captured {
+                call_scope.set(k, v);
+            }
+            // Bind arguments to parameters
+            let evaled_args: Result<Vec<_>> = args
+                .iter()
+                .map(|a| self.eval_expr(a, scope, depth + 1))
+                .collect();
+            let evaled_args = evaled_args?;
+            for (param, arg) in params.iter().zip(evaled_args) {
+                call_scope.set(param.clone(), arg);
+            }
+            return self.eval_expr(&body, &call_scope, depth + 1);
+        }
+
+        // Plain call with no args on an object — return the object
         if args.is_empty() {
             return Ok(func_val);
         }
         Err(Error::Eval("cannot call non-function".into()))
+    }
+
+    fn eval_method_call(
+        &mut self,
+        obj: &Value,
+        method: &str,
+        args: &[Value],
+    ) -> Result<Option<Value>> {
+        match (obj, method) {
+            // String methods
+            (Value::String(s), "contains") => {
+                let arg = args.first().and_then(|v| v.as_str()).unwrap_or("");
+                Ok(Some(Value::Bool(s.contains(arg))))
+            }
+            (Value::String(s), "startsWith") => {
+                let arg = args.first().and_then(|v| v.as_str()).unwrap_or("");
+                Ok(Some(Value::Bool(s.starts_with(arg))))
+            }
+            (Value::String(s), "endsWith") => {
+                let arg = args.first().and_then(|v| v.as_str()).unwrap_or("");
+                Ok(Some(Value::Bool(s.ends_with(arg))))
+            }
+            (Value::String(s), "replaceAll") => {
+                let from = args.first().and_then(|v| v.as_str()).unwrap_or("");
+                let to = args.get(1).and_then(|v| v.as_str()).unwrap_or("");
+                Ok(Some(Value::String(s.replace(from, to))))
+            }
+            (Value::String(s), "split") => {
+                let sep = args.first().and_then(|v| v.as_str()).unwrap_or("");
+                Ok(Some(Value::List(
+                    s.split(sep).map(|p| Value::String(p.to_string())).collect(),
+                )))
+            }
+            (Value::String(s), "trim") => Ok(Some(Value::String(s.trim().to_string()))),
+            (Value::String(s), "trimStart") => Ok(Some(Value::String(s.trim_start().to_string()))),
+            (Value::String(s), "trimEnd") => Ok(Some(Value::String(s.trim_end().to_string()))),
+            (Value::String(s), "toUpperCase") => Ok(Some(Value::String(s.to_uppercase()))),
+            (Value::String(s), "toLowerCase") => Ok(Some(Value::String(s.to_lowercase()))),
+            (Value::String(s), "toInt") => s
+                .parse::<i64>()
+                .map(|n| Some(Value::Int(n)))
+                .map_err(|_| Error::Eval(format!("cannot convert '{s}' to Int"))),
+
+            // List methods
+            (Value::List(items), "contains") => {
+                let arg = args.first().cloned().unwrap_or(Value::Null);
+                Ok(Some(Value::Bool(items.contains(&arg))))
+            }
+            (Value::List(items), "toList") => Ok(Some(Value::List(items.clone()))),
+            (Value::List(items), "toSet") => {
+                let mut seen = Vec::new();
+                for item in items {
+                    if !seen.contains(item) {
+                        seen.push(item.clone());
+                    }
+                }
+                Ok(Some(Value::List(seen)))
+            }
+            (Value::List(items), "join") => {
+                let sep = args.first().and_then(|v| v.as_str()).unwrap_or(",");
+                let s: Vec<String> = items.iter().map(value_to_display).collect();
+                Ok(Some(Value::String(s.join(sep))))
+            }
+            (Value::List(items), "reverse") => {
+                let mut rev = items.clone();
+                rev.reverse();
+                Ok(Some(Value::List(rev)))
+            }
+
+            // Object/Mapping methods
+            (Value::Object(map), "containsKey") => {
+                let key = args.first().and_then(|v| v.as_str()).unwrap_or("");
+                Ok(Some(Value::Bool(map.contains_key(key))))
+            }
+            (Value::Object(map), "toMap") => Ok(Some(Value::Object(map.clone()))),
+            (Value::Object(_), "toList") | (Value::Object(_), "toDynamic") => Ok(Some(obj.clone())),
+
+            // Int/Float methods
+            (Value::Int(n), "toString") => Ok(Some(Value::String(n.to_string()))),
+            (Value::Float(f), "toString") => Ok(Some(Value::String(f.to_string()))),
+            (Value::Bool(b), "toString") => Ok(Some(Value::String(b.to_string()))),
+
+            _ => Ok(None), // not a known method
+        }
     }
 
     fn eval_binop(
@@ -498,6 +751,16 @@ impl Scope {
         self.vars
             .get(name)
             .or_else(|| self.parent.as_ref().and_then(|p| p.get(name)))
+    }
+
+    fn flatten(&self) -> IndexMap<String, Value> {
+        let mut result = self
+            .parent
+            .as_ref()
+            .map(|p| p.flatten())
+            .unwrap_or_default();
+        result.extend(self.vars.clone());
+        result
     }
 }
 

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -3,7 +3,7 @@ use std::path::{Path, PathBuf};
 
 use crate::error::{Error, Result};
 use crate::lexer;
-use crate::parser::{self, BinOp, Entry, Expr, Module, Property, UnOp};
+use crate::parser::{self, BinOp, Entry, Expr, Module, Property, StringInterpPart, UnOp};
 use crate::value::Value;
 
 /// Evaluates pkl source files to [`Value`].
@@ -180,6 +180,19 @@ impl Evaluator {
             Expr::Int(n) => Ok(Value::Int(*n)),
             Expr::Float(f) => Ok(Value::Float(*f)),
             Expr::String(s) => Ok(Value::String(s.clone())),
+            Expr::StringInterpolation(parts) => {
+                let mut result = String::new();
+                for part in parts {
+                    match part {
+                        StringInterpPart::Literal(s) => result.push_str(s),
+                        StringInterpPart::Expr(e) => {
+                            let val = self.eval_expr(e, scope, depth + 1)?;
+                            result.push_str(&value_to_display(&val));
+                        }
+                    }
+                }
+                Ok(Value::String(result))
+            }
             Expr::Ident(name) => scope
                 .get(name)
                 .cloned()

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -300,14 +300,11 @@ impl Evaluator {
                                 Entry::ForGenerator(fgen) => {
                                     let collection =
                                         self.eval_expr(&fgen.collection, scope, depth + 1)?;
-                                    for (_k, v) in collection_to_items(collection) {
+                                    for (k, v) in collection_to_items(collection) {
                                         let mut iter_scope = scope.child();
                                         iter_scope.set(fgen.val_var.clone(), v);
                                         if let Some(key_var) = &fgen.key_var {
-                                            iter_scope.set(
-                                                key_var.clone(),
-                                                Value::Int(items.len() as i64),
-                                            );
+                                            iter_scope.set(key_var.clone(), k);
                                         }
                                         for sub in &fgen.body {
                                             if let Entry::Elem(e) = sub {
@@ -471,7 +468,7 @@ impl Evaluator {
                 .map(|a| self.eval_expr(a, scope, depth + 1))
                 .collect();
             let evaled_args = evaled_args?;
-            if let Some(result) = self.eval_method_call(&obj, method, &evaled_args)? {
+            if let Some(result) = self.eval_method_call(&obj, method, &evaled_args, depth)? {
                 return Ok(result);
             }
         }
@@ -546,28 +543,29 @@ impl Evaluator {
         obj: &Value,
         method: &str,
         args: &[Value],
+        depth: usize,
     ) -> Result<Option<Value>> {
         match (obj, method) {
             // String methods
             (Value::String(s), "contains") => {
-                let arg = args.first().and_then(|v| v.as_str()).unwrap_or("");
+                let arg = require_str_arg(args, 0, "contains")?;
                 Ok(Some(Value::Bool(s.contains(arg))))
             }
             (Value::String(s), "startsWith") => {
-                let arg = args.first().and_then(|v| v.as_str()).unwrap_or("");
+                let arg = require_str_arg(args, 0, "startsWith")?;
                 Ok(Some(Value::Bool(s.starts_with(arg))))
             }
             (Value::String(s), "endsWith") => {
-                let arg = args.first().and_then(|v| v.as_str()).unwrap_or("");
+                let arg = require_str_arg(args, 0, "endsWith")?;
                 Ok(Some(Value::Bool(s.ends_with(arg))))
             }
             (Value::String(s), "replaceAll") => {
-                let from = args.first().and_then(|v| v.as_str()).unwrap_or("");
-                let to = args.get(1).and_then(|v| v.as_str()).unwrap_or("");
+                let from = require_str_arg(args, 0, "replaceAll")?;
+                let to = require_str_arg(args, 1, "replaceAll")?;
                 Ok(Some(Value::String(s.replace(from, to))))
             }
             (Value::String(s), "split") => {
-                let sep = args.first().and_then(|v| v.as_str()).unwrap_or("");
+                let sep = require_str_arg(args, 0, "split")?;
                 Ok(Some(Value::List(
                     s.split(sep).map(|p| Value::String(p.to_string())).collect(),
                 )))
@@ -630,7 +628,7 @@ impl Evaluator {
                 for (param, arg) in params.iter().zip(args.iter()) {
                     call_scope.set(param.clone(), arg.clone());
                 }
-                Ok(Some(self.eval_expr(body, &call_scope, 0)?))
+                Ok(Some(self.eval_expr(body, &call_scope, depth + 1)?))
             }
 
             _ => Ok(None), // not a known method
@@ -786,6 +784,20 @@ impl Scope {
 }
 
 // --- Helpers ---
+
+fn require_str_arg<'a>(args: &'a [Value], idx: usize, method: &str) -> Result<&'a str> {
+    match args.get(idx) {
+        Some(Value::String(s)) => Ok(s.as_str()),
+        Some(other) => Err(Error::Eval(format!(
+            "{method}() requires a String argument, got {}",
+            value_type_name(other)
+        ))),
+        None => Err(Error::Eval(format!(
+            "{method}() requires {} argument(s)",
+            idx + 1
+        ))),
+    }
+}
 
 fn value_type_name(v: &Value) -> &'static str {
     match v {

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -1,10 +1,19 @@
 use crate::error::{Error, Result};
 
 #[derive(Debug, Clone, PartialEq)]
+pub enum StringPart {
+    Literal(String),
+    Tokens(Vec<Token>),
+}
+
+#[derive(Debug, Clone, PartialEq)]
 pub enum TokenKind {
     // Literals
     Ident(String),
     StringLit(String),
+    /// Interpolated string: alternating literal parts and expression-token groups.
+    /// Parts[0] is always a literal (possibly empty), Parts[1] is tokens for first \(...), etc.
+    InterpolatedString(Vec<StringPart>),
     IntLit(i64),
     FloatLit(f64),
     BoolLit(bool),
@@ -82,7 +91,7 @@ pub enum TokenKind {
     Eof,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct Token {
     pub kind: TokenKind,
     pub line: usize,
@@ -180,9 +189,11 @@ impl<'a> Lexer<'a> {
         }
     }
 
-    fn read_string(&mut self) -> Result<String> {
+    fn read_string_token(&mut self) -> Result<TokenKind> {
         // Assumes opening quote already consumed
-        let mut s = String::new();
+        let mut current = String::new();
+        let mut parts: Vec<StringPart> = Vec::new();
+        let mut has_interpolation = false;
         loop {
             match self.advance() {
                 None => {
@@ -191,28 +202,73 @@ impl<'a> Lexer<'a> {
                 Some('"') => break,
                 Some('\\') => {
                     match self.advance() {
-                        Some('n') => s.push('\n'),
-                        Some('t') => s.push('\t'),
-                        Some('r') => s.push('\r'),
-                        Some('"') => s.push('"'),
-                        Some('\\') => s.push('\\'),
+                        Some('n') => current.push('\n'),
+                        Some('t') => current.push('\t'),
+                        Some('r') => current.push('\r'),
+                        Some('"') => current.push('"'),
+                        Some('\\') => current.push('\\'),
                         Some('(') => {
-                            // String interpolation \( ... ) - not fully supported yet
-                            s.push_str("\\(");
+                            has_interpolation = true;
+                            parts.push(StringPart::Literal(std::mem::take(&mut current)));
+                            // Lex tokens until matching ')'
+                            let mut depth = 1;
+                            let mut expr_tokens = Vec::new();
+                            loop {
+                                self.skip_whitespace_and_comments();
+                                if self.peek().is_none() {
+                                    return Err(self.lex_error("unterminated string interpolation"));
+                                }
+                                if self.peek() == Some(')') && depth == 1 {
+                                    self.advance();
+                                    break;
+                                }
+                                // Use the main tokenizer to get one token
+                                let line = self.line;
+                                let col = self.col;
+                                let offset = self.pos;
+                                let kind = self.read_one_token()?;
+                                if matches!(kind, TokenKind::LParen) {
+                                    depth += 1;
+                                } else if matches!(kind, TokenKind::RParen) {
+                                    depth -= 1;
+                                    if depth == 0 {
+                                        break;
+                                    }
+                                }
+                                expr_tokens.push(Token {
+                                    kind,
+                                    line,
+                                    col,
+                                    offset,
+                                });
+                            }
+                            // Add Eof token so the parser knows when to stop
+                            expr_tokens.push(Token {
+                                kind: TokenKind::Eof,
+                                line: self.line,
+                                col: self.col,
+                                offset: self.pos,
+                            });
+                            parts.push(StringPart::Tokens(expr_tokens));
                         }
                         Some(c) => {
-                            s.push('\\');
-                            s.push(c);
+                            current.push('\\');
+                            current.push(c);
                         }
                         None => {
                             return Err(self.lex_error("unterminated escape"));
                         }
                     }
                 }
-                Some(c) => s.push(c),
+                Some(c) => current.push(c),
             }
         }
-        Ok(s)
+        if has_interpolation {
+            parts.push(StringPart::Literal(current));
+            Ok(TokenKind::InterpolatedString(parts))
+        } else {
+            Ok(TokenKind::StringLit(current))
+        }
     }
 
     fn read_multiline_string(&mut self) -> Result<String> {
@@ -357,200 +413,7 @@ impl<'a> Lexer<'a> {
                 Some(c) => c,
             };
 
-            let kind = match ch {
-                '{' => {
-                    self.advance();
-                    TokenKind::LBrace
-                }
-                '}' => {
-                    self.advance();
-                    TokenKind::RBrace
-                }
-                '(' => {
-                    self.advance();
-                    TokenKind::LParen
-                }
-                ')' => {
-                    self.advance();
-                    TokenKind::RParen
-                }
-                '[' => {
-                    self.advance();
-                    TokenKind::LBracket
-                }
-                ']' => {
-                    self.advance();
-                    TokenKind::RBracket
-                }
-                ',' => {
-                    self.advance();
-                    TokenKind::Comma
-                }
-                '.' => {
-                    self.advance();
-                    if self.source[self.pos..].starts_with("..") {
-                        self.advance();
-                        self.advance();
-                        TokenKind::DotDotDot
-                    } else {
-                        TokenKind::Dot
-                    }
-                }
-                '=' => {
-                    self.advance();
-                    if self.peek() == Some('=') {
-                        self.advance();
-                        TokenKind::EqEq
-                    } else if self.peek() == Some('>') {
-                        self.advance();
-                        TokenKind::ThinArrow
-                    } else {
-                        TokenKind::Equals
-                    }
-                }
-                ':' => {
-                    self.advance();
-                    TokenKind::Colon
-                }
-                '?' => {
-                    self.advance();
-                    if self.peek() == Some('?') {
-                        self.advance();
-                        TokenKind::QuestionQuestion
-                    } else if self.peek() == Some('.') {
-                        self.advance();
-                        TokenKind::QuestionDot
-                    } else {
-                        TokenKind::QuestionMark
-                    }
-                }
-                '!' => {
-                    self.advance();
-                    if self.peek() == Some('=') {
-                        self.advance();
-                        TokenKind::BangEq
-                    } else {
-                        TokenKind::Bang
-                    }
-                }
-                '|' => {
-                    self.advance();
-                    if self.peek() == Some('|') {
-                        self.advance();
-                        TokenKind::PipePipe
-                    } else {
-                        TokenKind::Pipe
-                    }
-                }
-                '^' => {
-                    self.advance();
-                    TokenKind::Caret
-                }
-                '@' => {
-                    self.advance();
-                    TokenKind::At
-                }
-                '+' => {
-                    self.advance();
-                    TokenKind::Plus
-                }
-                '-' => {
-                    self.advance();
-                    if self.peek() == Some('>') {
-                        self.advance();
-                        TokenKind::Arrow
-                    } else {
-                        TokenKind::Minus
-                    }
-                }
-                '*' => {
-                    self.advance();
-                    TokenKind::Star
-                }
-                '/' => {
-                    self.advance();
-                    TokenKind::Slash
-                }
-                '%' => {
-                    self.advance();
-                    TokenKind::Percent
-                }
-                '<' => {
-                    self.advance();
-                    if self.peek() == Some('=') {
-                        self.advance();
-                        TokenKind::LtEq
-                    } else {
-                        TokenKind::Lt
-                    }
-                }
-                '>' => {
-                    self.advance();
-                    if self.peek() == Some('=') {
-                        self.advance();
-                        TokenKind::GtEq
-                    } else {
-                        TokenKind::Gt
-                    }
-                }
-                '&' => {
-                    self.advance();
-                    if self.peek() == Some('&') {
-                        self.advance();
-                        TokenKind::AmpAmp
-                    } else {
-                        return Err(self.lex_error("unexpected '&'"));
-                    }
-                }
-                '"' => {
-                    self.advance();
-                    // Check for multiline string `"""`
-                    if self.source[self.pos..].starts_with("\"\"") {
-                        self.advance();
-                        self.advance();
-                        let s = self.read_multiline_string()?;
-                        TokenKind::StringLit(s)
-                    } else {
-                        let s = self.read_string()?;
-                        TokenKind::StringLit(s)
-                    }
-                }
-                '#' => {
-                    // #"..."# raw strings
-                    self.advance();
-                    if self.peek() == Some('"') {
-                        self.advance();
-                        let s = self.read_raw_string('#')?;
-                        TokenKind::StringLit(s)
-                    } else {
-                        // Could be a shebang line or annotation
-                        while self.peek().map(|c| c != '\n').unwrap_or(false) {
-                            self.advance();
-                        }
-                        continue;
-                    }
-                }
-                c if c.is_ascii_digit() => {
-                    self.advance();
-                    self.read_number(c)?
-                }
-                c if c.is_alphabetic() || c == '_' => {
-                    let start = self.pos; // pos points TO current char before advance
-                    self.advance();
-                    while self
-                        .peek()
-                        .map(|c| c.is_alphanumeric() || c == '_')
-                        .unwrap_or(false)
-                    {
-                        self.advance();
-                    }
-                    let ident = &self.source[start..self.pos];
-                    keyword_or_ident(ident)
-                }
-                c => {
-                    return Err(self.lex_error(format!("unexpected character: {c:?}")));
-                }
-            };
+            let kind = self.read_one_token_from(ch)?;
 
             tokens.push(Token {
                 kind,
@@ -560,6 +423,211 @@ impl<'a> Lexer<'a> {
             });
         }
         Ok(tokens)
+    }
+
+    fn read_one_token(&mut self) -> Result<TokenKind> {
+        self.skip_whitespace_and_comments();
+        let ch = self
+            .peek()
+            .ok_or_else(|| self.lex_error("unexpected end of input"))?;
+        self.read_one_token_from(ch)
+    }
+
+    fn read_one_token_from(&mut self, ch: char) -> Result<TokenKind> {
+        let kind = match ch {
+            '{' => {
+                self.advance();
+                TokenKind::LBrace
+            }
+            '}' => {
+                self.advance();
+                TokenKind::RBrace
+            }
+            '(' => {
+                self.advance();
+                TokenKind::LParen
+            }
+            ')' => {
+                self.advance();
+                TokenKind::RParen
+            }
+            '[' => {
+                self.advance();
+                TokenKind::LBracket
+            }
+            ']' => {
+                self.advance();
+                TokenKind::RBracket
+            }
+            ',' => {
+                self.advance();
+                TokenKind::Comma
+            }
+            '.' => {
+                self.advance();
+                if self.source[self.pos..].starts_with("..") {
+                    self.advance();
+                    self.advance();
+                    TokenKind::DotDotDot
+                } else {
+                    TokenKind::Dot
+                }
+            }
+            '=' => {
+                self.advance();
+                if self.peek() == Some('=') {
+                    self.advance();
+                    TokenKind::EqEq
+                } else if self.peek() == Some('>') {
+                    self.advance();
+                    TokenKind::ThinArrow
+                } else {
+                    TokenKind::Equals
+                }
+            }
+            ':' => {
+                self.advance();
+                TokenKind::Colon
+            }
+            '?' => {
+                self.advance();
+                if self.peek() == Some('?') {
+                    self.advance();
+                    TokenKind::QuestionQuestion
+                } else if self.peek() == Some('.') {
+                    self.advance();
+                    TokenKind::QuestionDot
+                } else {
+                    TokenKind::QuestionMark
+                }
+            }
+            '!' => {
+                self.advance();
+                if self.peek() == Some('=') {
+                    self.advance();
+                    TokenKind::BangEq
+                } else {
+                    TokenKind::Bang
+                }
+            }
+            '|' => {
+                self.advance();
+                if self.peek() == Some('|') {
+                    self.advance();
+                    TokenKind::PipePipe
+                } else {
+                    TokenKind::Pipe
+                }
+            }
+            '^' => {
+                self.advance();
+                TokenKind::Caret
+            }
+            '@' => {
+                self.advance();
+                TokenKind::At
+            }
+            '+' => {
+                self.advance();
+                TokenKind::Plus
+            }
+            '-' => {
+                self.advance();
+                if self.peek() == Some('>') {
+                    self.advance();
+                    TokenKind::Arrow
+                } else {
+                    TokenKind::Minus
+                }
+            }
+            '*' => {
+                self.advance();
+                TokenKind::Star
+            }
+            '/' => {
+                self.advance();
+                TokenKind::Slash
+            }
+            '%' => {
+                self.advance();
+                TokenKind::Percent
+            }
+            '<' => {
+                self.advance();
+                if self.peek() == Some('=') {
+                    self.advance();
+                    TokenKind::LtEq
+                } else {
+                    TokenKind::Lt
+                }
+            }
+            '>' => {
+                self.advance();
+                if self.peek() == Some('=') {
+                    self.advance();
+                    TokenKind::GtEq
+                } else {
+                    TokenKind::Gt
+                }
+            }
+            '&' => {
+                self.advance();
+                if self.peek() == Some('&') {
+                    self.advance();
+                    TokenKind::AmpAmp
+                } else {
+                    return Err(self.lex_error("unexpected '&'"));
+                }
+            }
+            '"' => {
+                self.advance();
+                // Check for multiline string `"""`
+                if self.source[self.pos..].starts_with("\"\"") {
+                    self.advance();
+                    self.advance();
+                    let s = self.read_multiline_string()?;
+                    TokenKind::StringLit(s)
+                } else {
+                    self.read_string_token()?
+                }
+            }
+            '#' => {
+                // #"..."# raw strings
+                self.advance();
+                if self.peek() == Some('"') {
+                    self.advance();
+                    let s = self.read_raw_string('#')?;
+                    TokenKind::StringLit(s)
+                } else {
+                    // Could be a shebang line or annotation — skip line
+                    while self.peek().map(|c| c != '\n').unwrap_or(false) {
+                        self.advance();
+                    }
+                    return self.read_one_token();
+                }
+            }
+            c if c.is_ascii_digit() => {
+                self.advance();
+                self.read_number(c)?
+            }
+            c if c.is_alphabetic() || c == '_' => {
+                let start = self.pos; // pos points TO current char before advance
+                self.advance();
+                while self
+                    .peek()
+                    .map(|c| c.is_alphanumeric() || c == '_')
+                    .unwrap_or(false)
+                {
+                    self.advance();
+                }
+                let ident = &self.source[start..self.pos];
+                keyword_or_ident(ident)
+            }
+            c => {
+                return Err(self.lex_error(format!("unexpected character: {c:?}")));
+            }
+        };
+        Ok(kind)
     }
 
     fn read_raw_string(&mut self, _delimiter: char) -> Result<String> {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,28 +1,28 @@
 use crate::error::{Error, Result};
 use crate::lexer::{Token, TokenKind};
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum StringInterpPart {
     Literal(String),
     Expr(Expr),
 }
 
 /// A pkl module (top-level file).
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct Module {
     pub amends: Option<String>,
     pub imports: Vec<Import>,
     pub body: Vec<Entry>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct Import {
     pub uri: String,
     pub alias: Option<String>,
 }
 
 /// A top-level or object entry.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum Entry {
     /// `key = expr` or `key: Type = expr`
     Property(Property),
@@ -34,9 +34,11 @@ pub enum Entry {
     WhenGenerator(WhenGenerator),
     /// `...spread`
     Spread(Expr),
+    /// Bare element expression (used in Listing bodies)
+    Elem(Expr),
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct Property {
     pub modifiers: Vec<Modifier>,
     pub name: String,
@@ -46,7 +48,7 @@ pub struct Property {
     pub body: Option<Vec<Entry>>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum Modifier {
     Local,
     Const,
@@ -57,7 +59,7 @@ pub enum Modifier {
     External,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum TypeExpr {
     Named(String),
     Nullable(Box<TypeExpr>),
@@ -66,7 +68,7 @@ pub enum TypeExpr {
 }
 
 /// An expression.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum Expr {
     Null,
     Bool(bool),
@@ -98,6 +100,10 @@ pub enum Expr {
     ObjectBody(Vec<Entry>),
     /// String interpolation: alternating literal strings and expressions
     StringInterpolation(Vec<StringInterpPart>),
+    /// Null-safe field access: `expr?.field`
+    NullSafeField(Box<Expr>, String),
+    /// Lambda: `(params) -> body`
+    Lambda(Vec<String>, Box<Expr>),
     /// `throw("msg")`
     Throw(Box<Expr>),
     /// `trace(expr)`
@@ -106,7 +112,7 @@ pub enum Expr {
     Read(Box<Expr>),
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub enum BinOp {
     Add,
     Sub,
@@ -124,13 +130,13 @@ pub enum BinOp {
     NullCoalesce,
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub enum UnOp {
     Neg,
     Not,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct ForGenerator {
     pub key_var: Option<String>,
     pub val_var: String,
@@ -138,7 +144,7 @@ pub struct ForGenerator {
     pub body: Vec<Entry>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct WhenGenerator {
     pub condition: Expr,
     pub body: Vec<Entry>,
@@ -353,6 +359,22 @@ impl<'a> Parser<'a> {
                 Ok(Entry::Spread(expr))
             }
             _ => {
+                // Check for bare element (used in Listing bodies): literal values
+                // not followed by = or { or :
+                if matches!(
+                    self.peek(),
+                    TokenKind::StringLit(_)
+                        | TokenKind::InterpolatedString(_)
+                        | TokenKind::IntLit(_)
+                        | TokenKind::FloatLit(_)
+                        | TokenKind::BoolLit(_)
+                        | TokenKind::Null
+                        | TokenKind::KwNew
+                ) {
+                    let expr = self.parse_expr()?;
+                    return Ok(Entry::Elem(expr));
+                }
+
                 // Property: [modifiers] name [: Type] [= expr | { body }]
                 let mut modifiers = Vec::new();
                 loop {
@@ -572,6 +594,11 @@ impl<'a> Parser<'a> {
                     let field = self.expect_ident()?;
                     expr = Expr::Field(Box::new(expr), field);
                 }
+                TokenKind::QuestionDot => {
+                    self.advance();
+                    let field = self.expect_ident()?;
+                    expr = Expr::NullSafeField(Box::new(expr), field);
+                }
                 TokenKind::LBracket => {
                     // Only treat as indexing if on the same line as the expression.
                     // A `[` on a new line is a new dynamic entry, not indexing.
@@ -663,7 +690,21 @@ impl<'a> Parser<'a> {
                 Ok(Expr::StringInterpolation(interp_parts))
             }
             TokenKind::LParen => {
-                self.advance();
+                // Try to parse as lambda: (params) -> body
+                let saved_pos = self.pos;
+                let saved_last_line = self.last_line;
+                self.advance(); // consume (
+                if let Some(params) = self.try_parse_lambda_params()
+                    && matches!(self.peek(), TokenKind::Arrow)
+                {
+                    self.advance(); // consume ->
+                    let body = self.parse_expr()?;
+                    return Ok(Expr::Lambda(params, Box::new(body)));
+                }
+                // Not a lambda — restore and parse as parenthesized expression
+                self.pos = saved_pos;
+                self.last_line = saved_last_line;
+                self.advance(); // consume (
                 let e = self.parse_expr()?;
                 self.expect(&TokenKind::RParen)?;
                 Ok(e)
@@ -732,6 +773,39 @@ impl<'a> Parser<'a> {
                 Ok(Expr::Ident(name))
             }
             tok => Err(self.parse_error(format!("unexpected token in expression: {:?}", tok))),
+        }
+    }
+
+    /// Try to parse `ident, ident, ...) ` — returns None if not a valid lambda param list.
+    fn try_parse_lambda_params(&mut self) -> Option<Vec<String>> {
+        let mut params = Vec::new();
+        // Handle () -> expr (no params)
+        if matches!(self.peek(), TokenKind::RParen) {
+            self.advance();
+            return Some(params);
+        }
+        // First param
+        if let TokenKind::Ident(name) = self.peek().clone() {
+            self.advance();
+            params.push(name);
+        } else {
+            return None;
+        }
+        // Remaining params
+        while matches!(self.peek(), TokenKind::Comma) {
+            self.advance();
+            if let TokenKind::Ident(name) = self.peek().clone() {
+                self.advance();
+                params.push(name);
+            } else {
+                return None;
+            }
+        }
+        if matches!(self.peek(), TokenKind::RParen) {
+            self.advance();
+            Some(params)
+        } else {
+            None
         }
     }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,6 +1,12 @@
 use crate::error::{Error, Result};
 use crate::lexer::{Token, TokenKind};
 
+#[derive(Debug, Clone)]
+pub enum StringInterpPart {
+    Literal(String),
+    Expr(Expr),
+}
+
 /// A pkl module (top-level file).
 #[derive(Debug, Clone)]
 pub struct Module {
@@ -90,6 +96,8 @@ pub enum Expr {
     Unop(UnOp, Box<Expr>),
     /// Object/listing literal — anonymous `{ ... }`
     ObjectBody(Vec<Entry>),
+    /// String interpolation: alternating literal strings and expressions
+    StringInterpolation(Vec<StringInterpPart>),
     /// `throw("msg")`
     Throw(Box<Expr>),
     /// `trace(expr)`
@@ -162,6 +170,11 @@ pub fn parse(tokens: &[Token]) -> Result<Module> {
 pub fn parse_named(tokens: &[Token], source: &str, name: &str) -> Result<Module> {
     let mut p = Parser::new(tokens, source, name);
     p.parse_module()
+}
+
+pub fn parse_expr_tokens(tokens: &[Token], source: &str, name: &str) -> Result<Expr> {
+    let mut p = Parser::new(tokens, source, name);
+    p.parse_expr()
 }
 
 struct Parser<'a> {
@@ -632,6 +645,22 @@ impl<'a> Parser<'a> {
             TokenKind::StringLit(s) => {
                 self.advance();
                 Ok(Expr::String(s))
+            }
+            TokenKind::InterpolatedString(parts) => {
+                self.advance();
+                let mut interp_parts = Vec::new();
+                for part in parts {
+                    match part {
+                        crate::lexer::StringPart::Literal(s) => {
+                            interp_parts.push(StringInterpPart::Literal(s));
+                        }
+                        crate::lexer::StringPart::Tokens(tokens) => {
+                            let expr = parse_expr_tokens(&tokens, &self.source, &self.name)?;
+                            interp_parts.push(StringInterpPart::Expr(expr));
+                        }
+                    }
+                }
+                Ok(Expr::StringInterpolation(interp_parts))
             }
             TokenKind::LParen => {
                 self.advance();

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -359,9 +359,9 @@ impl<'a> Parser<'a> {
                 Ok(Entry::Spread(expr))
             }
             _ => {
-                // Check for bare element (used in Listing bodies): literal values
-                // not followed by = or { or :
-                if matches!(
+                // Check for bare element (used in Listing bodies): literal values,
+                // or identifiers not followed by = or { or : (which would be properties)
+                let is_bare_literal = matches!(
                     self.peek(),
                     TokenKind::StringLit(_)
                         | TokenKind::InterpolatedString(_)
@@ -370,7 +370,14 @@ impl<'a> Parser<'a> {
                         | TokenKind::BoolLit(_)
                         | TokenKind::Null
                         | TokenKind::KwNew
-                ) {
+                );
+                let is_bare_ident = matches!(self.peek(), TokenKind::Ident(_))
+                    && self.pos + 1 < self.tokens.len()
+                    && !matches!(
+                        self.tokens[self.pos + 1].kind,
+                        TokenKind::Equals | TokenKind::LBrace | TokenKind::Colon
+                    );
+                if is_bare_literal || is_bare_ident {
                     let expr = self.parse_expr()?;
                     return Ok(Entry::Elem(expr));
                 }

--- a/src/value.rs
+++ b/src/value.rs
@@ -1,6 +1,8 @@
 use indexmap::IndexMap;
 use serde_json::json;
 
+use crate::parser::Expr;
+
 /// A pkl runtime value.
 ///
 /// Pkl's `Mapping` type (arbitrary key→value) is represented as `Object` when
@@ -19,6 +21,8 @@ pub enum Value {
     Object(IndexMap<String, Value>),
     /// Listing (ordered list).
     List(Vec<Value>),
+    /// Lambda function: param names + body expression + captured scope values
+    Lambda(Vec<String>, Expr, IndexMap<String, Value>),
 }
 
 impl Value {
@@ -39,6 +43,7 @@ impl Value {
             Value::List(items) => {
                 serde_json::Value::Array(items.iter().map(|v| v.to_json()).collect())
             }
+            Value::Lambda(..) => json!("<lambda>"),
         }
     }
 

--- a/tests/fixtures/base.pkl
+++ b/tests/fixtures/base.pkl
@@ -1,0 +1,3 @@
+name = "default"
+version = 1
+enabled = true

--- a/tests/pkl_features.rs
+++ b/tests/pkl_features.rs
@@ -121,7 +121,6 @@ fn string_concatenation() {
 }
 
 #[test]
-#[ignore = "string interpolation not yet implemented"]
 fn string_interpolation() {
     let json = eval(
         r#"
@@ -133,7 +132,6 @@ x = "hello \(name)"
 }
 
 #[test]
-#[ignore = "string interpolation not yet implemented"]
 fn string_interpolation_expr() {
     let json = eval(
         r#"
@@ -594,7 +592,6 @@ x {
 // ============================================================
 
 #[test]
-#[ignore = "string interpolation not yet implemented"]
 fn interpolation_in_key() {
     let json = eval(
         r#"

--- a/tests/pkl_features.rs
+++ b/tests/pkl_features.rs
@@ -612,7 +612,7 @@ fn lambda_basic() {
     let json = eval(
         r#"
 local double = (x) -> x * 2
-result = double(5)
+result = double.apply(5)
 "#,
     );
     assert_eq!(json["result"], 10);
@@ -623,7 +623,7 @@ fn lambda_two_params() {
     let json = eval(
         r#"
 local add = (a, b) -> a + b
-result = add(3, 4)
+result = add.apply(3, 4)
 "#,
     );
     assert_eq!(json["result"], 7);
@@ -635,7 +635,7 @@ fn lambda_captures_scope() {
         r#"
 local multiplier = 3
 local mul = (x) -> x * multiplier
-result = mul(5)
+result = mul.apply(5)
 "#,
     );
     assert_eq!(json["result"], 15);

--- a/tests/pkl_features.rs
+++ b/tests/pkl_features.rs
@@ -421,7 +421,6 @@ fn list_concatenation() {
 }
 
 #[test]
-#[ignore = "new Listing body syntax not yet implemented"]
 fn listing_body() {
     let json = eval(
         r#"
@@ -609,15 +608,37 @@ x {
 // ============================================================
 
 #[test]
-#[ignore = "lambda expressions not yet implemented"]
 fn lambda_basic() {
     let json = eval(
         r#"
 local double = (x) -> x * 2
-result = double.apply(5)
+result = double(5)
 "#,
     );
     assert_eq!(json["result"], 10);
+}
+
+#[test]
+fn lambda_two_params() {
+    let json = eval(
+        r#"
+local add = (a, b) -> a + b
+result = add(3, 4)
+"#,
+    );
+    assert_eq!(json["result"], 7);
+}
+
+#[test]
+fn lambda_captures_scope() {
+    let json = eval(
+        r#"
+local multiplier = 3
+local mul = (x) -> x * multiplier
+result = mul(5)
+"#,
+    );
+    assert_eq!(json["result"], 15);
 }
 
 // ============================================================
@@ -625,7 +646,6 @@ result = double.apply(5)
 // ============================================================
 
 #[test]
-#[ignore = "method calls not yet implemented"]
 fn method_length() {
     let json = eval(
         r#"
@@ -636,7 +656,6 @@ x = List(1, 2, 3).length
 }
 
 #[test]
-#[ignore = "method calls not yet implemented"]
 fn method_is_empty() {
     let json = eval(
         r#"
@@ -651,16 +670,42 @@ x = List().isEmpty
 // ============================================================
 
 #[test]
-#[ignore = "import resolution not yet implemented"]
 fn import_local_file() {
-    // This would require a fixture file setup
-    let json = eval(
-        r#"
-import "tests/fixtures/helper.pkl"
+    let mut ev = pklr::eval::Evaluator::new();
+    // Set base path so relative imports resolve correctly
+    let base = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures");
+    ev.set_base_path(&base);
+    let src = r#"
+import "helper.pkl"
 x = helper.value
-"#,
-    );
+"#;
+    let path = base.join("test_import.pkl");
+    let val = ev.eval_source(src, &path).unwrap();
+    let json = val.to_json();
     assert_eq!(json["x"], 42);
+}
+
+// ============================================================
+// Amends resolution
+// ============================================================
+
+#[test]
+fn amends_local_file() {
+    let mut ev = pklr::eval::Evaluator::new();
+    let base = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures");
+    ev.set_base_path(&base);
+    let src = r#"
+amends "base.pkl"
+name = "override"
+"#;
+    let path = base.join("test_amends.pkl");
+    let val = ev.eval_source(src, &path).unwrap();
+    let json = val.to_json();
+    // name is overridden
+    assert_eq!(json["name"], "override");
+    // version and enabled are inherited from base
+    assert_eq!(json["version"], 1);
+    assert_eq!(json["enabled"], true);
 }
 
 // ============================================================
@@ -722,7 +767,6 @@ fn throw_produces_error() {
 // ============================================================
 
 #[test]
-#[ignore = "null-safe access not yet implemented"]
 fn null_safe_access() {
     let json = eval(
         r#"


### PR DESCRIPTION
## Summary
Implements 7 core pkl language features needed for v1:

1. **String interpolation** `\(expr)` — lexer produces `InterpolatedString` tokens with embedded expression token groups, parsed and evaluated inline
2. **`new Listing { entries }` body syntax** — bare elements (strings, ints, etc.) in Listing bodies produce list values without needing `List()`
3. **Null-safe access `?.`** — `x?.field` returns null when `x` is null
4. **Lambda expressions** `(x) -> expr` — with scope capture, supports multi-param `(a, b) -> expr`
5. **Method calls on values** — `.length`, `.isEmpty`, `.contains()`, `.keys`, `.values`, `.join()`, `.split()`, `.trim()`, `.toUpperCase()`, `.toLowerCase()`, `.startsWith()`, `.endsWith()`, `.replaceAll()`, `.containsKey()`, `.toMap()`, `.toList()`, `.toDynamic()`, `.toString()`, `.toInt()`, `.first`, `.last`, `.reverse()`, `.toSet()`
6. **Import resolution** — `import "file.pkl"` loads and evaluates local files, binds to alias or filename stem
7. **Amends resolution** — `amends "base.pkl"` loads base module, overlays current module's properties on top

### Test results
- **87 passing** (up from 53)
- **2 ignored** (class definitions with defaults, object amendment syntax)

Also includes parser fixes from #11 (null coalesce `??`, dynamic key `["key"] = value`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)