### PR TITLE
feat: v1 part 2 — object amendment, module/annotation skipping, higher-order methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,9 @@ No external binary or CLI required.
 
 - Lexer, parser, and evaluator written entirely in Rust
 - Evaluates `.pkl` files to `serde_json::Value`
-- Import analysis for cache invalidation
+- Import and amends resolution for local files
+- String interpolation, lambdas, higher-order methods
+- Rich error diagnostics via [miette](https://crates.io/crates/miette)
 
 ## Supported Pkl Subset
 
@@ -59,7 +61,7 @@ pklr implements a subset of the [Pkl language](https://pkl-lang.org/main/current
 | `List(...)` / `Listing(...)` | Supported |
 | `new Listing { ... }` body syntax | Supported |
 | `Set(...)` | Parsed (treated as List) |
-| Object amendment (`(base) { overrides }`) | Not yet supported |
+| Object amendment (`(base) { overrides }`) | Supported |
 | Spread operator (`...expr`) | Supported |
 | Late binding | Not supported |
 | Default elements/values | Not supported |
@@ -91,29 +93,47 @@ pklr implements a subset of the [Pkl language](https://pkl-lang.org/main/current
 |---|---|
 | `import` / `amends` | Supported (local files) |
 | Import resolution & evaluation | Supported (local files) |
+| `module` keyword | Supported (parsed and skipped) |
 | `import*` (globbed imports) | Not supported |
 | `extends` | Not supported |
-| `module` keyword | Not supported |
 
-### Classes & Methods
+### Functions & Methods
 
 | Feature | Status |
 |---|---|
+| Anonymous functions / lambdas (`(x) -> x * 2`) | Supported |
+| Lambda invocation via `.apply()` | Supported |
+| `.length`, `.isEmpty`, `.first`, `.last` | Supported |
+| `.contains()`, `.containsKey()` | Supported |
+| `.keys`, `.values` | Supported |
+| `.map()`, `.filter()`, `.fold()` | Supported |
+| `.flatMap()`, `.any()`, `.every()` | Supported |
+| `.join()`, `.reverse()`, `.toSet()` | Supported |
+| `.split()`, `.trim()`, `.toUpperCase()`, `.toLowerCase()` | Supported |
+| `.startsWith()`, `.endsWith()`, `.replaceAll()` | Supported |
+| `.toMap()`, `.toList()`, `.toDynamic()`, `.mapValues()` | Supported |
+| `.toString()`, `.toInt()` | Supported |
 | Class definitions (`class Foo { ... }`) | Not yet supported |
 | Class inheritance | Not supported |
-| Methods and member access (`.length`, `.isEmpty`, `.contains()`, etc.) | Supported |
-| Anonymous functions / lambdas (`(x) -> x * 2`) | Supported |
 | `this` / `outer` keywords | Not yet supported |
 | `super` keyword | Not supported |
+
+### Annotations & Declarations
+
+| Feature | Status |
+|---|---|
+| Annotations (`@Deprecated`, `@ModuleInfo`, etc.) | Parsed and skipped |
+| Class declarations | Parsed and skipped |
+| Type alias declarations | Parsed and skipped |
+| Function declarations | Parsed and skipped |
 
 ### Not Yet Supported
 
 The following Pkl features are not currently implemented:
 
-- **Type aliases** and **type constraints**
+- **Type aliases** and **type constraints** (declarations are skipped)
 - **Type annotations** (parsed but not validated)
 - **Member predicates** (`[[...]]`)
-- **Annotations** (`@Deprecated`, `@ModuleInfo`, etc.)
 - **Regular expressions** (`Regex`)
 - **Packages** and **projects**
 - **Standard library** modules
@@ -123,20 +143,12 @@ The following Pkl features are not currently implemented:
 
 ### Roadmap
 
-Planned features, roughly in priority order:
+Planned features:
 
-1. Object amendment (`(base) { overrides }`)
-2. `this` / `outer` keywords
-3. Class definitions with defaults (`class Foo { name: String = "default" }`)
-4. Module header — parse and skip gracefully
-5. Annotations (`@Foo`) — parse and skip
-
-Nice-to-have:
-
-- More stdlib methods (`.map()`, `.filter()`, `.fold()`, etc.)
-- `import*` glob imports
-- Package URI imports (`package://...`)
-- Type checking / validation
+1. `this` / `outer` keywords
+2. Class definitions with defaults (`class Foo { name: String = "default" }`)
+3. `import*` glob imports
+4. Package URI imports (`package://...`)
 
 ## Usage
 

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -595,6 +595,80 @@ impl Evaluator {
                 }
                 Ok(Some(Value::List(seen)))
             }
+            (Value::List(items), "map") => {
+                let lambda = args
+                    .first()
+                    .ok_or_else(|| Error::Eval("map requires a function argument".into()))?;
+                let mut result = Vec::new();
+                for item in items {
+                    result.push(self.invoke_lambda(lambda, std::slice::from_ref(item))?);
+                }
+                Ok(Some(Value::List(result)))
+            }
+            (Value::List(items), "flatMap") => {
+                let lambda = args
+                    .first()
+                    .ok_or_else(|| Error::Eval("flatMap requires a function argument".into()))?;
+                let mut result = Vec::new();
+                for item in items {
+                    let val = self.invoke_lambda(lambda, std::slice::from_ref(item))?;
+                    if let Value::List(inner) = val {
+                        result.extend(inner);
+                    } else {
+                        result.push(val);
+                    }
+                }
+                Ok(Some(Value::List(result)))
+            }
+            (Value::List(items), "filter") => {
+                let lambda = args
+                    .first()
+                    .ok_or_else(|| Error::Eval("filter requires a function argument".into()))?;
+                let mut result = Vec::new();
+                for item in items {
+                    let cond = self.invoke_lambda(lambda, std::slice::from_ref(item))?;
+                    if is_truthy(&cond) {
+                        result.push(item.clone());
+                    }
+                }
+                Ok(Some(Value::List(result)))
+            }
+            (Value::List(items), "fold") => {
+                let init = args
+                    .first()
+                    .ok_or_else(|| Error::Eval("fold requires initial value".into()))?
+                    .clone();
+                let lambda = args
+                    .get(1)
+                    .ok_or_else(|| Error::Eval("fold requires a function argument".into()))?;
+                let mut acc = init;
+                for item in items {
+                    acc = self.invoke_lambda(lambda, &[acc, item.clone()])?;
+                }
+                Ok(Some(acc))
+            }
+            (Value::List(items), "any") => {
+                let lambda = args
+                    .first()
+                    .ok_or_else(|| Error::Eval("any requires a function argument".into()))?;
+                for item in items {
+                    if is_truthy(&self.invoke_lambda(lambda, std::slice::from_ref(item))?) {
+                        return Ok(Some(Value::Bool(true)));
+                    }
+                }
+                Ok(Some(Value::Bool(false)))
+            }
+            (Value::List(items), "every") => {
+                let lambda = args
+                    .first()
+                    .ok_or_else(|| Error::Eval("every requires a function argument".into()))?;
+                for item in items {
+                    if !is_truthy(&self.invoke_lambda(lambda, std::slice::from_ref(item))?) {
+                        return Ok(Some(Value::Bool(false)));
+                    }
+                }
+                Ok(Some(Value::Bool(true)))
+            }
             (Value::List(items), "join") => {
                 let sep = args.first().and_then(|v| v.as_str()).unwrap_or(",");
                 let s: Vec<String> = items.iter().map(value_to_display).collect();
@@ -612,6 +686,18 @@ impl Evaluator {
                 Ok(Some(Value::Bool(map.contains_key(key))))
             }
             (Value::Object(map), "toMap") => Ok(Some(Value::Object(map.clone()))),
+            (Value::Object(map), "mapValues") => {
+                let lambda = args
+                    .first()
+                    .ok_or_else(|| Error::Eval("mapValues requires a function".into()))?;
+                let mut result = IndexMap::new();
+                for (k, v) in map {
+                    let new_v =
+                        self.invoke_lambda(lambda, &[Value::String(k.clone()), v.clone()])?;
+                    result.insert(k.clone(), new_v);
+                }
+                Ok(Some(Value::Object(result)))
+            }
             (Value::Object(_), "toList") | (Value::Object(_), "toDynamic") => Ok(Some(obj.clone())),
 
             // Int/Float methods
@@ -632,6 +718,21 @@ impl Evaluator {
             }
 
             _ => Ok(None), // not a known method
+        }
+    }
+
+    fn invoke_lambda(&mut self, lambda: &Value, args: &[Value]) -> Result<Value> {
+        if let Value::Lambda(params, body, captured) = lambda {
+            let mut scope = Scope::default();
+            for (k, v) in captured {
+                scope.set(k.clone(), v.clone());
+            }
+            for (param, arg) in params.iter().zip(args.iter()) {
+                scope.set(param.clone(), arg.clone());
+            }
+            self.eval_expr(body, &scope, 0)
+        } else {
+            Err(Error::Eval("expected a function".into()))
         }
     }
 

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -601,7 +601,7 @@ impl Evaluator {
                     .ok_or_else(|| Error::Eval("map requires a function argument".into()))?;
                 let mut result = Vec::new();
                 for item in items {
-                    result.push(self.invoke_lambda(lambda, std::slice::from_ref(item))?);
+                    result.push(self.invoke_lambda(lambda, std::slice::from_ref(item), depth)?);
                 }
                 Ok(Some(Value::List(result)))
             }
@@ -611,7 +611,7 @@ impl Evaluator {
                     .ok_or_else(|| Error::Eval("flatMap requires a function argument".into()))?;
                 let mut result = Vec::new();
                 for item in items {
-                    let val = self.invoke_lambda(lambda, std::slice::from_ref(item))?;
+                    let val = self.invoke_lambda(lambda, std::slice::from_ref(item), depth)?;
                     if let Value::List(inner) = val {
                         result.extend(inner);
                     } else {
@@ -626,7 +626,7 @@ impl Evaluator {
                     .ok_or_else(|| Error::Eval("filter requires a function argument".into()))?;
                 let mut result = Vec::new();
                 for item in items {
-                    let cond = self.invoke_lambda(lambda, std::slice::from_ref(item))?;
+                    let cond = self.invoke_lambda(lambda, std::slice::from_ref(item), depth)?;
                     if is_truthy(&cond) {
                         result.push(item.clone());
                     }
@@ -643,7 +643,7 @@ impl Evaluator {
                     .ok_or_else(|| Error::Eval("fold requires a function argument".into()))?;
                 let mut acc = init;
                 for item in items {
-                    acc = self.invoke_lambda(lambda, &[acc, item.clone()])?;
+                    acc = self.invoke_lambda(lambda, &[acc, item.clone()], depth)?;
                 }
                 Ok(Some(acc))
             }
@@ -652,7 +652,7 @@ impl Evaluator {
                     .first()
                     .ok_or_else(|| Error::Eval("any requires a function argument".into()))?;
                 for item in items {
-                    if is_truthy(&self.invoke_lambda(lambda, std::slice::from_ref(item))?) {
+                    if is_truthy(&self.invoke_lambda(lambda, std::slice::from_ref(item), depth)?) {
                         return Ok(Some(Value::Bool(true)));
                     }
                 }
@@ -663,7 +663,7 @@ impl Evaluator {
                     .first()
                     .ok_or_else(|| Error::Eval("every requires a function argument".into()))?;
                 for item in items {
-                    if !is_truthy(&self.invoke_lambda(lambda, std::slice::from_ref(item))?) {
+                    if !is_truthy(&self.invoke_lambda(lambda, std::slice::from_ref(item), depth)?) {
                         return Ok(Some(Value::Bool(false)));
                     }
                 }
@@ -693,7 +693,7 @@ impl Evaluator {
                 let mut result = IndexMap::new();
                 for (k, v) in map {
                     let new_v =
-                        self.invoke_lambda(lambda, &[Value::String(k.clone()), v.clone()])?;
+                        self.invoke_lambda(lambda, &[Value::String(k.clone()), v.clone()], depth)?;
                     result.insert(k.clone(), new_v);
                 }
                 Ok(Some(Value::Object(result)))
@@ -721,7 +721,7 @@ impl Evaluator {
         }
     }
 
-    fn invoke_lambda(&mut self, lambda: &Value, args: &[Value]) -> Result<Value> {
+    fn invoke_lambda(&mut self, lambda: &Value, args: &[Value], depth: usize) -> Result<Value> {
         if let Value::Lambda(params, body, captured) = lambda {
             let mut scope = Scope::default();
             for (k, v) in captured {
@@ -730,7 +730,7 @@ impl Evaluator {
             for (param, arg) in params.iter().zip(args.iter()) {
                 scope.set(param.clone(), arg.clone());
             }
-            self.eval_expr(body, &scope, 0)
+            self.eval_expr(body, &scope, depth + 1)
         } else {
             Err(Error::Eval("expected a function".into()))
         }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -241,11 +241,84 @@ impl<'a> Parser<'a> {
         matches!(self.peek(), TokenKind::Eof)
     }
 
+    /// Skip annotation blocks: `@Ident` or `@Ident { ... }`
+    fn skip_annotations(&mut self) {
+        while matches!(self.peek(), TokenKind::At) {
+            self.advance(); // @
+            // Skip ident (and optional dotted path)
+            while matches!(self.peek(), TokenKind::Ident(_)) {
+                self.advance();
+                if matches!(self.peek(), TokenKind::Dot) {
+                    self.advance();
+                } else {
+                    break;
+                }
+            }
+            // Skip annotation body if present
+            if matches!(self.peek(), TokenKind::LBrace) {
+                self.advance();
+                let mut depth = 1;
+                while depth > 0 && !self.at_eof() {
+                    match self.peek() {
+                        TokenKind::LBrace => {
+                            depth += 1;
+                            self.advance();
+                        }
+                        TokenKind::RBrace => {
+                            depth -= 1;
+                            self.advance();
+                        }
+                        _ => {
+                            self.advance();
+                        }
+                    }
+                }
+            }
+            // Skip annotation arguments if present
+            if matches!(self.peek(), TokenKind::LParen) {
+                self.advance();
+                let mut depth = 1;
+                while depth > 0 && !self.at_eof() {
+                    match self.peek() {
+                        TokenKind::LParen => {
+                            depth += 1;
+                            self.advance();
+                        }
+                        TokenKind::RParen => {
+                            depth -= 1;
+                            self.advance();
+                        }
+                        _ => {
+                            self.advance();
+                        }
+                    }
+                }
+            }
+        }
+    }
+
     fn parse_module(&mut self) -> Result<Module> {
         let mut amends = None;
         let mut imports = Vec::new();
 
-        // Parse header: amends + imports (can be interleaved)
+        // Skip annotations at module level (e.g. @ModuleInfo)
+        self.skip_annotations();
+
+        // Parse header: module declaration, amends, imports
+        // Skip `module <name>` declaration if present
+        if matches!(self.peek(), TokenKind::KwModule) {
+            self.advance();
+            // Skip module name (may be dotted like `hk.Config`)
+            while matches!(self.peek(), TokenKind::Ident(_)) {
+                self.advance();
+                if matches!(self.peek(), TokenKind::Dot) {
+                    self.advance();
+                } else {
+                    break;
+                }
+            }
+        }
+
         loop {
             match self.peek().clone() {
                 TokenKind::KwAmends => {
@@ -279,10 +352,74 @@ impl<'a> Parser<'a> {
     fn parse_entries(&mut self) -> Result<Vec<Entry>> {
         let mut entries = Vec::new();
         while !self.at_eof() && !matches!(self.peek(), TokenKind::RBrace) {
+            self.skip_annotations();
+            // Skip class/typealias/function declarations at top level
+            if matches!(
+                self.peek(),
+                TokenKind::KwClass | TokenKind::KwTypeAlias | TokenKind::KwFunction
+            ) {
+                self.skip_declaration();
+                continue;
+            }
+            if self.at_eof() || matches!(self.peek(), TokenKind::RBrace) {
+                break;
+            }
             let entry = self.parse_entry()?;
             entries.push(entry);
         }
         Ok(entries)
+    }
+
+    /// Skip a class, typealias, or function declaration.
+    fn skip_declaration(&mut self) {
+        self.advance(); // class/typealias/function keyword
+        // Skip until we find a balanced { } or = expr or next entry
+        let mut depth = 0;
+        loop {
+            if self.at_eof() {
+                break;
+            }
+            match self.peek() {
+                TokenKind::LBrace => {
+                    depth += 1;
+                    self.advance();
+                }
+                TokenKind::RBrace if depth > 0 => {
+                    depth -= 1;
+                    self.advance();
+                    if depth == 0 {
+                        break;
+                    }
+                }
+                TokenKind::RBrace => break, // don't consume — belongs to parent
+                _ if depth == 0 => {
+                    // At top level of declaration: look for start of next entry
+                    // A declaration ends before annotations, keywords, or identifiers
+                    // that start new entries
+                    let next = self.peek().clone();
+                    if matches!(
+                        next,
+                        TokenKind::At
+                            | TokenKind::KwClass
+                            | TokenKind::KwTypeAlias
+                            | TokenKind::KwFunction
+                            | TokenKind::KwLocal
+                            | TokenKind::KwConst
+                            | TokenKind::KwFixed
+                            | TokenKind::KwHidden
+                            | TokenKind::KwAbstract
+                            | TokenKind::KwOpen
+                            | TokenKind::KwExternal
+                    ) {
+                        break;
+                    }
+                    self.advance();
+                }
+                _ => {
+                    self.advance();
+                }
+            }
+        }
     }
 
     fn parse_entry(&mut self) -> Result<Entry> {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -410,6 +410,7 @@ impl<'a> Parser<'a> {
                             | TokenKind::KwAbstract
                             | TokenKind::KwOpen
                             | TokenKind::KwExternal
+                            | TokenKind::Ident(_)
                     ) {
                         break;
                     }

--- a/tests/pkl_features.rs
+++ b/tests/pkl_features.rs
@@ -735,7 +735,6 @@ x = new Person {
 // ============================================================
 
 #[test]
-#[ignore = "object amendment syntax not yet implemented"]
 fn object_amendment() {
     let json = eval(
         r#"
@@ -775,4 +774,92 @@ result = x?.name ?? "default"
 "#,
     );
     assert_eq!(json["result"], "default");
+}
+
+// ============================================================
+// Module header
+// ============================================================
+
+#[test]
+fn module_header_skipped() {
+    let json = eval(
+        r#"
+module my.Config
+x = 42
+"#,
+    );
+    assert_eq!(json["x"], 42);
+}
+
+// ============================================================
+// Higher-order methods (map, filter, fold)
+// ============================================================
+
+#[test]
+fn list_map() {
+    let json = eval(
+        r#"
+local items = List(1, 2, 3)
+x = items.map((n) -> n * 2)
+"#,
+    );
+    assert_eq!(json["x"], serde_json::json!([2, 4, 6]));
+}
+
+#[test]
+fn list_filter() {
+    let json = eval(
+        r#"
+local items = List(1, 2, 3, 4, 5)
+x = items.filter((n) -> n > 2)
+"#,
+    );
+    assert_eq!(json["x"], serde_json::json!([3, 4, 5]));
+}
+
+#[test]
+fn list_fold() {
+    let json = eval(
+        r#"
+local items = List(1, 2, 3, 4)
+x = items.fold(0, (acc, n) -> acc + n)
+"#,
+    );
+    assert_eq!(json["x"], 10);
+}
+
+#[test]
+fn list_any_every() {
+    let json = eval(
+        r#"
+local items = List(1, 2, 3)
+has_even = items.any((n) -> n % 2 == 0)
+all_positive = items.every((n) -> n > 0)
+"#,
+    );
+    assert_eq!(json["has_even"], true);
+    assert_eq!(json["all_positive"], true);
+}
+
+#[test]
+fn object_amendment_with_named_property() {
+    let json = eval(
+        r#"
+local base = new Mapping {
+    ["a"] {
+        value = 1
+    }
+}
+x = (base) {
+    ["a"] {
+        value = 2
+    }
+    ["b"] {
+        value = 3
+    }
+}
+"#,
+    );
+    assert_eq!(json["x"]["a"]["value"], 2);
+    assert_eq!(json["x"]["b"]["value"], 3);
 }


### PR DESCRIPTION
## Summary
Builds on #13 with additional v1 features:

**New features:**
- **Object amendment** `(base) { overrides }` — now tested and documented (was already implemented in eval, just needed testing)
- **`module` keyword** — parsed and gracefully skipped (`module hk.Config`)
- **Annotations** — `@Foo`, `@Foo { ... }`, `@Foo(...)` all parsed and skipped
- **Class/typealias/function declarations** — parsed and skipped at top level (no eval, but won't error)
- **Higher-order list methods** — `.map()`, `.filter()`, `.fold()`, `.flatMap()`, `.any()`, `.every()`
- **Object `.mapValues()`** method

**Updated README:**
- All feature tables updated to reflect current status
- Roadmap trimmed to remaining items (this/outer, class definitions, import*, packages)
- Added new "Functions & Methods" and "Annotations & Declarations" sections

### Test results
- **94 passing** (up from 87)
- **1 ignored** (class definitions with defaults)

Includes all changes from #13 (string interpolation, import/amends, lambdas, null-safe access, method calls, new Listing body, null coalesce, dynamic keys).

🤖 Generated with [Claude Code](https://claude.com/claude-code)