### PR TITLE
feat: class definitions, outer keyword — v1 complete

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,9 +113,10 @@ pklr implements a subset of the [Pkl language](https://pkl-lang.org/main/current
 | `.startsWith()`, `.endsWith()`, `.replaceAll()` | Supported |
 | `.toMap()`, `.toList()`, `.toDynamic()`, `.mapValues()` | Supported |
 | `.toString()`, `.toInt()` | Supported |
-| Class definitions (`class Foo { ... }`) | Not yet supported |
+| Class definitions with defaults | Supported |
 | Class inheritance | Not supported |
-| `this` / `outer` keywords | Not yet supported |
+| `outer` keyword | Supported |
+| `this` keyword | Not yet supported |
 | `super` keyword | Not supported |
 
 ### Annotations & Declarations
@@ -123,7 +124,7 @@ pklr implements a subset of the [Pkl language](https://pkl-lang.org/main/current
 | Feature | Status |
 |---|---|
 | Annotations (`@Deprecated`, `@ModuleInfo`, etc.) | Parsed and skipped |
-| Class declarations | Parsed and skipped |
+| Class declarations | Parsed and evaluated (defaults extracted) |
 | Type alias declarations | Parsed and skipped |
 | Function declarations | Parsed and skipped |
 
@@ -145,10 +146,10 @@ The following Pkl features are not currently implemented:
 
 Planned features:
 
-1. `this` / `outer` keywords
-2. Class definitions with defaults (`class Foo { name: String = "default" }`)
-3. `import*` glob imports
-4. Package URI imports (`package://...`)
+1. `this` keyword (self-referencing within objects)
+2. `import*` glob imports
+3. Package URI imports (`package://...`)
+4. Class inheritance (`extends`)
 
 ## Usage
 

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -111,13 +111,6 @@ impl Evaluator {
             }
         }
 
-        // Collect class definitions into module scope
-        for entry in &module.body {
-            if let Entry::ClassDef(name, body) = entry {
-                let defaults = self.eval_entries(body, &scope, depth + 1)?;
-                scope.set(name.clone(), defaults);
-            }
-        }
         // First pass: collect all `local` variable definitions into scope
         for entry in &module.body {
             if let Entry::Property(prop) = entry
@@ -129,6 +122,13 @@ impl Evaluator {
             {
                 let val = self.eval_expr(expr, &scope, depth)?;
                 scope.set(prop.name.clone(), val);
+            }
+        }
+        // Collect class definitions into module scope (after locals so defaults can reference them)
+        for entry in &module.body {
+            if let Entry::ClassDef(name, body) = entry {
+                let defaults = self.eval_entries(body, &scope, depth + 1)?;
+                scope.set(name.clone(), defaults);
             }
         }
 
@@ -175,13 +175,6 @@ impl Evaluator {
         // Set `outer` to a snapshot of the parent scope's variables as an object
         let outer_obj = Value::Object(scope.flatten());
         child_scope.set("outer".into(), outer_obj);
-        // Collect class definitions into scope
-        for entry in entries {
-            if let Entry::ClassDef(name, body) = entry {
-                let defaults = self.eval_entries(body, &child_scope, depth + 1)?;
-                child_scope.set(name.clone(), defaults);
-            }
-        }
         // First pass: collect locals
         for entry in entries {
             if let Entry::Property(prop) = entry
@@ -193,6 +186,13 @@ impl Evaluator {
             {
                 let val = self.eval_expr(expr, &child_scope, depth)?;
                 child_scope.set(prop.name.clone(), val);
+            }
+        }
+        // Collect class definitions into scope (after locals so defaults can reference them)
+        for entry in entries {
+            if let Entry::ClassDef(name, body) = entry {
+                let defaults = self.eval_entries(body, &child_scope, depth + 1)?;
+                child_scope.set(name.clone(), defaults);
             }
         }
 

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -111,6 +111,13 @@ impl Evaluator {
             }
         }
 
+        // Collect class definitions into module scope
+        for entry in &module.body {
+            if let Entry::ClassDef(name, body) = entry {
+                let defaults = self.eval_entries(body, &scope, depth + 1)?;
+                scope.set(name.clone(), defaults);
+            }
+        }
         // First pass: collect all `local` variable definitions into scope
         for entry in &module.body {
             if let Entry::Property(prop) = entry
@@ -165,6 +172,16 @@ impl Evaluator {
 
     fn eval_entries(&mut self, entries: &[Entry], scope: &Scope, depth: usize) -> Result<Value> {
         let mut child_scope = scope.child();
+        // Set `outer` to a snapshot of the parent scope's variables as an object
+        let outer_obj = Value::Object(scope.flatten());
+        child_scope.set("outer".into(), outer_obj);
+        // Collect class definitions into scope
+        for entry in entries {
+            if let Entry::ClassDef(name, body) = entry {
+                let defaults = self.eval_entries(body, &child_scope, depth + 1)?;
+                child_scope.set(name.clone(), defaults);
+            }
+        }
         // First pass: collect locals
         for entry in entries {
             if let Entry::Property(prop) = entry
@@ -236,6 +253,7 @@ impl Evaluator {
                     }
                 }
                 Entry::Elem(_) => {} // bare elements only valid in Listing bodies
+                Entry::ClassDef(..) => {} // handled in scope setup
             }
         }
         Ok(Value::Object(map))
@@ -328,8 +346,18 @@ impl Evaluator {
                         Ok(Value::Object(map))
                     }
                     _ => {
-                        // Generic new: treat as object
-                        self.eval_entries(entries, scope, depth + 1)
+                        // Check if type name matches a class in scope
+                        let base = type_name.as_ref().and_then(|name| scope.get(name)).cloned();
+                        let overlay = self.eval_entries(entries, scope, depth + 1)?;
+                        if let Some(Value::Object(base_map)) = base {
+                            let mut merged = base_map;
+                            if let Value::Object(overlay_map) = overlay {
+                                merged.extend(overlay_map);
+                            }
+                            Ok(Value::Object(merged))
+                        } else {
+                            Ok(overlay)
+                        }
                     }
                 }
             }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -359,11 +359,38 @@ impl<'a> Parser<'a> {
             if matches!(self.peek(), TokenKind::KwClass) {
                 self.advance(); // consume 'class'
                 let name = self.expect_ident()?;
-                // Skip optional extends/type params
-                while !self.at_eof()
-                    && !matches!(self.peek(), TokenKind::LBrace | TokenKind::RBrace)
-                {
+                // Skip optional type params <...>
+                if matches!(self.peek(), TokenKind::Lt) {
+                    let mut angle_depth = 0;
+                    loop {
+                        match self.peek() {
+                            TokenKind::Lt => {
+                                angle_depth += 1;
+                                self.advance();
+                            }
+                            TokenKind::Gt | TokenKind::GtEq => {
+                                angle_depth -= 1;
+                                self.advance();
+                                if angle_depth == 0 {
+                                    break;
+                                }
+                            }
+                            TokenKind::Eof => break,
+                            _ => {
+                                self.advance();
+                            }
+                        }
+                    }
+                }
+                // Skip optional extends clause
+                if matches!(self.peek(), TokenKind::KwExtends) {
                     self.advance();
+                    // Skip the parent type name and optional type params
+                    while !self.at_eof()
+                        && !matches!(self.peek(), TokenKind::LBrace | TokenKind::RBrace)
+                    {
+                        self.advance();
+                    }
                 }
                 if matches!(self.peek(), TokenKind::LBrace) {
                     self.advance();

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -36,6 +36,8 @@ pub enum Entry {
     Spread(Expr),
     /// Bare element expression (used in Listing bodies)
     Elem(Expr),
+    /// Class definition: `class Name { properties... }`
+    ClassDef(String, Vec<Entry>),
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -353,11 +355,25 @@ impl<'a> Parser<'a> {
         let mut entries = Vec::new();
         while !self.at_eof() && !matches!(self.peek(), TokenKind::RBrace) {
             self.skip_annotations();
-            // Skip class/typealias/function declarations at top level
-            if matches!(
-                self.peek(),
-                TokenKind::KwClass | TokenKind::KwTypeAlias | TokenKind::KwFunction
-            ) {
+            // Parse class definitions; skip typealias/function declarations
+            if matches!(self.peek(), TokenKind::KwClass) {
+                self.advance(); // consume 'class'
+                let name = self.expect_ident()?;
+                // Skip optional extends/type params
+                while !self.at_eof()
+                    && !matches!(self.peek(), TokenKind::LBrace | TokenKind::RBrace)
+                {
+                    self.advance();
+                }
+                if matches!(self.peek(), TokenKind::LBrace) {
+                    self.advance();
+                    let body = self.parse_entries()?;
+                    self.expect(&TokenKind::RBrace)?;
+                    entries.push(Entry::ClassDef(name, body));
+                }
+                continue;
+            }
+            if matches!(self.peek(), TokenKind::KwTypeAlias | TokenKind::KwFunction) {
                 self.skip_declaration();
                 continue;
             }
@@ -916,6 +932,14 @@ impl<'a> Parser<'a> {
             TokenKind::Ident(name) => {
                 self.advance();
                 Ok(Expr::Ident(name))
+            }
+            TokenKind::KwThis => {
+                self.advance();
+                Ok(Expr::Ident("this".into()))
+            }
+            TokenKind::KwModule => {
+                self.advance();
+                Ok(Expr::Ident("module".into()))
             }
             tok => Err(self.parse_error(format!("unexpected token in expression: {:?}", tok))),
         }

--- a/tests/pkl_features.rs
+++ b/tests/pkl_features.rs
@@ -905,3 +905,33 @@ x = new Config {
     assert_eq!(json["x"]["port"], 8080);
     assert_eq!(json["x"]["host"], "localhost");
 }
+
+#[test]
+fn class_defaults_reference_locals() {
+    let json = eval(
+        r#"
+local DEFAULT_PORT = 8080
+
+class Config {
+    port: Int = DEFAULT_PORT
+}
+x = new Config {}
+"#,
+    );
+    assert_eq!(json["x"]["port"], 8080);
+}
+
+#[test]
+fn class_with_type_params() {
+    let json = eval(
+        r#"
+class Container<T> {
+    value: T = "default"
+}
+x = new Container {
+    value = "custom"
+}
+"#,
+    );
+    assert_eq!(json["x"]["value"], "custom");
+}

--- a/tests/pkl_features.rs
+++ b/tests/pkl_features.rs
@@ -713,7 +713,6 @@ name = "override"
 // ============================================================
 
 #[test]
-#[ignore = "class definitions not yet implemented"]
 fn class_new_with_defaults() {
     let json = eval(
         r#"
@@ -862,4 +861,47 @@ x = (base) {
     );
     assert_eq!(json["x"]["a"]["value"], 2);
     assert_eq!(json["x"]["b"]["value"], 3);
+}
+
+// ============================================================
+// this / outer keywords
+// ============================================================
+
+#[test]
+fn outer_keyword() {
+    let json = eval(
+        r#"
+local prefix = "test"
+data {
+    local before = "\(prefix)-data"
+    inner {
+        name = outer.before
+    }
+}
+"#,
+    );
+    assert_eq!(json["data"]["inner"]["name"], "test-data");
+}
+
+// ============================================================
+// Class definitions
+// ============================================================
+
+#[test]
+fn class_multiple_defaults() {
+    let json = eval(
+        r#"
+class Config {
+    debug: Boolean = false
+    port: Int = 8080
+    host: String = "localhost"
+}
+x = new Config {
+    debug = true
+}
+"#,
+    );
+    assert_eq!(json["x"]["debug"], true);
+    assert_eq!(json["x"]["port"], 8080);
+    assert_eq!(json["x"]["host"], "localhost");
 }


### PR DESCRIPTION
## Summary
Final v1 features, building on #13 and #14:

- **Class definitions** — `class Foo { name: String = "default" }` parsed and evaluated; defaults extracted from body and merged with `new Foo { overrides }`
- **`outer` keyword** — gives access to enclosing scope as an object (`outer.varName`)
- **`this` / `module` keywords** — parsed as expressions in primary position

### Test results
- **97 passing, 0 ignored** (up from 94 passing, 1 ignored)

### README updates
- Class definitions and `outer` marked as Supported
- Roadmap trimmed to: `this` (self-reference), `import*`, package URIs, class inheritance

🤖 Generated with [Claude Code](https://claude.com/claude-code)