### PR TITLE
feat: async evaluator with HTTP/HTTPS/package:// import support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,10 +3,78 @@
 version = 4
 
 [[package]]
+name = "async-recursion"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "bitflags"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+
+[[package]]
+name = "bumpalo"
+version = "3.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
+name = "bytes"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+
+[[package]]
+name = "cc"
+version = "1.2.57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a0dd1ca384932ff3641c8718a02769f1698e7563dc6974ffd03346116310423"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "equivalent"
@@ -15,10 +83,287 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "wasi",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "r-efi",
+ "wasip2",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+
+[[package]]
+name = "http"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "hyper"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "http",
+ "http-body",
+ "httparse",
+ "itoa",
+ "pin-project-lite",
+ "pin-utils",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+ "webpki-roots",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "ipnet",
+ "libc",
+ "percent-encoding",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "icu_collections"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+
+[[package]]
+name = "icu_properties"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
+
+[[package]]
+name = "icu_provider"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
 
 [[package]]
 name = "indexmap"
@@ -31,10 +376,60 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipnet"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+
+[[package]]
+name = "iri-string"
+version = "0.7.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8e7418f59cc01c88316161279a7f665217ae316b388e58a0d10e29f54f1e5eb"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "js-sys"
+version = "0.3.91"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
+dependencies = [
+ "once_cell",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "libc"
+version = "0.2.183"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+
+[[package]]
+name = "litemap"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
+
+[[package]]
+name = "log"
+version = "0.4.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "memchr"
@@ -65,13 +460,69 @@ dependencies = [
 ]
 
 [[package]]
+name = "mio"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
+dependencies = [
+ "libc",
+ "wasi",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "once_cell"
+version = "1.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
 name = "pklr"
 version = "0.1.0"
 dependencies = [
+ "async-recursion",
  "indexmap",
  "miette",
+ "reqwest",
  "serde_json",
  "thiserror",
+ "tokio",
+]
+
+[[package]]
+name = "potential_utf"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
+dependencies = [
+ "zerovec",
+]
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
 ]
 
 [[package]]
@@ -84,6 +535,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -93,12 +599,153 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "rand"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+dependencies = [
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+
+[[package]]
+name = "rustls"
+version = "0.23.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
+dependencies = [
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+dependencies = [
+ "web-time",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
+
+[[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
 name = "serde"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
+ "serde_derive",
 ]
 
 [[package]]
@@ -135,6 +782,58 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
+name = "smallvec"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "socket2"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
 name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -143,6 +842,26 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -166,6 +885,137 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinystr"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
+name = "tinyvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "tokio"
+version = "1.50.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
+dependencies = [
+ "bytes",
+ "libc",
+ "mio",
+ "pin-project-lite",
+ "socket2",
+ "tokio-macros",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
+]
+
+[[package]]
+name = "tower"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "iri-string",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
+
+[[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "pin-project-lite",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -176,6 +1026,419 @@ name = "unicode-width"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasip2"
+version = "1.0.2+wasi-0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.114"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9c5522b3a28661442748e09d40924dfb9ca614b21c00d3fd135720e48b67db8"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "js-sys",
+ "once_cell",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.114"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.114"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.114"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.91"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+
+[[package]]
+name = "writeable"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+
+[[package]]
+name = "yoke"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efbb2a062be311f2ba113ce66f697a4dc589f85e78a4aea276200804cea0ed87"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e8bc7269b54418e7aeeef514aa68f8690b8c0489a06b0136e5f57c4c5ccab89"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+
+[[package]]
+name = "zerotrie"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "zmij"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,9 @@ indexmap    = "2"
 miette     = { version = "7", features = ["derive"] }
 serde_json = "1"
 thiserror  = "2"
+async-recursion = "1"
+reqwest         = { version = "0.12", default-features = false, features = ["rustls-tls"] }
+tokio           = { version = "1", features = ["rt"] }
+
+[dev-dependencies]
+tokio = { version = "1", features = ["rt-multi-thread", "macros"] }

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -1,3 +1,6 @@
+use std::collections::HashMap;
+
+use async_recursion::async_recursion;
 use indexmap::IndexMap;
 use std::path::{Path, PathBuf};
 
@@ -11,6 +14,10 @@ pub struct Evaluator {
     base_path: PathBuf,
     /// Maximum import depth to prevent infinite recursion
     max_depth: usize,
+    /// Cache for fetched HTTP sources (URL → source text)
+    http_cache: HashMap<String, String>,
+    /// Reusable HTTP client for connection pooling
+    http_client: reqwest::Client,
 }
 
 impl Default for Evaluator {
@@ -18,6 +25,8 @@ impl Default for Evaluator {
         Self {
             base_path: PathBuf::from("."),
             max_depth: 32,
+            http_cache: HashMap::new(),
+            http_client: reqwest::Client::new(),
         }
     }
 }
@@ -31,14 +40,34 @@ impl Evaluator {
         self.base_path = path.to_path_buf();
     }
 
-    pub fn eval_source(&mut self, source: &str, path: &Path) -> Result<Value> {
+    async fn fetch_source(&mut self, url: &str) -> Result<String> {
+        if let Some(cached) = self.http_cache.get(url) {
+            return Ok(cached.clone());
+        }
+        let body = self
+            .http_client
+            .get(url)
+            .send()
+            .await
+            .map_err(|e| Error::Eval(format!("HTTP fetch failed for {url}: {e}")))?
+            .error_for_status()
+            .map_err(|e| Error::Eval(format!("HTTP error for {url}: {e}")))?
+            .text()
+            .await
+            .map_err(|e| Error::Eval(format!("HTTP read failed for {url}: {e}")))?;
+        self.http_cache.insert(url.to_string(), body.clone());
+        Ok(body)
+    }
+
+    pub async fn eval_source(&mut self, source: &str, path: &Path) -> Result<Value> {
         let name = path.display().to_string();
         let tokens = lexer::lex_named(source, &name)?;
         let module = parser::parse_named(&tokens, source, &name)?;
-        self.eval_module(&module, path, 0)
+        self.eval_module(&module, path, 0).await
     }
 
-    fn eval_module(&mut self, module: &Module, path: &Path, depth: usize) -> Result<Value> {
+    #[async_recursion(?Send)]
+    async fn eval_module(&mut self, module: &Module, path: &Path, depth: usize) -> Result<Value> {
         if depth > self.max_depth {
             return Err(Error::Eval(format!(
                 "max import depth {} exceeded",
@@ -50,10 +79,70 @@ impl Evaluator {
         // Process imports
         for import in &module.imports {
             let uri = &import.uri;
-            // Skip package URIs and non-local imports
+
+            if uri.starts_with("https://") || uri.starts_with("http://") {
+                // HTTP import
+                let source = self.fetch_source(uri).await?;
+                let imported_val = {
+                    let tokens = lexer::lex_named(&source, uri)?;
+                    let imp_module = parser::parse_named(&tokens, &source, uri)?;
+                    self.eval_module(&imp_module, Path::new(uri), depth + 1)
+                        .await?
+                };
+                let alias = import.alias.clone().unwrap_or_else(|| {
+                    uri.rsplit('/')
+                        .next()
+                        .unwrap_or(uri)
+                        .strip_suffix(".pkl")
+                        .unwrap_or(uri)
+                        .to_string()
+                });
+                scope.set(alias, imported_val);
+                continue;
+            }
+
+            if uri.starts_with("package://") {
+                // Convert package URI to GitHub release URL
+                // Format: package://pkg.pkl-lang.org/github.com/owner/repo@version#/path.pkl
+                // → https://github.com/owner/repo/releases/download/version/path.pkl
+                if let Some(rest) = uri.strip_prefix("package://pkg.pkl-lang.org/github.com/")
+                    && let Some((repo_ver, fragment)) = rest.split_once('#')
+                    && let Some((repo, version)) = repo_ver.split_once('@')
+                {
+                    let file_path = fragment.strip_prefix('/').unwrap_or(fragment);
+                    let url = format!(
+                        "https://github.com/{repo}/releases/download/{version}/{file_path}"
+                    );
+                    let source = self.fetch_source(&url).await?;
+                    let imported_val = {
+                        let tokens = lexer::lex_named(&source, &url)?;
+                        let imp_module = parser::parse_named(&tokens, &source, &url)?;
+                        self.eval_module(&imp_module, Path::new(&url), depth + 1)
+                            .await?
+                    };
+                    let alias = import.alias.clone().unwrap_or_else(|| {
+                        file_path
+                            .rsplit('/')
+                            .next()
+                            .unwrap_or(file_path)
+                            .strip_suffix(".pkl")
+                            .unwrap_or(file_path)
+                            .to_string()
+                    });
+                    scope.set(alias, imported_val);
+                } else {
+                    return Err(Error::Eval(format!(
+                        "unsupported package URI (only pkg.pkl-lang.org/github.com is supported): {uri}"
+                    )));
+                }
+                continue;
+            }
+
+            // Skip other non-local imports
             if uri.contains("://") && !uri.starts_with("file://") {
                 continue;
             }
+
             let import_path = if let Some(rel) = uri.strip_prefix("file://") {
                 PathBuf::from(rel)
             } else {
@@ -70,7 +159,8 @@ impl Evaluator {
                     let name = import_path.display().to_string();
                     let tokens = lexer::lex_named(&source, &name)?;
                     let imp_module = parser::parse_named(&tokens, &source, &name)?;
-                    self.eval_module(&imp_module, &import_path, depth + 1)?
+                    self.eval_module(&imp_module, &import_path, depth + 1)
+                        .await?
                 };
                 // Determine the binding name: alias or filename stem
                 let alias = import.alias.clone().unwrap_or_else(|| {
@@ -87,23 +177,57 @@ impl Evaluator {
         // Process amends: load base module as starting values
         let mut base_obj = IndexMap::new();
         if let Some(uri) = &module.amends {
-            // Skip package URIs
-            if !uri.contains("://") || uri.starts_with("file://") {
+            if uri.starts_with("https://") || uri.starts_with("http://") {
+                // HTTP amends
+                let source = self.fetch_source(uri).await?;
+                let tokens = lexer::lex_named(&source, uri)?;
+                let base_module = parser::parse_named(&tokens, &source, uri)?;
+                let base_val = self
+                    .eval_module(&base_module, Path::new(uri), depth + 1)
+                    .await?;
+                if let Value::Object(m) = base_val {
+                    base_obj = m;
+                }
+            } else if uri.starts_with("package://") {
+                // Convert package URI to GitHub release URL
+                if let Some(rest) = uri.strip_prefix("package://pkg.pkl-lang.org/github.com/")
+                    && let Some((repo_ver, fragment)) = rest.split_once('#')
+                    && let Some((repo, version)) = repo_ver.split_once('@')
+                {
+                    let file_path = fragment.strip_prefix('/').unwrap_or(fragment);
+                    let url = format!(
+                        "https://github.com/{repo}/releases/download/{version}/{file_path}"
+                    );
+                    let source = self.fetch_source(&url).await?;
+                    let tokens = lexer::lex_named(&source, &url)?;
+                    let base_module = parser::parse_named(&tokens, &source, &url)?;
+                    let base_val = self
+                        .eval_module(&base_module, Path::new(&url), depth + 1)
+                        .await?;
+                    if let Value::Object(m) = base_val {
+                        base_obj = m;
+                    }
+                } else {
+                    return Err(Error::Eval(format!(
+                        "unsupported package URI (only pkg.pkl-lang.org/github.com is supported): {uri}"
+                    )));
+                }
+            } else if !uri.contains("://") || uri.starts_with("file://") {
                 let amends_path = if let Some(rel) = uri.strip_prefix("file://") {
                     PathBuf::from(rel)
                 } else {
                     let base = path.parent().unwrap_or(Path::new("."));
                     base.join(uri)
                 };
-                if !amends_path.exists() {
-                    // Amends file may be a schema reference that doesn't exist locally — skip
-                } else {
+                if amends_path.exists() {
                     let source = std::fs::read_to_string(&amends_path)
                         .map_err(|e| Error::Io(amends_path.clone(), e))?;
                     let name = amends_path.display().to_string();
                     let tokens = lexer::lex_named(&source, &name)?;
                     let base_module = parser::parse_named(&tokens, &source, &name)?;
-                    let base_val = self.eval_module(&base_module, &amends_path, depth + 1)?;
+                    let base_val = self
+                        .eval_module(&base_module, &amends_path, depth + 1)
+                        .await?;
                     if let Value::Object(m) = base_val {
                         base_obj = m;
                     }
@@ -120,14 +244,14 @@ impl Evaluator {
                     .any(|m| matches!(m, crate::parser::Modifier::Local))
                 && let Some(expr) = &prop.value
             {
-                let val = self.eval_expr(expr, &scope, depth)?;
+                let val = self.eval_expr(expr, &scope, depth).await?;
                 scope.set(prop.name.clone(), val);
             }
         }
         // Collect class definitions into module scope (after locals so defaults can reference them)
         for entry in &module.body {
             if let Entry::ClassDef(name, body) = entry {
-                let defaults = self.eval_entries(body, &scope, depth + 1)?;
+                let defaults = self.eval_entries(body, &scope, depth + 1).await?;
                 scope.set(name.clone(), defaults);
             }
         }
@@ -143,7 +267,7 @@ impl Evaluator {
                 {
                     continue; // already collected
                 }
-                let val = self.eval_property(prop, &scope, depth)?;
+                let val = self.eval_property(prop, &scope, depth).await?;
                 if let Some(v) = val {
                     out.insert(prop.name.clone(), v);
                 }
@@ -153,24 +277,31 @@ impl Evaluator {
         Ok(Value::Object(out))
     }
 
-    fn eval_property(
+    #[async_recursion(?Send)]
+    async fn eval_property(
         &mut self,
         prop: &Property,
         scope: &Scope,
         depth: usize,
     ) -> Result<Option<Value>> {
         if let Some(expr) = &prop.value {
-            return Ok(Some(self.eval_expr(expr, scope, depth)?));
+            return Ok(Some(self.eval_expr(expr, scope, depth).await?));
         }
         if let Some(body) = &prop.body {
             // `foo { ... }` — object body amendment
-            let val = self.eval_entries(body, scope, depth)?;
+            let val = self.eval_entries(body, scope, depth).await?;
             return Ok(Some(val));
         }
         Ok(None) // bare type-only declaration
     }
 
-    fn eval_entries(&mut self, entries: &[Entry], scope: &Scope, depth: usize) -> Result<Value> {
+    #[async_recursion(?Send)]
+    async fn eval_entries(
+        &mut self,
+        entries: &[Entry],
+        scope: &Scope,
+        depth: usize,
+    ) -> Result<Value> {
         let mut child_scope = scope.child();
         // Set `outer` to a snapshot of the parent scope's variables as an object
         let outer_obj = Value::Object(scope.flatten());
@@ -184,14 +315,14 @@ impl Evaluator {
                     .any(|m| matches!(m, crate::parser::Modifier::Local))
                 && let Some(expr) = &prop.value
             {
-                let val = self.eval_expr(expr, &child_scope, depth)?;
+                let val = self.eval_expr(expr, &child_scope, depth).await?;
                 child_scope.set(prop.name.clone(), val);
             }
         }
         // Collect class definitions into scope (after locals so defaults can reference them)
         for entry in entries {
             if let Entry::ClassDef(name, body) = entry {
-                let defaults = self.eval_entries(body, &child_scope, depth + 1)?;
+                let defaults = self.eval_entries(body, &child_scope, depth + 1).await?;
                 child_scope.set(name.clone(), defaults);
             }
         }
@@ -207,24 +338,26 @@ impl Evaluator {
                     {
                         continue;
                     }
-                    if let Some(v) = self.eval_property(prop, &child_scope, depth)? {
+                    if let Some(v) = self.eval_property(prop, &child_scope, depth).await? {
                         map.insert(prop.name.clone(), v);
                     }
                 }
                 Entry::DynProperty(key_expr, val_expr) => {
-                    let key = self.eval_expr(key_expr, &child_scope, depth)?;
-                    let val = self.eval_expr(val_expr, &child_scope, depth)?;
+                    let key = self.eval_expr(key_expr, &child_scope, depth).await?;
+                    let val = self.eval_expr(val_expr, &child_scope, depth).await?;
                     let key_str = value_to_key(&key)?;
                     map.insert(key_str, val);
                 }
                 Entry::Spread(expr) => {
-                    let val = self.eval_expr(expr, &child_scope, depth)?;
+                    let val = self.eval_expr(expr, &child_scope, depth).await?;
                     if let Value::Object(m) = val {
                         map.extend(m);
                     }
                 }
                 Entry::ForGenerator(fgen) => {
-                    let collection = self.eval_expr(&fgen.collection, &child_scope, depth)?;
+                    let collection = self
+                        .eval_expr(&fgen.collection, &child_scope, depth)
+                        .await?;
                     let items = collection_to_items(collection);
                     for (k, v) in items {
                         let mut iter_scope = child_scope.child();
@@ -232,21 +365,21 @@ impl Evaluator {
                         if let Some(key_var) = &fgen.key_var {
                             iter_scope.set(key_var.clone(), k);
                         }
-                        let body_val = self.eval_entries(&fgen.body, &iter_scope, depth)?;
+                        let body_val = self.eval_entries(&fgen.body, &iter_scope, depth).await?;
                         if let Value::Object(m) = body_val {
                             map.extend(m);
                         }
                     }
                 }
                 Entry::WhenGenerator(wgen) => {
-                    let cond = self.eval_expr(&wgen.condition, &child_scope, depth)?;
+                    let cond = self.eval_expr(&wgen.condition, &child_scope, depth).await?;
                     if is_truthy(&cond) {
-                        let body_val = self.eval_entries(&wgen.body, &child_scope, depth)?;
+                        let body_val = self.eval_entries(&wgen.body, &child_scope, depth).await?;
                         if let Value::Object(m) = body_val {
                             map.extend(m);
                         }
                     } else if let Some(else_body) = &wgen.else_body {
-                        let else_val = self.eval_entries(else_body, &child_scope, depth)?;
+                        let else_val = self.eval_entries(else_body, &child_scope, depth).await?;
                         if let Value::Object(m) = else_val {
                             map.extend(m);
                         }
@@ -259,7 +392,8 @@ impl Evaluator {
         Ok(Value::Object(map))
     }
 
-    fn eval_expr(&mut self, expr: &Expr, scope: &Scope, depth: usize) -> Result<Value> {
+    #[async_recursion(?Send)]
+    async fn eval_expr(&mut self, expr: &Expr, scope: &Scope, depth: usize) -> Result<Value> {
         if depth > self.max_depth {
             return Err(Error::Eval("maximum recursion depth exceeded".into()));
         }
@@ -275,7 +409,7 @@ impl Evaluator {
                     match part {
                         StringInterpPart::Literal(s) => result.push_str(s),
                         StringInterpPart::Expr(e) => {
-                            let val = self.eval_expr(e, scope, depth + 1)?;
+                            let val = self.eval_expr(e, scope, depth + 1).await?;
                             result.push_str(&value_to_display(&val));
                         }
                     }
@@ -298,17 +432,16 @@ impl Evaluator {
                         for entry in entries {
                             match entry {
                                 Entry::Elem(e) => {
-                                    items.push(self.eval_expr(e, scope, depth + 1)?);
+                                    items.push(self.eval_expr(e, scope, depth + 1).await?);
                                 }
                                 Entry::Property(p) if p.value.is_some() => {
-                                    items.push(self.eval_expr(
-                                        p.value.as_ref().unwrap(),
-                                        scope,
-                                        depth + 1,
-                                    )?);
+                                    items.push(
+                                        self.eval_expr(p.value.as_ref().unwrap(), scope, depth + 1)
+                                            .await?,
+                                    );
                                 }
                                 Entry::Spread(e) => {
-                                    let v = self.eval_expr(e, scope, depth + 1)?;
+                                    let v = self.eval_expr(e, scope, depth + 1).await?;
                                     match v {
                                         Value::List(l) => items.extend(l),
                                         Value::Object(m) => items.extend(m.into_values()),
@@ -317,7 +450,7 @@ impl Evaluator {
                                 }
                                 Entry::ForGenerator(fgen) => {
                                     let collection =
-                                        self.eval_expr(&fgen.collection, scope, depth + 1)?;
+                                        self.eval_expr(&fgen.collection, scope, depth + 1).await?;
                                     for (k, v) in collection_to_items(collection) {
                                         let mut iter_scope = scope.child();
                                         iter_scope.set(fgen.val_var.clone(), v);
@@ -326,11 +459,10 @@ impl Evaluator {
                                         }
                                         for sub in &fgen.body {
                                             if let Entry::Elem(e) = sub {
-                                                items.push(self.eval_expr(
-                                                    e,
-                                                    &iter_scope,
-                                                    depth + 1,
-                                                )?);
+                                                items.push(
+                                                    self.eval_expr(e, &iter_scope, depth + 1)
+                                                        .await?,
+                                                );
                                             }
                                         }
                                     }
@@ -342,13 +474,14 @@ impl Evaluator {
                     }
                     Some("Mapping") | Some("Map") => {
                         let mut map = IndexMap::new();
-                        self.eval_mapping_entries(entries, scope, depth, &mut map)?;
+                        self.eval_mapping_entries(entries, scope, depth, &mut map)
+                            .await?;
                         Ok(Value::Object(map))
                     }
                     _ => {
                         // Check if type name matches a class in scope
                         let base = type_name.as_ref().and_then(|name| scope.get(name)).cloned();
-                        let overlay = self.eval_entries(entries, scope, depth + 1)?;
+                        let overlay = self.eval_entries(entries, scope, depth + 1).await?;
                         if let Some(Value::Object(base_map)) = base {
                             let mut merged = base_map;
                             if let Value::Object(overlay_map) = overlay {
@@ -361,9 +494,9 @@ impl Evaluator {
                     }
                 }
             }
-            Expr::ObjectBody(entries) => self.eval_entries(entries, scope, depth + 1),
+            Expr::ObjectBody(entries) => self.eval_entries(entries, scope, depth + 1).await,
             Expr::Field(obj_expr, field) => {
-                let obj = self.eval_expr(obj_expr, scope, depth + 1)?;
+                let obj = self.eval_expr(obj_expr, scope, depth + 1).await?;
                 // Built-in properties
                 match (&obj, field.as_str()) {
                     (Value::List(items), "length") => return Ok(Value::Int(items.len() as i64)),
@@ -416,7 +549,7 @@ impl Evaluator {
                 }
             }
             Expr::NullSafeField(obj_expr, field) => {
-                let obj = self.eval_expr(obj_expr, scope, depth + 1)?;
+                let obj = self.eval_expr(obj_expr, scope, depth + 1).await?;
                 match &obj {
                     Value::Null => Ok(Value::Null),
                     Value::Object(map) => Ok(map.get(field).cloned().unwrap_or(Value::Null)),
@@ -427,8 +560,8 @@ impl Evaluator {
                 }
             }
             Expr::Index(obj_expr, key_expr) => {
-                let obj = self.eval_expr(obj_expr, scope, depth + 1)?;
-                let key = self.eval_expr(key_expr, scope, depth + 1)?;
+                let obj = self.eval_expr(obj_expr, scope, depth + 1).await?;
+                let key = self.eval_expr(key_expr, scope, depth + 1).await?;
                 let key_str = value_to_key(&key)?;
                 match obj {
                     Value::Object(map) => map
@@ -438,24 +571,24 @@ impl Evaluator {
                     _ => Err(Error::Eval("cannot index non-object".into())),
                 }
             }
-            Expr::Call(func_expr, args) => self.eval_call(func_expr, args, scope, depth),
+            Expr::Call(func_expr, args) => self.eval_call(func_expr, args, scope, depth).await,
             Expr::If(cond, then_expr, else_expr) => {
-                let c = self.eval_expr(cond, scope, depth + 1)?;
+                let c = self.eval_expr(cond, scope, depth + 1).await?;
                 if is_truthy(&c) {
-                    self.eval_expr(then_expr, scope, depth + 1)
+                    self.eval_expr(then_expr, scope, depth + 1).await
                 } else {
-                    self.eval_expr(else_expr, scope, depth + 1)
+                    self.eval_expr(else_expr, scope, depth + 1).await
                 }
             }
             Expr::Let(name, val_expr, body_expr) => {
-                let val = self.eval_expr(val_expr, scope, depth + 1)?;
+                let val = self.eval_expr(val_expr, scope, depth + 1).await?;
                 let mut child = scope.child();
                 child.set(name.clone(), val);
-                self.eval_expr(body_expr, &child, depth + 1)
+                self.eval_expr(body_expr, &child, depth + 1).await
             }
-            Expr::Binop(op, left, right) => self.eval_binop(*op, left, right, scope, depth),
+            Expr::Binop(op, left, right) => self.eval_binop(*op, left, right, scope, depth).await,
             Expr::Unop(op, operand) => {
-                let v = self.eval_expr(operand, scope, depth + 1)?;
+                let v = self.eval_expr(operand, scope, depth + 1).await?;
                 match op {
                     UnOp::Neg => match v {
                         Value::Int(n) => Ok(Value::Int(-n)),
@@ -476,20 +609,20 @@ impl Evaluator {
             }
             Expr::Is(expr, _ty) => {
                 // Simplified: just evaluate the expression, ignore type check
-                self.eval_expr(expr, scope, depth + 1)
+                self.eval_expr(expr, scope, depth + 1).await
             }
-            Expr::As(expr, _ty) => self.eval_expr(expr, scope, depth + 1),
+            Expr::As(expr, _ty) => self.eval_expr(expr, scope, depth + 1).await,
             Expr::Throw(msg_expr) => {
-                let msg = self.eval_expr(msg_expr, scope, depth + 1)?;
+                let msg = self.eval_expr(msg_expr, scope, depth + 1).await?;
                 Err(Error::Eval(format!("throw: {}", value_to_display(&msg))))
             }
             Expr::Trace(expr) => {
-                let v = self.eval_expr(expr, scope, depth + 1)?;
+                let v = self.eval_expr(expr, scope, depth + 1).await?;
                 eprintln!("[pklr trace] {}", value_to_display(&v));
                 Ok(v)
             }
             Expr::Read(uri_expr) => {
-                let uri = self.eval_expr(uri_expr, scope, depth + 1)?;
+                let uri = self.eval_expr(uri_expr, scope, depth + 1).await?;
                 Err(Error::Unsupported(format!(
                     "read() not supported: {}",
                     value_to_display(&uri)
@@ -498,7 +631,8 @@ impl Evaluator {
         }
     }
 
-    fn eval_call(
+    #[async_recursion(?Send)]
+    async fn eval_call(
         &mut self,
         func_expr: &Expr,
         args: &[Expr],
@@ -507,13 +641,15 @@ impl Evaluator {
     ) -> Result<Value> {
         // Handle method calls: obj.method(args)
         if let Expr::Field(obj_expr, method) = func_expr {
-            let obj = self.eval_expr(obj_expr, scope, depth + 1)?;
-            let evaled_args: Result<Vec<_>> = args
-                .iter()
-                .map(|a| self.eval_expr(a, scope, depth + 1))
-                .collect();
-            let evaled_args = evaled_args?;
-            if let Some(result) = self.eval_method_call(&obj, method, &evaled_args, depth)? {
+            let obj = self.eval_expr(obj_expr, scope, depth + 1).await?;
+            let mut evaled_args = Vec::new();
+            for a in args {
+                evaled_args.push(self.eval_expr(a, scope, depth + 1).await?);
+            }
+            if let Some(result) = self
+                .eval_method_call(&obj, method, &evaled_args, depth)
+                .await?
+            {
                 return Ok(result);
             }
         }
@@ -522,27 +658,26 @@ impl Evaluator {
         if let Expr::Ident(name) = func_expr {
             match name.as_str() {
                 "List" | "Listing" => {
-                    let items: Result<Vec<_>> = args
-                        .iter()
-                        .map(|a| self.eval_expr(a, scope, depth + 1))
-                        .collect();
-                    return Ok(Value::List(items?));
+                    let mut items = Vec::new();
+                    for a in args {
+                        items.push(self.eval_expr(a, scope, depth + 1).await?);
+                    }
+                    return Ok(Value::List(items));
                 }
                 "Set" => {
-                    let items: Result<Vec<_>> = args
-                        .iter()
-                        .map(|a| self.eval_expr(a, scope, depth + 1))
-                        .collect();
-                    return Ok(Value::List(items?)); // treat Set as List
+                    let mut items = Vec::new();
+                    for a in args {
+                        items.push(self.eval_expr(a, scope, depth + 1).await?);
+                    }
+                    return Ok(Value::List(items)); // treat Set as List
                 }
                 "Map" => {
                     // Map(k1, v1, k2, v2, ...)
                     let mut map = IndexMap::new();
-                    let evaled: Result<Vec<_>> = args
-                        .iter()
-                        .map(|a| self.eval_expr(a, scope, depth + 1))
-                        .collect();
-                    let evaled = evaled?;
+                    let mut evaled = Vec::new();
+                    for a in args {
+                        evaled.push(self.eval_expr(a, scope, depth + 1).await?);
+                    }
                     for pair in evaled.chunks(2) {
                         if let [k, v] = pair {
                             map.insert(value_to_key(k)?, v.clone());
@@ -555,7 +690,7 @@ impl Evaluator {
         }
 
         // Evaluate the function expression
-        let func_val = self.eval_expr(func_expr, scope, depth + 1)?;
+        let func_val = self.eval_expr(func_expr, scope, depth + 1).await?;
 
         // Lambda call
         if let Value::Lambda(params, body, captured) = func_val {
@@ -565,15 +700,14 @@ impl Evaluator {
                 call_scope.set(k, v);
             }
             // Bind arguments to parameters
-            let evaled_args: Result<Vec<_>> = args
-                .iter()
-                .map(|a| self.eval_expr(a, scope, depth + 1))
-                .collect();
-            let evaled_args = evaled_args?;
+            let mut evaled_args = Vec::new();
+            for a in args {
+                evaled_args.push(self.eval_expr(a, scope, depth + 1).await?);
+            }
             for (param, arg) in params.iter().zip(evaled_args) {
                 call_scope.set(param.clone(), arg);
             }
-            return self.eval_expr(&body, &call_scope, depth + 1);
+            return self.eval_expr(&body, &call_scope, depth + 1).await;
         }
 
         // Plain call with no args on an object — return the object
@@ -583,7 +717,8 @@ impl Evaluator {
         Err(Error::Eval("cannot call non-function".into()))
     }
 
-    fn eval_method_call(
+    #[async_recursion(?Send)]
+    async fn eval_method_call(
         &mut self,
         obj: &Value,
         method: &str,
@@ -646,7 +781,10 @@ impl Evaluator {
                     .ok_or_else(|| Error::Eval("map requires a function argument".into()))?;
                 let mut result = Vec::new();
                 for item in items {
-                    result.push(self.invoke_lambda(lambda, std::slice::from_ref(item), depth)?);
+                    result.push(
+                        self.invoke_lambda(lambda, std::slice::from_ref(item), depth)
+                            .await?,
+                    );
                 }
                 Ok(Some(Value::List(result)))
             }
@@ -656,7 +794,9 @@ impl Evaluator {
                     .ok_or_else(|| Error::Eval("flatMap requires a function argument".into()))?;
                 let mut result = Vec::new();
                 for item in items {
-                    let val = self.invoke_lambda(lambda, std::slice::from_ref(item), depth)?;
+                    let val = self
+                        .invoke_lambda(lambda, std::slice::from_ref(item), depth)
+                        .await?;
                     if let Value::List(inner) = val {
                         result.extend(inner);
                     } else {
@@ -671,7 +811,9 @@ impl Evaluator {
                     .ok_or_else(|| Error::Eval("filter requires a function argument".into()))?;
                 let mut result = Vec::new();
                 for item in items {
-                    let cond = self.invoke_lambda(lambda, std::slice::from_ref(item), depth)?;
+                    let cond = self
+                        .invoke_lambda(lambda, std::slice::from_ref(item), depth)
+                        .await?;
                     if is_truthy(&cond) {
                         result.push(item.clone());
                     }
@@ -688,7 +830,9 @@ impl Evaluator {
                     .ok_or_else(|| Error::Eval("fold requires a function argument".into()))?;
                 let mut acc = init;
                 for item in items {
-                    acc = self.invoke_lambda(lambda, &[acc, item.clone()], depth)?;
+                    acc = self
+                        .invoke_lambda(lambda, &[acc, item.clone()], depth)
+                        .await?;
                 }
                 Ok(Some(acc))
             }
@@ -697,7 +841,11 @@ impl Evaluator {
                     .first()
                     .ok_or_else(|| Error::Eval("any requires a function argument".into()))?;
                 for item in items {
-                    if is_truthy(&self.invoke_lambda(lambda, std::slice::from_ref(item), depth)?) {
+                    if is_truthy(
+                        &self
+                            .invoke_lambda(lambda, std::slice::from_ref(item), depth)
+                            .await?,
+                    ) {
                         return Ok(Some(Value::Bool(true)));
                     }
                 }
@@ -708,7 +856,11 @@ impl Evaluator {
                     .first()
                     .ok_or_else(|| Error::Eval("every requires a function argument".into()))?;
                 for item in items {
-                    if !is_truthy(&self.invoke_lambda(lambda, std::slice::from_ref(item), depth)?) {
+                    if !is_truthy(
+                        &self
+                            .invoke_lambda(lambda, std::slice::from_ref(item), depth)
+                            .await?,
+                    ) {
                         return Ok(Some(Value::Bool(false)));
                     }
                 }
@@ -737,8 +889,9 @@ impl Evaluator {
                     .ok_or_else(|| Error::Eval("mapValues requires a function".into()))?;
                 let mut result = IndexMap::new();
                 for (k, v) in map {
-                    let new_v =
-                        self.invoke_lambda(lambda, &[Value::String(k.clone()), v.clone()], depth)?;
+                    let new_v = self
+                        .invoke_lambda(lambda, &[Value::String(k.clone()), v.clone()], depth)
+                        .await?;
                     result.insert(k.clone(), new_v);
                 }
                 Ok(Some(Value::Object(result)))
@@ -759,14 +912,20 @@ impl Evaluator {
                 for (param, arg) in params.iter().zip(args.iter()) {
                     call_scope.set(param.clone(), arg.clone());
                 }
-                Ok(Some(self.eval_expr(body, &call_scope, depth + 1)?))
+                Ok(Some(self.eval_expr(body, &call_scope, depth + 1).await?))
             }
 
             _ => Ok(None), // not a known method
         }
     }
 
-    fn invoke_lambda(&mut self, lambda: &Value, args: &[Value], depth: usize) -> Result<Value> {
+    #[async_recursion(?Send)]
+    async fn invoke_lambda(
+        &mut self,
+        lambda: &Value,
+        args: &[Value],
+        depth: usize,
+    ) -> Result<Value> {
         if let Value::Lambda(params, body, captured) = lambda {
             let mut scope = Scope::default();
             for (k, v) in captured {
@@ -775,13 +934,14 @@ impl Evaluator {
             for (param, arg) in params.iter().zip(args.iter()) {
                 scope.set(param.clone(), arg.clone());
             }
-            self.eval_expr(body, &scope, depth + 1)
+            self.eval_expr(body, &scope, depth + 1).await
         } else {
             Err(Error::Eval("expected a function".into()))
         }
     }
 
-    fn eval_binop(
+    #[async_recursion(?Send)]
+    async fn eval_binop(
         &mut self,
         op: BinOp,
         left: &Expr,
@@ -793,13 +953,13 @@ impl Evaluator {
         if let BinOp::Add = op
             && let Expr::ObjectBody(entries) = right
         {
-            let base = self.eval_expr(left, scope, depth + 1)?;
-            let overlay = self.eval_entries(entries, scope, depth + 1)?;
+            let base = self.eval_expr(left, scope, depth + 1).await?;
+            let overlay = self.eval_entries(entries, scope, depth + 1).await?;
             return Ok(merge_values(base, overlay));
         }
 
-        let l = self.eval_expr(left, scope, depth + 1)?;
-        let r = self.eval_expr(right, scope, depth + 1)?;
+        let l = self.eval_expr(left, scope, depth + 1).await?;
+        let r = self.eval_expr(right, scope, depth + 1).await?;
         match op {
             BinOp::Add => add_values(l, r),
             BinOp::Sub => arithmetic(l, r, |a, b| Ok(a - b), |a, b| Ok(a - b)),
@@ -884,7 +1044,7 @@ impl Evaluator {
                             call_scope.set(k, v);
                         }
                         call_scope.set(params[0].clone(), l);
-                        self.eval_expr(&body, &call_scope, depth + 1)
+                        self.eval_expr(&body, &call_scope, depth + 1).await
                     }
                     _ => Err(Error::Eval(
                         "pipe operator requires a function on the right side".into(),
@@ -894,7 +1054,8 @@ impl Evaluator {
         }
     }
 
-    fn eval_mapping_entries(
+    #[async_recursion(?Send)]
+    async fn eval_mapping_entries(
         &mut self,
         entries: &[crate::parser::Entry],
         scope: &Scope,
@@ -904,8 +1065,8 @@ impl Evaluator {
         for entry in entries {
             match entry {
                 Entry::DynProperty(key_expr, val_expr) => {
-                    let key = self.eval_expr(key_expr, scope, depth + 1)?;
-                    let val = self.eval_expr(val_expr, scope, depth + 1)?;
+                    let key = self.eval_expr(key_expr, scope, depth + 1).await?;
+                    let val = self.eval_expr(val_expr, scope, depth + 1).await?;
                     map.insert(value_to_key(&key)?, val);
                 }
                 Entry::Property(prop)
@@ -917,20 +1078,21 @@ impl Evaluator {
                     // skip locals in mapping
                 }
                 Entry::Spread(e) => {
-                    let v = self.eval_expr(e, scope, depth + 1)?;
+                    let v = self.eval_expr(e, scope, depth + 1).await?;
                     if let Value::Object(m) = v {
                         map.extend(m);
                     }
                 }
                 Entry::ForGenerator(fgen) => {
-                    let collection = self.eval_expr(&fgen.collection, scope, depth + 1)?;
+                    let collection = self.eval_expr(&fgen.collection, scope, depth + 1).await?;
                     for (k, v) in collection_to_items(collection) {
                         let mut iter_scope = scope.child();
                         iter_scope.set(fgen.val_var.clone(), v);
                         if let Some(kv) = &fgen.key_var {
                             iter_scope.set(kv.clone(), k);
                         }
-                        self.eval_mapping_entries(&fgen.body, &iter_scope, depth + 1, map)?;
+                        self.eval_mapping_entries(&fgen.body, &iter_scope, depth + 1, map)
+                            .await?;
                     }
                 }
                 _ => {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,11 +12,11 @@ use std::path::Path;
 
 /// Evaluate a pkl file and return its contents as a JSON value.
 /// This is the primary entry point for use in tools like hk.
-pub fn eval_to_json(path: &Path) -> Result<serde_json::Value> {
+pub async fn eval_to_json(path: &Path) -> Result<serde_json::Value> {
     let source = std::fs::read_to_string(path).map_err(|e| Error::Io(path.to_path_buf(), e))?;
     let mut evaluator = Evaluator::new();
     evaluator.set_base_path(path.parent().unwrap_or(Path::new(".")));
-    let value = evaluator.eval_source(&source, path)?;
+    let value = evaluator.eval_source(&source, path).await?;
     Ok(value.to_json())
 }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -991,14 +991,6 @@ impl<'a> Parser<'a> {
                 self.advance();
                 Ok(Expr::Ident(name))
             }
-            TokenKind::KwThis => {
-                self.advance();
-                Ok(Expr::Ident("this".into()))
-            }
-            TokenKind::KwModule => {
-                self.advance();
-                Ok(Expr::Ident("module".into()))
-            }
             tok => Err(self.parse_error(format!("unexpected token in expression: {:?}", tok))),
         }
     }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -59,10 +59,13 @@ import "pkl/Builtins.pkl"
 // --- Evaluator tests ---
 
 fn eval_src(src: &str) -> serde_json::Value {
-    let mut ev = Evaluator::new();
-    let path = std::path::Path::new("test.pkl");
-    let val = ev.eval_source(src, path).unwrap();
-    val.to_json()
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    rt.block_on(async {
+        let mut ev = Evaluator::new();
+        let path = std::path::Path::new("test.pkl");
+        let val = ev.eval_source(src, path).await.unwrap();
+        val.to_json()
+    })
 }
 
 #[test]

--- a/tests/pkl_features.rs
+++ b/tests/pkl_features.rs
@@ -6,19 +6,25 @@
 use pklr::eval::Evaluator;
 
 fn eval(src: &str) -> serde_json::Value {
-    let mut ev = Evaluator::new();
-    let path = std::path::Path::new("test.pkl");
-    let val = ev.eval_source(src, path).unwrap();
-    val.to_json()
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    rt.block_on(async {
+        let mut ev = Evaluator::new();
+        let path = std::path::Path::new("test.pkl");
+        let val = ev.eval_source(src, path).await.unwrap();
+        val.to_json()
+    })
 }
 
 fn eval_fails(src: &str) -> String {
-    let mut ev = Evaluator::new();
-    let path = std::path::Path::new("test.pkl");
-    match ev.eval_source(src, path) {
-        Err(e) => e.to_string(),
-        Ok(v) => panic!("expected error, got: {:?}", v.to_json()),
-    }
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    rt.block_on(async {
+        let mut ev = Evaluator::new();
+        let path = std::path::Path::new("test.pkl");
+        match ev.eval_source(src, path).await {
+            Err(e) => e.to_string(),
+            Ok(v) => panic!("expected error, got: {:?}", v.to_json()),
+        }
+    })
 }
 
 // ============================================================
@@ -862,8 +868,8 @@ x = List().isEmpty
 // Import resolution (future)
 // ============================================================
 
-#[test]
-fn import_local_file() {
+#[tokio::test]
+async fn import_local_file() {
     let mut ev = pklr::eval::Evaluator::new();
     // Set base path so relative imports resolve correctly
     let base = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures");
@@ -873,7 +879,7 @@ import "helper.pkl"
 x = helper.value
 "#;
     let path = base.join("test_import.pkl");
-    let val = ev.eval_source(src, &path).unwrap();
+    let val = ev.eval_source(src, &path).await.unwrap();
     let json = val.to_json();
     assert_eq!(json["x"], 42);
 }
@@ -882,8 +888,8 @@ x = helper.value
 // Amends resolution
 // ============================================================
 
-#[test]
-fn amends_local_file() {
+#[tokio::test]
+async fn amends_local_file() {
     let mut ev = pklr::eval::Evaluator::new();
     let base = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures");
     ev.set_base_path(&base);
@@ -892,7 +898,7 @@ amends "base.pkl"
 name = "override"
 "#;
     let path = base.join("test_amends.pkl");
-    let val = ev.eval_source(src, &path).unwrap();
+    let val = ev.eval_source(src, &path).await.unwrap();
     let json = val.to_json();
     // name is overridden
     assert_eq!(json["name"], "override");


### PR DESCRIPTION
## Summary
Makes the evaluator fully async and adds HTTP-based import support.

**Async evaluator:**
- All `Evaluator` methods are now `async fn` with `#[async_recursion(?Send)]`
- Public `eval_to_json` is now async
- Added `reqwest` + `tokio` + `async-recursion` dependencies

**HTTP imports:**
- `import "https://example.com/config.pkl"` fetches and evaluates remote pkl files
- `amends "https://example.com/base.pkl"` works for remote base modules
- HTTP responses cached in-memory (`HashMap<String, String>`) to avoid re-fetching
- `package://` URIs automatically converted to GitHub release URLs:
  ```
  package://pkg.pkl-lang.org/github.com/owner/repo@version#/path.pkl
  → https://github.com/owner/repo/releases/download/version/path.pkl
  ```

**Test updates:**
- Test helpers use `tokio::runtime::Runtime::new()` to block on async
- Import/amends tests use `#[tokio::test]`

Also includes all changes from #15 (class definitions, outer keyword).

### Test results
97 passing, 0 ignored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)