### PR TITLE
feat: integer division, exponentiation, non-null assertion, pipe operator

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,8 @@ pklr implements a subset of the [Pkl language](https://pkl-lang.org/main/current
 | Feature | Status |
 |---|---|
 | Arithmetic (`+`, `-`, `*`, `/`, `%`) | Supported |
-| Integer division (`~/`) | Not supported |
-| Exponentiation (`**`) | Not supported |
+| Integer division (`~/`) | Supported |
+| Exponentiation (`**`) | Supported |
 | Comparison (`==`, `!=`, `<`, `>`, `<=`, `>=`) | Supported |
 | Logical (`&&`, `\|\|`, `!`) | Supported |
 | Null coalescing (`??`) | Supported |
@@ -46,8 +46,8 @@ pklr implements a subset of the [Pkl language](https://pkl-lang.org/main/current
 | List concatenation (`+`) | Supported |
 | Object merging (`+`) | Supported |
 | Null propagation (`?.`) | Supported |
-| Non-null assertion (`!!`) | Not supported |
-| Pipe operator (`\|>`) | Not supported |
+| Non-null assertion (`!!`) | Supported |
+| Pipe operator (`\|>`) | Supported |
 
 ### Objects, Listings & Mappings
 

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -812,7 +812,20 @@ impl Evaluator {
                 },
                 |a, b| Ok((a / b).floor()),
             ),
-            BinOp::Pow => arithmetic(l, r, |a, b| Ok(a.pow(b as u32)), |a, b| Ok(a.powf(b))),
+            BinOp::Pow => arithmetic(
+                l,
+                r,
+                |a, b| {
+                    if b < 0 {
+                        Err(Error::Eval(
+                            "integer exponentiation with negative exponent is not supported".into(),
+                        ))
+                    } else {
+                        Ok(a.pow(b as u32))
+                    }
+                },
+                |a, b| Ok(a.powf(b)),
+            ),
             BinOp::NullCoalesce => {
                 if matches!(l, Value::Null) {
                     Ok(r)
@@ -824,13 +837,17 @@ impl Evaluator {
                 // x |> f  is equivalent to  f(x)
                 match r {
                     Value::Lambda(params, body, captured) => {
+                        if params.len() != 1 {
+                            return Err(Error::Eval(format!(
+                                "pipe operator requires a single-parameter function, got {}",
+                                params.len()
+                            )));
+                        }
                         let mut call_scope = Scope::default();
                         for (k, v) in captured {
                             call_scope.set(k, v);
                         }
-                        if let Some(param) = params.first() {
-                            call_scope.set(param.clone(), l);
-                        }
+                        call_scope.set(params[0].clone(), l);
                         self.eval_expr(&body, &call_scope, depth + 1)
                     }
                     _ => Err(Error::Eval(

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -427,6 +427,15 @@ impl Evaluator {
                         _ => Err(Error::Eval("cannot negate non-number".into())),
                     },
                     UnOp::Not => Ok(Value::Bool(!is_truthy(&v))),
+                    UnOp::NonNull => {
+                        if matches!(v, Value::Null) {
+                            Err(Error::Eval(
+                                "non-null assertion failed: value is null".into(),
+                            ))
+                        } else {
+                            Ok(v)
+                        }
+                    }
                 }
             }
             Expr::Is(expr, _ty) => {
@@ -791,11 +800,42 @@ impl Evaluator {
             BinOp::Ge => compare_or_eq(l, r, std::cmp::Ordering::Greater),
             BinOp::And => Ok(Value::Bool(is_truthy(&l) && is_truthy(&r))),
             BinOp::Or => Ok(Value::Bool(is_truthy(&l) || is_truthy(&r))),
+            BinOp::IntDiv => arithmetic(
+                l,
+                r,
+                |a, b| {
+                    if b == 0 {
+                        Err(Error::Eval("division by zero".into()))
+                    } else {
+                        Ok(a / b)
+                    }
+                },
+                |a, b| Ok((a / b).floor()),
+            ),
+            BinOp::Pow => arithmetic(l, r, |a, b| Ok(a.pow(b as u32)), |a, b| Ok(a.powf(b))),
             BinOp::NullCoalesce => {
                 if matches!(l, Value::Null) {
                     Ok(r)
                 } else {
                     Ok(l)
+                }
+            }
+            BinOp::Pipe => {
+                // x |> f  is equivalent to  f(x)
+                match r {
+                    Value::Lambda(params, body, captured) => {
+                        let mut call_scope = Scope::default();
+                        for (k, v) in captured {
+                            call_scope.set(k, v);
+                        }
+                        if let Some(param) = params.first() {
+                            call_scope.set(param.clone(), l);
+                        }
+                        self.eval_expr(&body, &call_scope, depth + 1)
+                    }
+                    _ => Err(Error::Eval(
+                        "pipe operator requires a function on the right side".into(),
+                    )),
                 }
             }
         }

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -35,7 +35,9 @@ pub enum TokenKind {
     QuestionQuestion, // ??
     QuestionDot,      // ?.
     Bang,             // !
+    BangBang,         // !!
     Pipe,             // |
+    PipeGt,           // |>
     Caret,            // ^
     At,               // @
 
@@ -51,6 +53,8 @@ pub enum TokenKind {
     Gt,
     LtEq,
     GtEq,
+    TildeSlash, // ~/
+    StarStar,   // **
     AmpAmp,
     PipePipe,
     Arrow,     // ->
@@ -506,6 +510,9 @@ impl<'a> Lexer<'a> {
                 if self.peek() == Some('=') {
                     self.advance();
                     TokenKind::BangEq
+                } else if self.peek() == Some('!') {
+                    self.advance();
+                    TokenKind::BangBang
                 } else {
                     TokenKind::Bang
                 }
@@ -515,6 +522,9 @@ impl<'a> Lexer<'a> {
                 if self.peek() == Some('|') {
                     self.advance();
                     TokenKind::PipePipe
+                } else if self.peek() == Some('>') {
+                    self.advance();
+                    TokenKind::PipeGt
                 } else {
                     TokenKind::Pipe
                 }
@@ -542,7 +552,12 @@ impl<'a> Lexer<'a> {
             }
             '*' => {
                 self.advance();
-                TokenKind::Star
+                if self.peek() == Some('*') {
+                    self.advance();
+                    TokenKind::StarStar
+                } else {
+                    TokenKind::Star
+                }
             }
             '/' => {
                 self.advance();
@@ -604,6 +619,15 @@ impl<'a> Lexer<'a> {
                         self.advance();
                     }
                     return self.read_one_token();
+                }
+            }
+            '~' => {
+                self.advance();
+                if self.peek() == Some('/') {
+                    self.advance();
+                    TokenKind::TildeSlash
+                } else {
+                    return Err(self.lex_error("unexpected '~'"));
                 }
             }
             c if c.is_ascii_digit() => {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -119,6 +119,8 @@ pub enum BinOp {
     Mul,
     Div,
     Mod,
+    IntDiv,
+    Pow,
     Eq,
     Ne,
     Lt,
@@ -128,12 +130,14 @@ pub enum BinOp {
     And,
     Or,
     NullCoalesce,
+    Pipe,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum UnOp {
     Neg,
     Not,
+    NonNull,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -633,7 +637,17 @@ impl<'a> Parser<'a> {
     }
 
     fn parse_expr(&mut self) -> Result<Expr> {
-        self.parse_null_coalesce()
+        self.parse_pipe()
+    }
+
+    fn parse_pipe(&mut self) -> Result<Expr> {
+        let mut left = self.parse_null_coalesce()?;
+        while matches!(self.peek(), TokenKind::PipeGt) {
+            self.advance();
+            let right = self.parse_null_coalesce()?;
+            left = Expr::Binop(BinOp::Pipe, Box::new(left), Box::new(right));
+        }
+        Ok(left)
     }
 
     fn parse_null_coalesce(&mut self) -> Result<Expr> {
@@ -701,19 +715,32 @@ impl<'a> Parser<'a> {
     }
 
     fn parse_mul(&mut self) -> Result<Expr> {
-        let mut left = self.parse_unary()?;
+        let mut left = self.parse_exp()?;
         loop {
             let op = match self.peek() {
                 TokenKind::Star => BinOp::Mul,
                 TokenKind::Slash => BinOp::Div,
                 TokenKind::Percent => BinOp::Mod,
+                TokenKind::TildeSlash => BinOp::IntDiv,
                 _ => break,
             };
             self.advance();
-            let right = self.parse_unary()?;
+            let right = self.parse_exp()?;
             left = Expr::Binop(op, Box::new(left), Box::new(right));
         }
         Ok(left)
+    }
+
+    fn parse_exp(&mut self) -> Result<Expr> {
+        let base = self.parse_unary()?;
+        if matches!(self.peek(), TokenKind::StarStar) {
+            self.advance();
+            // Right-associative: recurse into parse_exp
+            let exp = self.parse_exp()?;
+            Ok(Expr::Binop(BinOp::Pow, Box::new(base), Box::new(exp)))
+        } else {
+            Ok(base)
+        }
     }
 
     fn parse_unary(&mut self) -> Result<Expr> {
@@ -789,6 +816,10 @@ impl<'a> Parser<'a> {
                     self.advance();
                     let ty = self.parse_type()?;
                     expr = Expr::As(Box::new(expr), ty);
+                }
+                TokenKind::BangBang => {
+                    self.advance();
+                    expr = Expr::Unop(UnOp::NonNull, Box::new(expr));
                 }
                 _ => break,
             }

--- a/tests/pkl_features.rs
+++ b/tests/pkl_features.rs
@@ -264,6 +264,18 @@ fn exp_precedence() {
     assert_eq!(json["x"], 18);
 }
 
+#[test]
+fn exp_negative_exponent_errors() {
+    let msg = eval_fails(r#"x = 2 ** -1"#);
+    assert!(msg.contains("negative exponent"));
+}
+
+#[test]
+fn exp_float_negative_exponent() {
+    let json = eval(r#"x = 2.0 ** -1.0"#);
+    assert_eq!(json["x"], 0.5);
+}
+
 // ============================================================
 // Non-null assertion
 // ============================================================
@@ -326,6 +338,17 @@ result = 5 |> double |> addOne
 "#,
     );
     assert_eq!(json["result"], 11);
+}
+
+#[test]
+fn pipe_multi_param_errors() {
+    let msg = eval_fails(
+        r#"
+local add = (a, b) -> a + b
+result = 5 |> add
+"#,
+    );
+    assert!(msg.contains("single-parameter"));
 }
 
 // ============================================================

--- a/tests/pkl_features.rs
+++ b/tests/pkl_features.rs
@@ -207,6 +207,128 @@ fn arithmetic_mod_by_zero() {
 }
 
 // ============================================================
+// Integer division
+// ============================================================
+
+#[test]
+fn int_div_basic() {
+    let json = eval(r#"x = 7 ~/ 2"#);
+    assert_eq!(json["x"], 3);
+}
+
+#[test]
+fn int_div_negative() {
+    let json = eval(r#"x = -7 ~/ 2"#);
+    assert_eq!(json["x"], -3);
+}
+
+#[test]
+fn int_div_float() {
+    let json = eval(r#"x = 7.5 ~/ 2.0"#);
+    assert_eq!(json["x"], 3.0);
+}
+
+#[test]
+fn int_div_by_zero() {
+    let msg = eval_fails(r#"x = 7 ~/ 0"#);
+    assert!(msg.contains("division by zero"));
+}
+
+// ============================================================
+// Exponentiation
+// ============================================================
+
+#[test]
+fn exp_basic() {
+    let json = eval(r#"x = 2 ** 10"#);
+    assert_eq!(json["x"], 1024);
+}
+
+#[test]
+fn exp_float() {
+    let json = eval(r#"x = 2.0 ** 3.0"#);
+    assert_eq!(json["x"], 8.0);
+}
+
+#[test]
+fn exp_right_associative() {
+    // 2 ** 3 ** 2 should be 2 ** (3 ** 2) = 2 ** 9 = 512
+    let json = eval(r#"x = 2 ** 3 ** 2"#);
+    assert_eq!(json["x"], 512);
+}
+
+#[test]
+fn exp_precedence() {
+    // 2 * 3 ** 2 should be 2 * (3 ** 2) = 2 * 9 = 18
+    let json = eval(r#"x = 2 * 3 ** 2"#);
+    assert_eq!(json["x"], 18);
+}
+
+// ============================================================
+// Non-null assertion
+// ============================================================
+
+#[test]
+fn non_null_assertion_pass() {
+    let json = eval(
+        r#"
+local x = 42
+y = x!!
+"#,
+    );
+    assert_eq!(json["y"], 42);
+}
+
+#[test]
+fn non_null_assertion_fail() {
+    let msg = eval_fails(
+        r#"
+local x = null
+y = x!!
+"#,
+    );
+    assert!(msg.contains("non-null assertion failed"));
+}
+
+#[test]
+fn non_null_assertion_string() {
+    let json = eval(
+        r#"
+local x = "hello"
+y = x!!
+"#,
+    );
+    assert_eq!(json["y"], "hello");
+}
+
+// ============================================================
+// Pipe operator
+// ============================================================
+
+#[test]
+fn pipe_basic() {
+    let json = eval(
+        r#"
+local double = (x) -> x * 2
+result = 5 |> double
+"#,
+    );
+    assert_eq!(json["result"], 10);
+}
+
+#[test]
+fn pipe_chain() {
+    let json = eval(
+        r#"
+local double = (x) -> x * 2
+local addOne = (x) -> x + 1
+result = 5 |> double |> addOne
+"#,
+    );
+    assert_eq!(json["result"], 11);
+}
+
+// ============================================================
 // Comparison and logical operators
 // ============================================================
 


### PR DESCRIPTION
## Summary
- Add integer division (`~/`) operator -- truncates towards zero for ints, floors for floats
- Add exponentiation (`**`) operator -- right-associative, higher precedence than `*`/`/`
- Add non-null assertion (`!!`) postfix operator -- errors on null values
- Add pipe operator (`|>`) -- passes left value as first argument to right-side function
- Update README to mark all four operators as supported

## Test plan
- [x] 13 new tests covering all four operators (basic usage, edge cases, precedence, error conditions)
- [x] All 90 feature tests pass
- [x] All existing tests still pass (107 total)
- [x] Clippy clean, `cargo fmt --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)