### PR TITLE
fix(parser): skip generic type params in new expressions

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -365,26 +365,7 @@ impl<'a> Parser<'a> {
                 let name = self.expect_ident()?;
                 // Skip optional type params <...>
                 if matches!(self.peek(), TokenKind::Lt) {
-                    let mut angle_depth = 0;
-                    loop {
-                        match self.peek() {
-                            TokenKind::Lt => {
-                                angle_depth += 1;
-                                self.advance();
-                            }
-                            TokenKind::Gt | TokenKind::GtEq => {
-                                angle_depth -= 1;
-                                self.advance();
-                                if angle_depth == 0 {
-                                    break;
-                                }
-                            }
-                            TokenKind::Eof => break,
-                            _ => {
-                                self.advance();
-                            }
-                        }
-                    }
+                    self.skip_generic_params()?;
                 }
                 // Skip optional extends clause
                 if matches!(self.peek(), TokenKind::KwExtends) {
@@ -415,6 +396,34 @@ impl<'a> Parser<'a> {
             entries.push(entry);
         }
         Ok(entries)
+    }
+
+    /// Skip generic type parameters: `<Type, Type<Nested>, ...>`
+    /// Assumes the current token is `<`. Consumes through the matching `>`.
+    fn skip_generic_params(&mut self) -> Result<()> {
+        let mut depth = 0;
+        loop {
+            match self.peek() {
+                TokenKind::Lt => {
+                    depth += 1;
+                    self.advance();
+                }
+                TokenKind::Gt => {
+                    depth -= 1;
+                    self.advance();
+                    if depth == 0 {
+                        break;
+                    }
+                }
+                TokenKind::Eof => {
+                    return Err(self.parse_error("unclosed generic type parameters"));
+                }
+                _ => {
+                    self.advance();
+                }
+            }
+        }
+        Ok(())
     }
 
     /// Skip a class, typealias, or function declaration.
@@ -941,6 +950,10 @@ impl<'a> Parser<'a> {
                 } else {
                     None
                 };
+                // Skip optional generic type params: <Type, Type, ...>
+                if matches!(self.peek(), TokenKind::Lt) {
+                    self.skip_generic_params()?;
+                }
                 self.expect(&TokenKind::LBrace)?;
                 let entries = self.parse_entries()?;
                 self.expect(&TokenKind::RBrace)?;

--- a/tests/pkl_features.rs
+++ b/tests/pkl_features.rs
@@ -672,6 +672,48 @@ fn map_function() {
     assert_eq!(json["x"]["b"], 2);
 }
 
+#[test]
+fn new_mapping_with_generic_params() {
+    let json = eval(
+        r#"
+x = new Mapping<String, String> {
+    ["a"] = "hello"
+    ["b"] = "world"
+}
+"#,
+    );
+    assert_eq!(json["x"]["a"], "hello");
+    assert_eq!(json["x"]["b"], "world");
+}
+
+#[test]
+fn new_listing_with_generic_params() {
+    let json = eval(
+        r#"
+x = new Listing<String> {
+    "a"
+    "b"
+    "c"
+}
+"#,
+    );
+    assert_eq!(json["x"], serde_json::json!(["a", "b", "c"]));
+}
+
+#[test]
+fn new_mapping_nested_generic_params() {
+    let json = eval(
+        r#"
+x = new Mapping<String, Mapping<String, Int>> {
+    ["outer"] = new Mapping<String, Int> {
+        ["inner"] = 42
+    }
+}
+"#,
+    );
+    assert_eq!(json["x"]["outer"]["inner"], 42);
+}
+
 // ============================================================
 // Spread operator
 // ============================================================


### PR DESCRIPTION
## Summary
- `new Mapping<String, Step | Group> { ... }` was failing with "expected LBrace, got Lt"
- Parser now skips `<...>` type parameters (including nested generics) after the type name in `new` expressions
- Unblocks parsing of hk.pkl which uses `new Mapping<String, Step | Group> { ... }`

## Test plan
- [x] `new Mapping<String, String> { ... }` parses and evaluates correctly
- [x] `new Listing<String> { ... }` parses and evaluates correctly
- [x] Nested generics `new Mapping<String, Mapping<String, Int>> { ... }` work
- [x] All 129 existing tests pass
- [x] Clippy clean, fmt clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)