### PR TITLE
feat: add import* glob import support

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ pklr implements a subset of the [Pkl language](https://pkl-lang.org/main/current
 | `import` / `amends` | Supported (local files) |
 | Import resolution & evaluation | Supported (local files) |
 | `module` keyword | Supported (parsed and skipped) |
-| `import*` (globbed imports) | Not supported |
+| `import*` (globbed imports) | Supported (local files) |
 | `extends` | Not supported |
 
 ### Functions & Methods
@@ -152,9 +152,8 @@ The following Pkl features are not currently implemented:
 Planned features:
 
 1. `this` keyword (self-referencing within objects)
-2. `import*` glob imports
-3. Package URI imports (`package://...`)
-4. Class inheritance (`extends`)
+2. Package URI imports (`package://...`)
+3. Class inheritance (`extends`)
 
 ## Usage
 

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -66,6 +66,15 @@ impl Evaluator {
         self.eval_module(&module, path, 0).await
     }
 
+    /// Read, lex, parse, and evaluate a local file.
+    async fn eval_file(&mut self, path: &Path, depth: usize) -> Result<Value> {
+        let source = std::fs::read_to_string(path).map_err(|e| Error::Io(path.to_path_buf(), e))?;
+        let name = path.display().to_string();
+        let tokens = lexer::lex_named(&source, &name)?;
+        let module = parser::parse_named(&tokens, &source, &name)?;
+        self.eval_module(&module, path, depth).await
+    }
+
     #[async_recursion(?Send)]
     async fn eval_module(&mut self, module: &Module, path: &Path, depth: usize) -> Result<Value> {
         if depth > self.max_depth {
@@ -79,6 +88,31 @@ impl Evaluator {
         // Process imports
         for import in &module.imports {
             let uri = &import.uri;
+
+            // Handle glob imports: import* "dir/*.pkl" as Alias
+            if import.is_glob {
+                let alias = import
+                    .alias
+                    .clone()
+                    .ok_or_else(|| Error::Eval("import* requires an alias".into()))?;
+
+                // Non-local glob imports bind an empty mapping
+                if uri.contains("://") {
+                    scope.set(alias, Value::Object(IndexMap::new()));
+                    continue;
+                }
+
+                let base_dir = path.parent().unwrap_or(Path::new("."));
+                let matched = expand_glob(base_dir, uri)?;
+                let mut mapping = IndexMap::new();
+                for matched_path in matched {
+                    let rel_key = pathdiff_or_full(&matched_path, base_dir);
+                    let val = self.eval_file(&matched_path, depth + 1).await?;
+                    mapping.insert(rel_key, val);
+                }
+                scope.set(alias, Value::Object(mapping));
+                continue;
+            }
 
             if uri.starts_with("https://") || uri.starts_with("http://") {
                 // HTTP import
@@ -153,15 +187,7 @@ impl Evaluator {
                 return Err(Error::ImportNotFound(import_path.display().to_string()));
             }
             {
-                let source = std::fs::read_to_string(&import_path)
-                    .map_err(|e| Error::Io(import_path.clone(), e))?;
-                let imported_val = {
-                    let name = import_path.display().to_string();
-                    let tokens = lexer::lex_named(&source, &name)?;
-                    let imp_module = parser::parse_named(&tokens, &source, &name)?;
-                    self.eval_module(&imp_module, &import_path, depth + 1)
-                        .await?
-                };
+                let imported_val = self.eval_file(&import_path, depth + 1).await?;
                 // Determine the binding name: alias or filename stem
                 let alias = import.alias.clone().unwrap_or_else(|| {
                     import_path
@@ -220,14 +246,7 @@ impl Evaluator {
                     base.join(uri)
                 };
                 if amends_path.exists() {
-                    let source = std::fs::read_to_string(&amends_path)
-                        .map_err(|e| Error::Io(amends_path.clone(), e))?;
-                    let name = amends_path.display().to_string();
-                    let tokens = lexer::lex_named(&source, &name)?;
-                    let base_module = parser::parse_named(&tokens, &source, &name)?;
-                    let base_val = self
-                        .eval_module(&base_module, &amends_path, depth + 1)
-                        .await?;
+                    let base_val = self.eval_file(&amends_path, depth + 1).await?;
                     if let Value::Object(m) = base_val {
                         base_obj = m;
                     }
@@ -1371,6 +1390,60 @@ fn make_unit_object(value: Value, unit: &str) -> Value {
     map.insert("value".to_string(), value);
     map.insert("unit".to_string(), Value::String(unit.to_string()));
     Value::Object(map)
+}
+
+/// Expand a simple glob pattern relative to a base directory.
+/// Supports `dir/*.ext` and `*.ext` patterns (single `*` only).
+/// Expand a simple glob pattern relative to a base directory.
+/// Supports `dir/*.ext` and `*.ext` patterns (single `*` only).
+pub fn expand_glob(base: &Path, pattern: &str) -> Result<Vec<PathBuf>> {
+    let full = base.join(pattern);
+    let dir = full.parent().unwrap_or(base).to_path_buf();
+    let file_pattern = full
+        .file_name()
+        .map(|f| f.to_string_lossy().to_string())
+        .unwrap_or_default();
+
+    if !dir.is_dir() {
+        return Ok(vec![]);
+    }
+
+    // Convert simple glob to prefix/suffix matching
+    let (prefix, suffix) = if let Some(star_pos) = file_pattern.find('*') {
+        (
+            file_pattern[..star_pos].to_string(),
+            file_pattern[star_pos + 1..].to_string(),
+        )
+    } else {
+        // No wildcard — exact match
+        let p = dir.join(&file_pattern);
+        return if p.exists() { Ok(vec![p]) } else { Ok(vec![]) };
+    };
+
+    let min_len = prefix.len() + suffix.len();
+    let mut results = Vec::new();
+    let entries = std::fs::read_dir(&dir).map_err(|e| Error::Io(dir.to_path_buf(), e))?;
+    for entry in entries {
+        let entry = entry.map_err(|e| Error::Io(dir.to_path_buf(), e))?;
+        let name = entry.file_name().to_string_lossy().to_string();
+        if name.len() >= min_len
+            && name.starts_with(&prefix)
+            && name.ends_with(&suffix)
+            && entry.path().is_file()
+        {
+            results.push(entry.path());
+        }
+    }
+    results.sort();
+    Ok(results)
+}
+
+/// Get a relative path string from `path` relative to `base`, or the full path if not a prefix.
+fn pathdiff_or_full(path: &Path, base: &Path) -> String {
+    path.strip_prefix(base)
+        .unwrap_or(path)
+        .to_string_lossy()
+        .to_string()
 }
 
 fn collection_to_items(v: Value) -> Vec<(Value, Value)> {

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -698,7 +698,13 @@ impl<'a> Lexer<'a> {
                     self.advance();
                 }
                 let ident = &self.source[start..self.pos];
-                keyword_or_ident(ident)
+                // Handle `import*` as a single token
+                if ident == "import" && self.peek() == Some('*') {
+                    self.advance();
+                    TokenKind::KwImportStar
+                } else {
+                    keyword_or_ident(ident)
+                }
             }
             c => {
                 return Err(self.lex_error(format!("unexpected character: {c:?}")));
@@ -746,7 +752,6 @@ fn keyword_or_ident(s: &str) -> TokenKind {
         "function" => TokenKind::KwFunction,
         "this" => TokenKind::KwThis,
         "module" => TokenKind::KwModule,
-        "import*" => TokenKind::KwImportStar,
         "if" => TokenKind::KwIf,
         "else" => TokenKind::KwElse,
         "when" => TokenKind::KwWhen,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,16 +26,20 @@ pub fn analyze_imports(path: &Path) -> Result<Vec<std::path::PathBuf>> {
     let tokens = lexer::lex_named(&source, &path.display().to_string())?;
     let imports = parser::collect_imports(&tokens);
     let base = path.parent().unwrap_or(Path::new("."));
-    Ok(imports
-        .into_iter()
-        .filter_map(|uri| {
-            if let Some(rel) = uri.strip_prefix("file://") {
-                Some(std::path::PathBuf::from(rel))
-            } else if !uri.contains("://") {
-                Some(base.join(&uri))
+    let mut results = Vec::new();
+    for uri in imports {
+        if let Some(rel) = uri.strip_prefix("file://") {
+            results.push(std::path::PathBuf::from(rel));
+        } else if !uri.contains("://") {
+            if uri.contains('*') {
+                // Expand glob patterns to actual files
+                if let Ok(expanded) = eval::expand_glob(base, &uri) {
+                    results.extend(expanded);
+                }
             } else {
-                None
+                results.push(base.join(&uri));
             }
-        })
-        .collect())
+        }
+    }
+    Ok(results)
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -19,6 +19,8 @@ pub struct Module {
 pub struct Import {
     pub uri: String,
     pub alias: Option<String>,
+    /// `import*` glob import — result is a Mapping<String, Module>
+    pub is_glob: bool,
 }
 
 /// A top-level or object entry.
@@ -163,7 +165,7 @@ pub fn collect_imports(tokens: &[Token]) -> Vec<String> {
     let mut i = 0;
     while i < tokens.len() {
         match &tokens[i].kind {
-            TokenKind::KwAmends | TokenKind::KwImport => {
+            TokenKind::KwAmends | TokenKind::KwImport | TokenKind::KwImportStar => {
                 if let Some(TokenKind::StringLit(uri)) = tokens.get(i + 1).map(|t| &t.kind) {
                     imports.push(uri.clone());
                 }
@@ -332,7 +334,8 @@ impl<'a> Parser<'a> {
                     let uri = self.expect_string()?;
                     amends = Some(uri);
                 }
-                TokenKind::KwImport => {
+                TokenKind::KwImport | TokenKind::KwImportStar => {
+                    let is_glob = matches!(self.peek(), TokenKind::KwImportStar);
                     self.advance();
                     let uri = self.expect_string()?;
                     let alias = if matches!(self.peek(), TokenKind::KwAs) {
@@ -341,7 +344,11 @@ impl<'a> Parser<'a> {
                     } else {
                         None
                     };
-                    imports.push(Import { uri, alias });
+                    imports.push(Import {
+                        uri,
+                        alias,
+                        is_glob,
+                    });
                 }
                 _ => break,
             }

--- a/tests/fixtures/items/alpha.pkl
+++ b/tests/fixtures/items/alpha.pkl
@@ -1,0 +1,1 @@
+value = "alpha"

--- a/tests/fixtures/items/beta.pkl
+++ b/tests/fixtures/items/beta.pkl
@@ -1,0 +1,1 @@
+value = "beta"

--- a/tests/pkl_features.rs
+++ b/tests/pkl_features.rs
@@ -950,6 +950,27 @@ name = "override"
 }
 
 // ============================================================
+// Glob imports (import*)
+// ============================================================
+
+#[tokio::test]
+async fn import_glob() {
+    let mut ev = pklr::eval::Evaluator::new();
+    let base = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures");
+    ev.set_base_path(&base);
+    let src = r#"
+import* "items/*.pkl" as Items
+alpha_val = Items["items/alpha.pkl"].value
+beta_val = Items["items/beta.pkl"].value
+"#;
+    let path = base.join("test_glob.pkl");
+    let val = ev.eval_source(src, &path).await.unwrap();
+    let json = val.to_json();
+    assert_eq!(json["alpha_val"], "alpha");
+    assert_eq!(json["beta_val"], "beta");
+}
+
+// ============================================================
 // Class instantiation (future)
 // ============================================================
 


### PR DESCRIPTION
## Summary
- Implements `import* "dir/*.pkl" as Alias` which produces a `Mapping<String, Module>` where keys are relative file paths and values are evaluated modules
- Fixes lexer to produce `KwImportStar` as a single token (was incorrectly split into `KwImport` + `Star`)
- Adds `is_glob` flag to `Import` struct in parser
- Evaluator expands glob pattern on filesystem, evaluates each matched file
- Unblocks parsing of hk's `pkl/Builtins.pkl` which uses `import* "builtins/*.pkl" as Builtins`

## Test plan
- [x] New test: `import_glob` — glob imports two fixture files, accesses values via mapping keys
- [x] All 130 existing tests pass
- [x] Clippy clean, fmt clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)