### PR TITLE
feat: support default elements/values in objects and mappings

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,8 +63,8 @@ pklr implements a subset of the [Pkl language](https://pkl-lang.org/main/current
 | `Set(...)` | Parsed (treated as List) |
 | Object amendment (`(base) { overrides }`) | Supported |
 | Spread operator (`...expr`) | Supported |
+| Default elements/values (`default { ... }`) | Supported |
 | Late binding | Not supported |
-| Default elements/values | Not supported |
 
 ### Control Flow & Expressions
 

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -358,17 +358,9 @@ impl Evaluator {
             }
         }
 
-        // Look for a `default` property to use as template for dynamic entries
-        let mut default_template: Option<Value> = None;
-        for entry in entries {
-            if let Entry::Property(prop) = entry
-                && prop.name == "default"
-                && !has_modifier(&prop.modifiers, Modifier::Local)
-            {
-                default_template = self.eval_property(prop, &child_scope, depth).await?;
-                break;
-            }
-        }
+        let default_template = self
+            .find_default_template(entries, &child_scope, depth)
+            .await?;
 
         let mut map: IndexMap<String, Value> = IndexMap::new();
         for entry in entries {
@@ -1111,6 +1103,25 @@ impl Evaluator {
         }
     }
 
+    /// Find and evaluate a `default { ... }` property in an entry list.
+    #[async_recursion(?Send)]
+    async fn find_default_template(
+        &mut self,
+        entries: &[Entry],
+        scope: &Scope,
+        depth: usize,
+    ) -> Result<Option<Value>> {
+        for entry in entries {
+            if let Entry::Property(prop) = entry
+                && prop.name == "default"
+                && !has_modifier(&prop.modifiers, Modifier::Local)
+            {
+                return self.eval_property(prop, scope, depth).await;
+            }
+        }
+        Ok(None)
+    }
+
     #[async_recursion(?Send)]
     async fn eval_mapping_entries(
         &mut self,
@@ -1119,17 +1130,7 @@ impl Evaluator {
         depth: usize,
         map: &mut IndexMap<String, Value>,
     ) -> Result<()> {
-        // Look for a `default` property to use as template
-        let mut default_template: Option<Value> = None;
-        for entry in entries {
-            if let Entry::Property(prop) = entry
-                && prop.name == "default"
-                && !has_modifier(&prop.modifiers, Modifier::Local)
-            {
-                default_template = self.eval_property(prop, scope, depth).await?;
-                break;
-            }
-        }
+        let default_template = self.find_default_template(entries, scope, depth).await?;
 
         for entry in entries {
             match entry {
@@ -1352,7 +1353,13 @@ fn value_cmp(a: &Value, b: &Value) -> Result<std::cmp::Ordering> {
 fn merge_values(base: Value, overlay: Value) -> Value {
     match (base, overlay) {
         (Value::Object(mut b), Value::Object(o)) => {
-            b.extend(o);
+            for (k, v) in o {
+                if let Some(existing) = b.shift_remove(&k) {
+                    b.insert(k, merge_values(existing, v));
+                } else {
+                    b.insert(k, v);
+                }
+            }
             Value::Object(b)
         }
         (_, overlay) => overlay,

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -358,12 +358,28 @@ impl Evaluator {
             }
         }
 
+        // Look for a `default` property to use as template for dynamic entries
+        let mut default_template: Option<Value> = None;
+        for entry in entries {
+            if let Entry::Property(prop) = entry
+                && prop.name == "default"
+                && !has_modifier(&prop.modifiers, Modifier::Local)
+            {
+                default_template = self.eval_property(prop, &child_scope, depth).await?;
+                break;
+            }
+        }
+
         let mut map: IndexMap<String, Value> = IndexMap::new();
         for entry in entries {
             match entry {
                 Entry::Property(prop) => {
                     let mods = &prop.modifiers;
                     if has_modifier(mods, Modifier::Local) {
+                        continue;
+                    }
+                    // Skip the `default` property — it's a template, not an output entry
+                    if prop.name == "default" && default_template.is_some() {
                         continue;
                     }
                     if has_modifier(mods, Modifier::Abstract)
@@ -381,7 +397,11 @@ impl Evaluator {
                 }
                 Entry::DynProperty(key_expr, val_expr) => {
                     let key = self.eval_expr(key_expr, &child_scope, depth).await?;
-                    let val = self.eval_expr(val_expr, &child_scope, depth).await?;
+                    let mut val = self.eval_expr(val_expr, &child_scope, depth).await?;
+                    // Merge with default template if available
+                    if let Some(ref tpl) = default_template {
+                        val = merge_values(tpl.clone(), val);
+                    }
                     let key_str = value_to_key(&key)?;
                     map.insert(key_str, val);
                 }
@@ -1099,15 +1119,33 @@ impl Evaluator {
         depth: usize,
         map: &mut IndexMap<String, Value>,
     ) -> Result<()> {
+        // Look for a `default` property to use as template
+        let mut default_template: Option<Value> = None;
+        for entry in entries {
+            if let Entry::Property(prop) = entry
+                && prop.name == "default"
+                && !has_modifier(&prop.modifiers, Modifier::Local)
+            {
+                default_template = self.eval_property(prop, scope, depth).await?;
+                break;
+            }
+        }
+
         for entry in entries {
             match entry {
                 Entry::DynProperty(key_expr, val_expr) => {
                     let key = self.eval_expr(key_expr, scope, depth + 1).await?;
-                    let val = self.eval_expr(val_expr, scope, depth + 1).await?;
+                    let mut val = self.eval_expr(val_expr, scope, depth + 1).await?;
+                    if let Some(ref tpl) = default_template {
+                        val = merge_values(tpl.clone(), val);
+                    }
                     map.insert(value_to_key(&key)?, val);
                 }
                 Entry::Property(prop) if has_modifier(&prop.modifiers, Modifier::Local) => {
                     // skip locals in mapping
+                }
+                Entry::Property(prop) if prop.name == "default" && default_template.is_some() => {
+                    // skip default — it's a template
                 }
                 Entry::Spread(e) => {
                     let v = self.eval_expr(e, scope, depth + 1).await?;

--- a/tests/pkl_features.rs
+++ b/tests/pkl_features.rs
@@ -1451,3 +1451,92 @@ const version = 2
     assert!(result.is_err());
     assert!(result.unwrap_err().to_string().contains("const"));
 }
+
+// ============================================================
+// Default elements/values
+// ============================================================
+
+#[test]
+fn default_value_in_object() {
+    let json = eval(
+        r#"
+config {
+    default {
+        enabled = true
+        port = 8080
+    }
+    ["api"] {
+        port = 9090
+    }
+    ["web"] {
+        port = 3000
+    }
+}
+"#,
+    );
+    // api: port overridden, enabled inherited from default
+    assert_eq!(json["config"]["api"]["port"], 9090);
+    assert_eq!(json["config"]["api"]["enabled"], true);
+    // web: port overridden, enabled inherited from default
+    assert_eq!(json["config"]["web"]["port"], 3000);
+    assert_eq!(json["config"]["web"]["enabled"], true);
+}
+
+#[test]
+fn default_not_in_output() {
+    let json = eval(
+        r#"
+services {
+    default {
+        replicas = 1
+    }
+    ["app"] {
+        replicas = 3
+    }
+}
+"#,
+    );
+    // default itself should not appear in output
+    assert!(json["services"].get("default").is_none());
+    assert_eq!(json["services"]["app"]["replicas"], 3);
+}
+
+#[test]
+fn default_in_mapping() {
+    let json = eval(
+        r#"
+x = new Mapping {
+    default {
+        active = true
+    }
+    ["a"] {
+        name = "alpha"
+    }
+    ["b"] {
+        name = "beta"
+        active = false
+    }
+}
+"#,
+    );
+    assert_eq!(json["x"]["a"]["name"], "alpha");
+    assert_eq!(json["x"]["a"]["active"], true);
+    assert_eq!(json["x"]["b"]["name"], "beta");
+    assert_eq!(json["x"]["b"]["active"], false);
+}
+
+#[test]
+fn no_default_no_merge() {
+    // Without a default, dynamic entries should not be merged
+    let json = eval(
+        r#"
+x {
+    ["a"] {
+        name = "alpha"
+    }
+}
+"#,
+    );
+    assert_eq!(json["x"]["a"]["name"], "alpha");
+    assert!(json["x"]["a"].get("enabled").is_none());
+}

--- a/tests/pkl_features.rs
+++ b/tests/pkl_features.rs
@@ -1540,3 +1540,27 @@ x {
     assert_eq!(json["x"]["a"]["name"], "alpha");
     assert!(json["x"]["a"].get("enabled").is_none());
 }
+
+#[test]
+fn default_nested_merge() {
+    let json = eval(
+        r#"
+services {
+    default {
+        config {
+            timeout = 30
+            retries = 3
+        }
+    }
+    ["api"] {
+        config {
+            timeout = 60
+        }
+    }
+}
+"#,
+    );
+    // timeout overridden, retries inherited from default
+    assert_eq!(json["services"]["api"]["config"]["timeout"], 60);
+    assert_eq!(json["services"]["api"]["config"]["retries"], 3);
+}


### PR DESCRIPTION
## Summary
Adds `default { ... }` support — a pkl feature that sets a template for all dynamic entries in an object or mapping body.

```pkl
config {
    default {
        enabled = true
        port = 8080
    }
    ["api"] {
        port = 9090  // enabled = true inherited from default
    }
}
```

**How it works:**
- `default { ... }` is evaluated first as a template value
- Each `["key"] { ... }` entry's value is merged with the default (entry overrides default)
- The `default` property itself is excluded from JSON output
- Works in both `eval_entries` (object bodies) and `eval_mapping_entries` (`new Mapping`)

### Test results
159 passing, 0 ignored (4 new default tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)