### PR TITLE
feat: late binding for object amendment

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ pklr implements a subset of the [Pkl language](https://pkl-lang.org/main/current
 | Object amendment (`(base) { overrides }`) | Supported |
 | Spread operator (`...expr`) | Supported |
 | Default elements/values (`default { ... }`) | Supported |
-| Late binding | Not supported |
+| Late binding | Supported |
 
 ### Control Flow & Expressions
 

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -7,7 +7,7 @@ use std::path::{Path, PathBuf};
 use crate::error::{Error, Result};
 use crate::lexer;
 use crate::parser::{self, BinOp, Entry, Expr, Modifier, Module, Property, StringInterpPart, UnOp};
-use crate::value::Value;
+use crate::value::{ObjectSource, Value};
 
 /// Evaluates pkl source files to [`Value`].
 pub struct Evaluator {
@@ -98,7 +98,7 @@ impl Evaluator {
 
                 // Non-local glob imports bind an empty mapping
                 if uri.contains("://") {
-                    scope.set(alias, Value::Object(IndexMap::new()));
+                    scope.set(alias, Value::Object(IndexMap::new(), None));
                     continue;
                 }
 
@@ -110,7 +110,7 @@ impl Evaluator {
                     let val = self.eval_file(&matched_path, depth + 1).await?;
                     mapping.insert(rel_key, val);
                 }
-                scope.set(alias, Value::Object(mapping));
+                scope.set(alias, Value::Object(mapping, None));
                 continue;
             }
 
@@ -211,7 +211,7 @@ impl Evaluator {
                 let base_val = self
                     .eval_module(&base_module, Path::new(uri), depth + 1)
                     .await?;
-                if let Value::Object(m) = base_val {
+                if let Value::Object(m, _) = base_val {
                     base_obj = m;
                 }
             } else if uri.starts_with("package://") {
@@ -230,7 +230,7 @@ impl Evaluator {
                     let base_val = self
                         .eval_module(&base_module, Path::new(&url), depth + 1)
                         .await?;
-                    if let Value::Object(m) = base_val {
+                    if let Value::Object(m, _) = base_val {
                         base_obj = m;
                     }
                 } else {
@@ -247,7 +247,7 @@ impl Evaluator {
                 };
                 if amends_path.exists() {
                     let base_val = self.eval_file(&amends_path, depth + 1).await?;
-                    if let Value::Object(m) = base_val {
+                    if let Value::Object(m, _) = base_val {
                         base_obj = m;
                     }
                 }
@@ -327,7 +327,7 @@ impl Evaluator {
             }
         }
 
-        Ok(Value::Object(out))
+        Ok(Value::Object(out, None))
     }
 
     #[async_recursion(?Send)]
@@ -357,7 +357,7 @@ impl Evaluator {
     ) -> Result<Value> {
         let mut child_scope = scope.child();
         // Set `outer` to a snapshot of the parent scope's variables as an object
-        let outer_obj = Value::Object(scope.flatten());
+        let outer_obj = Value::Object(scope.flatten(), None);
         child_scope.set("outer".into(), outer_obj);
         // First pass: collect locals
         for entry in entries {
@@ -418,7 +418,7 @@ impl Evaluator {
                 }
                 Entry::Spread(expr) => {
                     let val = self.eval_expr(expr, &child_scope, depth).await?;
-                    if let Value::Object(m) = val {
+                    if let Value::Object(m, _) = val {
                         map.extend(m);
                     }
                 }
@@ -434,7 +434,7 @@ impl Evaluator {
                             iter_scope.set(key_var.clone(), k);
                         }
                         let body_val = self.eval_entries(&fgen.body, &iter_scope, depth).await?;
-                        if let Value::Object(m) = body_val {
+                        if let Value::Object(m, _) = body_val {
                             map.extend(m);
                         }
                     }
@@ -443,12 +443,12 @@ impl Evaluator {
                     let cond = self.eval_expr(&wgen.condition, &child_scope, depth).await?;
                     if is_truthy(&cond) {
                         let body_val = self.eval_entries(&wgen.body, &child_scope, depth).await?;
-                        if let Value::Object(m) = body_val {
+                        if let Value::Object(m, _) = body_val {
                             map.extend(m);
                         }
                     } else if let Some(else_body) = &wgen.else_body {
                         let else_val = self.eval_entries(else_body, &child_scope, depth).await?;
-                        if let Value::Object(m) = else_val {
+                        if let Value::Object(m, _) = else_val {
                             map.extend(m);
                         }
                     }
@@ -457,7 +457,74 @@ impl Evaluator {
                 Entry::ClassDef(..) => {} // handled in scope setup
             }
         }
-        Ok(Value::Object(map))
+        let source = ObjectSource {
+            entries: entries.to_vec(),
+            scope: child_scope.flatten(),
+        };
+        Ok(Value::Object(map, Some(Box::new(source))))
+    }
+
+    /// Evaluate an amended object with late binding.
+    ///
+    /// Merges the base object's original entries with the overlay entries,
+    /// then re-evaluates everything so that dependent properties pick up
+    /// overridden values.
+    #[async_recursion(?Send)]
+    async fn eval_amended_object(
+        &mut self,
+        base_entries: &[Entry],
+        base_scope: &IndexMap<String, Value>,
+        overlay_entries: &[Entry],
+        current_scope: &Scope,
+        depth: usize,
+    ) -> Result<Value> {
+        // Build merged entry list preserving base order.
+        // Overridden properties are replaced in-place so that later
+        // properties that reference them see the new value.
+        let mut merged: Vec<Entry> = Vec::new();
+        let mut overlay_by_name: IndexMap<String, &Entry> = IndexMap::new();
+        for entry in overlay_entries {
+            if let Entry::Property(prop) = entry {
+                overlay_by_name.insert(prop.name.clone(), entry);
+            }
+        }
+
+        // Walk base entries: substitute overridden properties in-place
+        let mut used_overlay: std::collections::HashSet<String> = std::collections::HashSet::new();
+        for entry in base_entries {
+            if let Entry::Property(prop) = entry
+                && let Some(replacement) = overlay_by_name.get(&prop.name)
+            {
+                merged.push((*replacement).clone());
+                used_overlay.insert(prop.name.clone());
+                continue;
+            }
+            merged.push(entry.clone());
+        }
+
+        // Append overlay entries that are genuinely new (not replacing a base entry)
+        for entry in overlay_entries {
+            if let Entry::Property(prop) = entry
+                && used_overlay.contains(&prop.name)
+            {
+                continue; // already placed in-order above
+            }
+            merged.push(entry.clone());
+        }
+
+        // Build scope: start with the base's captured scope, then layer current scope
+        let mut eval_scope = Scope::default();
+        for (k, v) in base_scope {
+            eval_scope.set(k.clone(), v.clone());
+        }
+        // Layer in current scope values (imports, module-level locals, etc.)
+        for (k, v) in current_scope.flatten() {
+            eval_scope.set(k, v);
+        }
+
+        // Evaluate the merged entries (eval_entries handles locals, classes,
+        // and evaluates properties in order with each added to scope)
+        self.eval_entries(&merged, &eval_scope, depth + 1).await
     }
 
     #[async_recursion(?Send)]
@@ -512,7 +579,7 @@ impl Evaluator {
                                     let v = self.eval_expr(e, scope, depth + 1).await?;
                                     match v {
                                         Value::List(l) => items.extend(l),
-                                        Value::Object(m) => items.extend(m.into_values()),
+                                        Value::Object(m, _) => items.extend(m.into_values()),
                                         other => items.push(other),
                                     }
                                 }
@@ -544,20 +611,31 @@ impl Evaluator {
                         let mut map = IndexMap::new();
                         self.eval_mapping_entries(entries, scope, depth, &mut map)
                             .await?;
-                        Ok(Value::Object(map))
+                        Ok(Value::Object(map, None))
                     }
                     _ => {
                         // Check if type name matches a class in scope
                         let base = type_name.as_ref().and_then(|name| scope.get(name)).cloned();
-                        let overlay = self.eval_entries(entries, scope, depth + 1).await?;
-                        if let Some(Value::Object(base_map)) = base {
+                        if let Some(Value::Object(_, Some(base_src))) = &base {
+                            // Late binding: re-evaluate merged base + overlay entries
+                            self.eval_amended_object(
+                                &base_src.entries.clone(),
+                                &base_src.scope.clone(),
+                                entries,
+                                scope,
+                                depth,
+                            )
+                            .await
+                        } else if let Some(Value::Object(base_map, _)) = base {
+                            // Fallback: eager merge
+                            let overlay = self.eval_entries(entries, scope, depth + 1).await?;
                             let mut merged = base_map;
-                            if let Value::Object(overlay_map) = overlay {
+                            if let Value::Object(overlay_map, _) = overlay {
                                 merged.extend(overlay_map);
                             }
-                            Ok(Value::Object(merged))
+                            Ok(Value::Object(merged, None))
                         } else {
-                            Ok(overlay)
+                            self.eval_entries(entries, scope, depth + 1).await
                         }
                     }
                 }
@@ -585,14 +663,14 @@ impl Evaluator {
                         return Ok(Value::Int(s.chars().count() as i64));
                     }
                     (Value::String(s), "isEmpty") => return Ok(Value::Bool(s.is_empty())),
-                    (Value::Object(map), "length") => return Ok(Value::Int(map.len() as i64)),
-                    (Value::Object(map), "isEmpty") => return Ok(Value::Bool(map.is_empty())),
-                    (Value::Object(map), "keys") => {
+                    (Value::Object(map, _), "length") => return Ok(Value::Int(map.len() as i64)),
+                    (Value::Object(map, _), "isEmpty") => return Ok(Value::Bool(map.is_empty())),
+                    (Value::Object(map, _), "keys") => {
                         return Ok(Value::List(
                             map.keys().map(|k| Value::String(k.clone())).collect(),
                         ));
                     }
-                    (Value::Object(map), "values") => {
+                    (Value::Object(map, _), "values") => {
                         return Ok(Value::List(map.values().cloned().collect()));
                     }
                     // Duration and DataSize units on numbers
@@ -606,7 +684,7 @@ impl Evaluator {
                     _ => {}
                 }
                 match &obj {
-                    Value::Object(map) => map
+                    Value::Object(map, _) => map
                         .get(field)
                         .cloned()
                         .ok_or_else(|| Error::Eval(format!("field not found: {field}"))),
@@ -620,7 +698,7 @@ impl Evaluator {
                 let obj = self.eval_expr(obj_expr, scope, depth + 1).await?;
                 match &obj {
                     Value::Null => Ok(Value::Null),
-                    Value::Object(map) => Ok(map.get(field).cloned().unwrap_or(Value::Null)),
+                    Value::Object(map, _) => Ok(map.get(field).cloned().unwrap_or(Value::Null)),
                     _ => Err(Error::Eval(format!(
                         "cannot access field '{field}' on {}",
                         value_type_name(&obj)
@@ -632,7 +710,7 @@ impl Evaluator {
                 let key = self.eval_expr(key_expr, scope, depth + 1).await?;
                 let key_str = value_to_key(&key)?;
                 match obj {
-                    Value::Object(map) => map
+                    Value::Object(map, _) => map
                         .get(&key_str)
                         .cloned()
                         .ok_or_else(|| Error::Eval(format!("key not found: {key_str}"))),
@@ -751,7 +829,7 @@ impl Evaluator {
                             map.insert(value_to_key(k)?, v.clone());
                         }
                     }
-                    return Ok(Value::Object(map));
+                    return Ok(Value::Object(map, None));
                 }
                 _ => {}
             }
@@ -946,12 +1024,12 @@ impl Evaluator {
             }
 
             // Object/Mapping methods
-            (Value::Object(map), "containsKey") => {
+            (Value::Object(map, _), "containsKey") => {
                 let key = args.first().and_then(|v| v.as_str()).unwrap_or("");
                 Ok(Some(Value::Bool(map.contains_key(key))))
             }
-            (Value::Object(map), "toMap") => Ok(Some(Value::Object(map.clone()))),
-            (Value::Object(map), "mapValues") => {
+            (Value::Object(map, _), "toMap") => Ok(Some(Value::Object(map.clone(), None))),
+            (Value::Object(map, _), "mapValues") => {
                 let lambda = args
                     .first()
                     .ok_or_else(|| Error::Eval("mapValues requires a function".into()))?;
@@ -962,9 +1040,11 @@ impl Evaluator {
                         .await?;
                     result.insert(k.clone(), new_v);
                 }
-                Ok(Some(Value::Object(result)))
+                Ok(Some(Value::Object(result, None)))
             }
-            (Value::Object(_), "toList") | (Value::Object(_), "toDynamic") => Ok(Some(obj.clone())),
+            (Value::Object(..), "toList") | (Value::Object(..), "toDynamic") => {
+                Ok(Some(obj.clone()))
+            }
 
             // Int/Float methods
             (Value::Int(n), "toString") => Ok(Some(Value::String(n.to_string()))),
@@ -1019,10 +1099,25 @@ impl Evaluator {
     ) -> Result<Value> {
         // Special case: object amendment `base + ObjectBody(entries)`
         if let BinOp::Add = op
-            && let Expr::ObjectBody(entries) = right
+            && let Expr::ObjectBody(overlay_entries) = right
         {
             let base = self.eval_expr(left, scope, depth + 1).await?;
-            let overlay = self.eval_entries(entries, scope, depth + 1).await?;
+            // Late binding: if the base carries its original entry definitions,
+            // merge entry lists and re-evaluate so dependent properties pick up
+            // overridden values.
+            if let Value::Object(_, Some(base_src)) = &base {
+                return self
+                    .eval_amended_object(
+                        &base_src.entries.clone(),
+                        &base_src.scope.clone(),
+                        overlay_entries,
+                        scope,
+                        depth,
+                    )
+                    .await;
+            }
+            // Fallback: eager merge when base has no entry source
+            let overlay = self.eval_entries(overlay_entries, scope, depth + 1).await?;
             return Ok(merge_values(base, overlay));
         }
 
@@ -1169,7 +1264,7 @@ impl Evaluator {
                 }
                 Entry::Spread(e) => {
                     let v = self.eval_expr(e, scope, depth + 1).await?;
-                    if let Value::Object(m) = v {
+                    if let Value::Object(m, _) = v {
                         map.extend(m);
                     }
                 }
@@ -1256,7 +1351,7 @@ fn value_type_name(v: &Value) -> &'static str {
         Value::Int(_) => "Int",
         Value::Float(_) => "Float",
         Value::String(_) => "String",
-        Value::Object(_) => "Object",
+        Value::Object(..) => "Object",
         Value::List(_) => "List",
         Value::Lambda(..) => "Function",
     }
@@ -1317,9 +1412,9 @@ fn add_values(l: Value, r: Value) -> Result<Value> {
             a.extend(b);
             Ok(Value::List(a))
         }
-        (Value::Object(mut a), Value::Object(b)) => {
+        (Value::Object(mut a, _), Value::Object(b, _)) => {
             a.extend(b);
-            Ok(Value::Object(a))
+            Ok(Value::Object(a, None))
         }
         (l, r) => Err(Error::Eval(format!("cannot add {:?} and {:?}", l, r))),
     }
@@ -1371,7 +1466,7 @@ fn value_cmp(a: &Value, b: &Value) -> Result<std::cmp::Ordering> {
 
 fn merge_values(base: Value, overlay: Value) -> Value {
     match (base, overlay) {
-        (Value::Object(mut b), Value::Object(o)) => {
+        (Value::Object(mut b, _), Value::Object(o, _)) => {
             for (k, v) in o {
                 if let Some(existing) = b.shift_remove(&k) {
                     b.insert(k, merge_values(existing, v));
@@ -1379,7 +1474,7 @@ fn merge_values(base: Value, overlay: Value) -> Value {
                     b.insert(k, v);
                 }
             }
-            Value::Object(b)
+            Value::Object(b, None)
         }
         (_, overlay) => overlay,
     }
@@ -1389,7 +1484,7 @@ fn make_unit_object(value: Value, unit: &str) -> Value {
     let mut map = IndexMap::new();
     map.insert("value".to_string(), value);
     map.insert("unit".to_string(), Value::String(unit.to_string()));
-    Value::Object(map)
+    Value::Object(map, None)
 }
 
 /// Expand a simple glob pattern relative to a base directory.
@@ -1453,7 +1548,7 @@ fn collection_to_items(v: Value) -> Vec<(Value, Value)> {
             .enumerate()
             .map(|(i, v)| (Value::Int(i as i64), v))
             .collect(),
-        Value::Object(map) => map
+        Value::Object(map, _) => map
             .into_iter()
             .map(|(k, v)| (Value::String(k), v))
             .collect(),

--- a/src/value.rs
+++ b/src/value.rs
@@ -1,7 +1,17 @@
 use indexmap::IndexMap;
 use serde_json::json;
 
-use crate::parser::Expr;
+use crate::parser::{Entry, Expr};
+
+/// Captures the original AST entries and scope for an object, enabling
+/// late binding: when this object is amended, its entries can be merged
+/// with the overlay's entries and re-evaluated so that dependent
+/// properties pick up overridden values.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ObjectSource {
+    pub entries: Vec<Entry>,
+    pub scope: IndexMap<String, Value>,
+}
 
 /// A pkl runtime value.
 ///
@@ -17,8 +27,9 @@ pub enum Value {
     Float(f64),
     String(String),
     /// Object (ordered string-keyed map). Represents both pkl objects and
-    /// string-keyed Mappings.
-    Object(IndexMap<String, Value>),
+    /// string-keyed Mappings.  The optional [`ObjectSource`] stores the
+    /// original entry definitions so late binding works on amendment.
+    Object(IndexMap<String, Value>, Option<Box<ObjectSource>>),
     /// Listing (ordered list).
     List(Vec<Value>),
     /// Lambda function: param names + body expression + captured scope values
@@ -33,7 +44,7 @@ impl Value {
             Value::Int(n) => json!(n),
             Value::Float(f) => json!(f),
             Value::String(s) => json!(s),
-            Value::Object(map) => {
+            Value::Object(map, _) => {
                 let mut obj = serde_json::Map::new();
                 for (k, v) in map {
                     obj.insert(k.clone(), v.to_json());
@@ -56,7 +67,7 @@ impl Value {
     }
 
     pub fn as_object_mut(&mut self) -> Option<&mut IndexMap<String, Value>> {
-        if let Value::Object(m) = self {
+        if let Value::Object(m, _) = self {
             Some(m)
         } else {
             None
@@ -66,7 +77,7 @@ impl Value {
     /// Merge `other` into `self`. For objects, other's keys win.
     pub fn merge(&mut self, other: Value) {
         match (self, other) {
-            (Value::Object(base), Value::Object(overlay)) => {
+            (Value::Object(base, _), Value::Object(overlay, _)) => {
                 for (k, v) in overlay {
                     base.insert(k, v);
                 }
@@ -95,7 +106,7 @@ impl From<serde_json::Value> for Value {
                 for (k, v) in o {
                     map.insert(k, Value::from(v));
                 }
-                Value::Object(map)
+                Value::Object(map, None)
             }
         }
     }

--- a/tests/pkl_features.rs
+++ b/tests/pkl_features.rs
@@ -1126,6 +1126,104 @@ x = (base) {
 }
 
 // ============================================================
+// Late binding
+// ============================================================
+
+#[test]
+fn late_binding_basic() {
+    // Overriding x should cause y to re-evaluate
+    let json = eval(
+        r#"
+local base = new {
+    x = 1
+    y = x + 1
+}
+result = (base) {
+    x = 10
+}
+"#,
+    );
+    assert_eq!(json["result"]["x"], 10);
+    assert_eq!(json["result"]["y"], 11);
+}
+
+#[test]
+fn late_binding_chained() {
+    // Chained dependency: x -> y -> z
+    let json = eval(
+        r#"
+local base = new {
+    x = 1
+    y = x + 1
+    z = y + 1
+}
+result = (base) {
+    x = 10
+}
+"#,
+    );
+    assert_eq!(json["result"]["x"], 10);
+    assert_eq!(json["result"]["y"], 11);
+    assert_eq!(json["result"]["z"], 12);
+}
+
+#[test]
+fn late_binding_unrelated_preserved() {
+    // Properties not depending on overridden ones stay the same
+    let json = eval(
+        r#"
+local base = new {
+    x = 1
+    y = x + 1
+    name = "hello"
+}
+result = (base) {
+    x = 10
+}
+"#,
+    );
+    assert_eq!(json["result"]["x"], 10);
+    assert_eq!(json["result"]["y"], 11);
+    assert_eq!(json["result"]["name"], "hello");
+}
+
+#[test]
+fn late_binding_class_new() {
+    // Late binding with class defaults
+    let json = eval(
+        r#"
+class Config {
+    port: Int = 8080
+    url: String = "http://localhost:\(port)"
+}
+result = new Config {
+    port = 3000
+}
+"#,
+    );
+    assert_eq!(json["result"]["port"], 3000);
+    assert_eq!(json["result"]["url"], "http://localhost:3000");
+}
+
+#[test]
+fn late_binding_string_interpolation() {
+    // Late binding with string interpolation
+    let json = eval(
+        r#"
+local base = new {
+    name = "world"
+    greeting = "Hello, \(name)!"
+}
+result = (base) {
+    name = "Pkl"
+}
+"#,
+    );
+    assert_eq!(json["result"]["name"], "Pkl");
+    assert_eq!(json["result"]["greeting"], "Hello, Pkl!");
+}
+
+// ============================================================
 // this / outer keywords
 // ============================================================
 


### PR DESCRIPTION
## Summary
- Objects now carry their original AST entries (`ObjectSource`) alongside evaluated values
- When amended via `(base) { overrides }` or instantiated via `new ClassName { overrides }`, entries are merged and re-evaluated so dependent properties pick up the new values
- Overlay entries replace base entries in-place (preserving definition order) so that forward references resolve correctly

## Example
```pkl
local base = new { x = 1; y = x + 1 }
result = (base) { x = 10 }
// result.y is now 11 (was 2 without late binding)
```

## Test plan
- [x] 5 new late binding tests: basic, chained deps, unrelated props, class `new`, string interpolation
- [x] All 160 existing tests still pass
- [x] Clippy clean, `cargo fmt --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)