### PR TITLE
chore: set MSRV to 1.88 and add cargo msrv verify to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,15 +23,27 @@ jobs:
       - run: cargo test
       - run: cargo clippy --all-targets -- -D warnings
       - run: cargo fmt --check
+  msrv:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: Swatinem/rust-cache@v2
+      - run: |
+          cargo install cargo-msrv --locked
+          cargo msrv verify
   final:
-    needs: test
+    needs: [test, msrv]
     runs-on: ubuntu-latest
     timeout-minutes: 1
     if: always()
     steps:
       - name: Check CI job results
         run: |
-          if [ "${{ needs.test.result }}" != "success" ]; then
-            echo "test failed or was skipped"
-            exit 1
-          fi
+          results=("${{ needs.test.result }}" "${{ needs.msrv.result }}")
+          for r in "${results[@]}"; do
+            if [ "$r" != "success" ]; then
+              echo "CI job failed or was skipped"
+              exit 1
+            fi
+          done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,9 +29,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: Swatinem/rust-cache@v2
-      - run: |
-          cargo install cargo-msrv --locked
-          cargo msrv verify
+      - uses: jdx/mise-action@v2
+      - run: cargo msrv verify
   final:
     needs: [test, msrv]
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name        = "pklr"
 version     = "0.1.0"
-edition     = "2024"
+edition      = "2024"
+rust-version = "1.88"
 description = "Pure Rust pkl configuration language parser and evaluator"
 license     = "MIT"
 repository  = "https://github.com/jdx/pklr"

--- a/mise.toml
+++ b/mise.toml
@@ -1,2 +1,4 @@
 [tools]
 communique = "latest"
+"cargo:cargo-binstall" = "latest"
+"cargo:cargo-msrv" = "latest"

--- a/mise.toml
+++ b/mise.toml
@@ -1,4 +1,4 @@
 [tools]
 communique = "latest"
-"cargo:cargo-binstall" = "latest"
+cargo-binstall = "latest"
 "cargo:cargo-msrv" = "latest"


### PR DESCRIPTION
## Summary
- Set `rust-version = "1.88"` in Cargo.toml to match jdx/mise's MSRV
- Add `msrv` CI job that runs `cargo msrv verify`

## Test plan
- [x] CI will verify MSRV on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)