### PR TITLE
feat: fully implement annotations (@Deprecated, @ModuleInfo, etc.)

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,8 @@ pklr implements a subset of the [Pkl language](https://pkl-lang.org/main/current
 
 | Feature | Status |
 |---|---|
-| Annotations (`@Deprecated`, `@ModuleInfo`, etc.) | Parsed and skipped |
+| Annotations (`@Deprecated`, `@ModuleInfo`, `@Since`, etc.) | Supported (parsed into AST, stored on properties) |
+| `@Deprecated` warnings | Supported (emits warning to stderr) |
 | Class declarations | Parsed and evaluated (defaults extracted) |
 | Type alias declarations | Parsed and skipped |
 | Function declarations | Parsed and skipped |

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -6,7 +6,9 @@ use std::path::{Path, PathBuf};
 
 use crate::error::{Error, Result};
 use crate::lexer;
-use crate::parser::{self, BinOp, Entry, Expr, Modifier, Module, Property, StringInterpPart, UnOp};
+use crate::parser::{
+    self, Annotation, BinOp, Entry, Expr, Modifier, Module, Property, StringInterpPart, UnOp,
+};
 use crate::value::{ObjectSource, Value};
 
 /// Evaluates pkl source files to [`Value`].
@@ -280,6 +282,7 @@ impl Evaluator {
                 if has_modifier(mods, Modifier::Local) {
                     continue; // already collected
                 }
+                check_deprecated(&prop.annotations, &prop.name);
                 // abstract/external properties must have a value (or be overridden)
                 if (has_modifier(mods, Modifier::Abstract)
                     || has_modifier(mods, Modifier::External))
@@ -389,6 +392,7 @@ impl Evaluator {
                     if has_modifier(mods, Modifier::Local) {
                         continue;
                     }
+                    check_deprecated(&prop.annotations, &prop.name);
                     // Skip the `default` property — it's a template, not an output entry
                     if prop.name == "default" && default_template.is_some() {
                         continue;
@@ -1325,6 +1329,28 @@ impl Scope {
 }
 
 // --- Helpers ---
+
+fn check_deprecated(annotations: &[Annotation], prop_name: &str) {
+    for ann in annotations {
+        if ann.name == "Deprecated" {
+            // Look for a "message" property in the annotation body
+            let mut message = None;
+            for entry in &ann.body {
+                if let Entry::Property(p) = entry
+                    && p.name == "message"
+                    && let Some(Expr::String(s)) = &p.value
+                {
+                    message = Some(s.clone());
+                }
+            }
+            if let Some(msg) = message {
+                eprintln!("[pklr] WARNING: property '{prop_name}' is deprecated: {msg}");
+            } else {
+                eprintln!("[pklr] WARNING: property '{prop_name}' is deprecated");
+            }
+        }
+    }
+}
 
 fn has_modifier(mods: &[Modifier], target: Modifier) -> bool {
     mods.contains(&target)

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -15,6 +15,7 @@ pub struct Annotation {
     pub body: Vec<Entry>,
 }
 
+/// A pkl module (top-level file).
 #[derive(Debug, Clone, PartialEq)]
 pub struct Module {
     pub amends: Option<String>,

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -8,10 +8,18 @@ pub enum StringInterpPart {
 }
 
 /// A pkl module (top-level file).
+/// An annotation: `@Name { body }` or `@Name`
+#[derive(Debug, Clone, PartialEq)]
+pub struct Annotation {
+    pub name: String,
+    pub body: Vec<Entry>,
+}
+
 #[derive(Debug, Clone, PartialEq)]
 pub struct Module {
     pub amends: Option<String>,
     pub imports: Vec<Import>,
+    pub annotations: Vec<Annotation>,
     pub body: Vec<Entry>,
 }
 
@@ -44,6 +52,7 @@ pub enum Entry {
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct Property {
+    pub annotations: Vec<Annotation>,
     pub modifiers: Vec<Modifier>,
     pub name: String,
     pub type_ann: Option<TypeExpr>,
@@ -249,68 +258,51 @@ impl<'a> Parser<'a> {
         matches!(self.peek(), TokenKind::Eof)
     }
 
-    /// Skip annotation blocks: `@Ident` or `@Ident { ... }`
-    fn skip_annotations(&mut self) {
+    /// Parse annotations: `@Name { body }` or `@Name`
+    fn parse_annotations(&mut self) -> Result<Vec<Annotation>> {
+        let mut annotations = Vec::new();
         while matches!(self.peek(), TokenKind::At) {
             self.advance(); // @
-            // Skip ident (and optional dotted path)
-            while matches!(self.peek(), TokenKind::Ident(_)) {
+            // Parse annotation name (possibly dotted: @Foo.Bar)
+            let mut name = self.expect_ident()?;
+            while matches!(self.peek(), TokenKind::Dot) {
                 self.advance();
-                if matches!(self.peek(), TokenKind::Dot) {
-                    self.advance();
-                } else {
-                    break;
-                }
+                let part = self.expect_ident()?;
+                name = format!("{name}.{part}");
             }
-            // Skip annotation body if present
-            if matches!(self.peek(), TokenKind::LBrace) {
+            // Parse annotation body if present
+            let body = if matches!(self.peek(), TokenKind::LBrace) {
                 self.advance();
-                let mut depth = 1;
-                while depth > 0 && !self.at_eof() {
-                    match self.peek() {
-                        TokenKind::LBrace => {
-                            depth += 1;
-                            self.advance();
-                        }
-                        TokenKind::RBrace => {
-                            depth -= 1;
-                            self.advance();
-                        }
-                        _ => {
-                            self.advance();
-                        }
+                let entries = self.parse_entries()?;
+                self.expect(&TokenKind::RBrace)?;
+                entries
+            } else if matches!(self.peek(), TokenKind::LParen) {
+                // Annotation with parens: @Foo("arg") — parse as a single-element body
+                self.advance();
+                let mut entries = Vec::new();
+                while !matches!(self.peek(), TokenKind::RParen | TokenKind::Eof) {
+                    let expr = self.parse_expr()?;
+                    entries.push(Entry::Elem(expr));
+                    if matches!(self.peek(), TokenKind::Comma) {
+                        self.advance();
                     }
                 }
-            }
-            // Skip annotation arguments if present
-            if matches!(self.peek(), TokenKind::LParen) {
-                self.advance();
-                let mut depth = 1;
-                while depth > 0 && !self.at_eof() {
-                    match self.peek() {
-                        TokenKind::LParen => {
-                            depth += 1;
-                            self.advance();
-                        }
-                        TokenKind::RParen => {
-                            depth -= 1;
-                            self.advance();
-                        }
-                        _ => {
-                            self.advance();
-                        }
-                    }
-                }
-            }
+                self.expect(&TokenKind::RParen)?;
+                entries
+            } else {
+                Vec::new()
+            };
+            annotations.push(Annotation { name, body });
         }
+        Ok(annotations)
     }
 
     fn parse_module(&mut self) -> Result<Module> {
         let mut amends = None;
         let mut imports = Vec::new();
 
-        // Skip annotations at module level (e.g. @ModuleInfo)
-        self.skip_annotations();
+        // Parse module-level annotations (e.g. @ModuleInfo)
+        let annotations = self.parse_annotations()?;
 
         // Parse header: module declaration, amends, imports
         // Skip `module <name>` declaration if present
@@ -358,6 +350,7 @@ impl<'a> Parser<'a> {
         Ok(Module {
             amends,
             imports,
+            annotations,
             body,
         })
     }
@@ -365,7 +358,7 @@ impl<'a> Parser<'a> {
     fn parse_entries(&mut self) -> Result<Vec<Entry>> {
         let mut entries = Vec::new();
         while !self.at_eof() && !matches!(self.peek(), TokenKind::RBrace) {
-            self.skip_annotations();
+            let entry_annotations = self.parse_annotations()?;
             // Parse class definitions; skip typealias/function declarations
             if matches!(self.peek(), TokenKind::KwClass) {
                 self.advance(); // consume 'class'
@@ -399,7 +392,13 @@ impl<'a> Parser<'a> {
             if self.at_eof() || matches!(self.peek(), TokenKind::RBrace) {
                 break;
             }
-            let entry = self.parse_entry()?;
+            let mut entry = self.parse_entry()?;
+            // Attach annotations to the parsed property
+            if !entry_annotations.is_empty()
+                && let Entry::Property(ref mut prop) = entry
+            {
+                prop.annotations = entry_annotations;
+            }
             entries.push(entry);
         }
         Ok(entries)
@@ -642,6 +641,7 @@ impl<'a> Parser<'a> {
                 };
 
                 Ok(Entry::Property(Property {
+                    annotations: Vec::new(), // filled by parse_entries if present
                     modifiers,
                     name,
                     type_ann,

--- a/tests/pkl_features.rs
+++ b/tests/pkl_features.rs
@@ -1683,3 +1683,74 @@ services {
     assert_eq!(json["services"]["api"]["config"]["timeout"], 60);
     assert_eq!(json["services"]["api"]["config"]["retries"], 3);
 }
+
+// ============================================================
+// Annotations
+// ============================================================
+
+#[test]
+fn annotation_module_info_parsed() {
+    // @ModuleInfo should be parsed without error
+    let json = eval(
+        r#"
+@ModuleInfo { minPklVersion = "0.25.0" }
+module my.Config
+x = 42
+"#,
+    );
+    assert_eq!(json["x"], 42);
+}
+
+#[test]
+fn annotation_deprecated_property() {
+    // @Deprecated annotation should not prevent evaluation
+    let json = eval(
+        r#"
+@Deprecated { message = "use newName instead" }
+oldName = "value"
+result = oldName
+"#,
+    );
+    assert_eq!(json["oldName"], "value");
+    assert_eq!(json["result"], "value");
+}
+
+#[test]
+fn annotation_multiple() {
+    let json = eval(
+        r#"
+@Since { version = "1.0" }
+@Deprecated { message = "removed in 2.0" }
+legacy = true
+current = false
+"#,
+    );
+    assert_eq!(json["legacy"], true);
+    assert_eq!(json["current"], false);
+}
+
+#[test]
+fn annotation_on_class() {
+    let json = eval(
+        r#"
+@Deprecated { message = "use NewConfig" }
+class OldConfig {
+    name: String = "old"
+}
+x = new OldConfig {}
+"#,
+    );
+    assert_eq!(json["x"]["name"], "old");
+}
+
+#[test]
+fn annotation_empty() {
+    // @Foo with no body
+    let json = eval(
+        r#"
+@Experimental
+feature = true
+"#,
+    );
+    assert_eq!(json["feature"], true);
+}


### PR DESCRIPTION
## Summary
Annotations are now fully parsed into the AST instead of being silently skipped.

**Parser changes:**
- New `Annotation` struct with `name: String` and `body: Vec<Entry>`
- `Module.annotations` — stores module-level annotations (`@ModuleInfo`)
- `Property.annotations` — stores property-level annotations (`@Deprecated`, `@Since`)
- `parse_annotations()` replaces `skip_annotations()` — parses annotation name, body (`{ ... }`), and arguments (`(...)`)
- Annotations attached to the next property in `parse_entries`

**Evaluator changes:**
- `@Deprecated` emits a warning to stderr when the annotated property is evaluated:
  ```
  [pklr] WARNING: property 'oldName' is deprecated: use newName instead
  ```
- `@Deprecated { message = "..." }` extracts the message from the body

**Supported annotation forms:**
- `@Name` (empty)
- `@Name { key = value }` (with body)
- `@Name("arg")` (with arguments)
- `@Dotted.Name { ... }` (dotted names)
- Multiple annotations on a single property

### Test results
165 passing, 0 ignored (5 new annotation tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)