### PR TITLE
fix(parser): support dotted type names in new expressions

### DIFF
--- a/src/eval.rs
+++ b/src/eval.rs
@@ -614,8 +614,18 @@ impl Evaluator {
                         Ok(Value::Object(map, None))
                     }
                     _ => {
-                        // Check if type name matches a class in scope
-                        let base = type_name.as_ref().and_then(|name| scope.get(name)).cloned();
+                        // Check if type name matches a class in scope (supports dotted names)
+                        let base = type_name.as_ref().and_then(|name| {
+                            let parts: Vec<&str> = name.split('.').collect();
+                            let mut val = scope.get(parts[0])?.clone();
+                            for part in &parts[1..] {
+                                val = match val {
+                                    Value::Object(ref map, _) => map.get(*part)?.clone(),
+                                    _ => return None,
+                                };
+                            }
+                            Some(val)
+                        });
                         if let Some(Value::Object(_, Some(base_src))) = &base {
                             // Late binding: re-evaluate merged base + overlay entries
                             self.eval_amended_object(

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -953,7 +953,15 @@ impl<'a> Parser<'a> {
             TokenKind::KwNew => {
                 self.advance();
                 let type_name = if let TokenKind::Ident(_) = self.peek() {
-                    Some(self.expect_ident()?)
+                    let mut name = self.expect_ident()?;
+                    // Handle dotted type names: new Config.Step { ... }
+                    while matches!(self.peek(), TokenKind::Dot) {
+                        self.advance();
+                        let part = self.expect_ident()?;
+                        name.push('.');
+                        name.push_str(&part);
+                    }
+                    Some(name)
                 } else {
                     None
                 };

--- a/tests/pkl_features.rs
+++ b/tests/pkl_features.rs
@@ -1296,6 +1296,26 @@ x = new Container {
     assert_eq!(json["x"]["value"], "custom");
 }
 
+#[test]
+fn new_with_dotted_type_name() {
+    // Dotted type names in new: resolves Config then .Step
+    let json = eval(
+        r#"
+local Config = new {
+    Step = new {
+        check = "default"
+        glob = "*.rs"
+    }
+}
+x = new Config.Step {
+    check = "custom"
+}
+"#,
+    );
+    assert_eq!(json["x"]["check"], "custom");
+    assert_eq!(json["x"]["glob"], "*.rs");
+}
+
 // ============================================================
 // Durations
 // ============================================================


### PR DESCRIPTION
## Summary
- `new Config.Step { ... }` now parses dotted type names (reads `Ident.Ident...` after `new`)
- Evaluator resolves dotted names by walking scope: looks up `Config`, then accesses `.Step` field
- Unblocks parsing of hk's builtin files which use `new Config.Step { ... }` and `new helpers.TestMaker { ... }`

## Test plan
- [x] New test: `new_with_dotted_type_name` — dotted type with default merging
- [x] All 145 existing tests pass
- [x] Clippy clean, fmt clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)