### PR TITLE
feat: this keyword for self-referencing within objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ pklr implements a subset of the [Pkl language](https://pkl-lang.org/main/current
 | Class definitions with defaults | Supported |
 | Class inheritance | Not supported |
 | `outer` keyword | Supported |
-| `this` keyword | Not yet supported |
+| `this` keyword | Supported |
 | `super` keyword | Not supported |
 
 ### Annotations & Declarations
@@ -152,9 +152,8 @@ The following Pkl features are not currently implemented:
 
 Planned features:
 
-1. `this` keyword (self-referencing within objects)
-2. Package URI imports (`package://...`)
-3. Class inheritance (`extends`)
+1. Package URI imports (`package://...`)
+2. Class inheritance (`extends`)
 
 ## Usage
 

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -276,6 +276,12 @@ impl Evaluator {
 
         // Second pass: evaluate non-local entries into output object
         let mut out = base_obj;
+        // all_props includes hidden properties — used for `this`/`module` snapshots
+        let mut all_props = out.clone();
+        // Bind `this` at module level so properties can reference the module object
+        scope.set("this".into(), Value::Object(all_props.clone(), None));
+        // Also bind `module` to the same value
+        scope.set("module".into(), Value::Object(all_props.clone(), None));
         for entry in &module.body {
             if let Entry::Property(prop) = entry {
                 let mods = &prop.modifiers;
@@ -323,9 +329,15 @@ impl Evaluator {
                     }
                     // Always add to scope so other properties can reference it
                     scope.set(prop.name.clone(), v.clone());
+                    // Track in all_props (including hidden) for `this`/`module`
+                    all_props.insert(prop.name.clone(), v.clone());
                     if !has_modifier(mods, Modifier::Hidden) {
                         out.insert(prop.name.clone(), v);
                     }
+                    // Update `this` and `module` with all properties (including hidden)
+                    let snapshot = Value::Object(all_props.clone(), None);
+                    scope.set("this".into(), snapshot.clone());
+                    scope.set("module".into(), snapshot);
                 }
             }
         }
@@ -385,6 +397,10 @@ impl Evaluator {
             .await?;
 
         let mut map: IndexMap<String, Value> = IndexMap::new();
+        // all_props includes hidden properties — used for `this` snapshot
+        let mut all_props: IndexMap<String, Value> = IndexMap::new();
+        // Bind `this` so properties can reference the object being built
+        child_scope.set("this".into(), Value::Object(all_props.clone(), None));
         for entry in entries {
             match entry {
                 Entry::Property(prop) => {
@@ -405,9 +421,12 @@ impl Evaluator {
                     }
                     if let Some(v) = self.eval_property(prop, &child_scope, depth).await? {
                         child_scope.set(prop.name.clone(), v.clone());
+                        all_props.insert(prop.name.clone(), v.clone());
                         if !has_modifier(mods, Modifier::Hidden) {
                             map.insert(prop.name.clone(), v);
                         }
+                        // Update `this` with all properties (including hidden)
+                        child_scope.set("this".into(), Value::Object(all_props.clone(), None));
                     }
                 }
                 Entry::DynProperty(key_expr, val_expr) => {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1020,6 +1020,14 @@ impl<'a> Parser<'a> {
                 self.advance();
                 Ok(Expr::Ident(name))
             }
+            TokenKind::KwThis => {
+                self.advance();
+                Ok(Expr::Ident("this".into()))
+            }
+            TokenKind::KwModule => {
+                self.advance();
+                Ok(Expr::Ident("module".into()))
+            }
             tok => Err(self.parse_error(format!("unexpected token in expression: {:?}", tok))),
         }
     }

--- a/tests/pkl_features.rs
+++ b/tests/pkl_features.rs
@@ -1243,6 +1243,107 @@ data {
     assert_eq!(json["data"]["inner"]["name"], "test-data");
 }
 
+#[test]
+fn this_keyword_basic() {
+    // `this` refers to the current object
+    let json = eval(
+        r#"
+data {
+    x = 1
+    y = this.x + 1
+}
+"#,
+    );
+    assert_eq!(json["data"]["x"], 1);
+    assert_eq!(json["data"]["y"], 2);
+}
+
+#[test]
+fn this_keyword_nested() {
+    // `this` in a nested object refers to the inner object, not the outer
+    let json = eval(
+        r#"
+data {
+    x = 10
+    inner {
+        x = 20
+        y = this.x + 1
+    }
+}
+"#,
+    );
+    assert_eq!(json["data"]["x"], 10);
+    assert_eq!(json["data"]["inner"]["x"], 20);
+    assert_eq!(json["data"]["inner"]["y"], 21);
+}
+
+#[test]
+fn this_keyword_module_level() {
+    // `this` at module level refers to the module object
+    let json = eval(
+        r#"
+x = 42
+y = this.x + 1
+"#,
+    );
+    assert_eq!(json["x"], 42);
+    assert_eq!(json["y"], 43);
+}
+
+#[test]
+fn this_keyword_in_string_interpolation() {
+    let json = eval(
+        r#"
+data {
+    name = "world"
+    greeting = "Hello, \(this.name)!"
+}
+"#,
+    );
+    assert_eq!(json["data"]["greeting"], "Hello, world!");
+}
+
+#[test]
+fn this_keyword_with_hidden_property() {
+    let json = eval(
+        r#"
+data {
+    hidden base = "https://example.com"
+    url = this.base + "/api"
+}
+"#,
+    );
+    // base must not appear in output (hidden)
+    assert!(json["data"].get("base").is_none());
+    // but url must resolve via this.base
+    assert_eq!(json["data"]["url"], "https://example.com/api");
+}
+
+#[test]
+fn this_keyword_hidden_at_module_level() {
+    let json = eval(
+        r#"
+hidden secret = "abc123"
+derived = this.secret + "-derived"
+"#,
+    );
+    assert!(json.get("secret").is_none());
+    assert_eq!(json["derived"], "abc123-derived");
+}
+
+#[test]
+fn module_keyword_at_top_level() {
+    // `module` refers to the top-level module object
+    let json = eval(
+        r#"
+x = 1
+y = module.x + 10
+"#,
+    );
+    assert_eq!(json["x"], 1);
+    assert_eq!(json["y"], 11);
+}
+
 // ============================================================
 // Class definitions
 // ============================================================


### PR DESCRIPTION
## Summary
- Bind `this` in scope during `eval_entries` (object bodies) and `eval_module` (top-level), updated after each property so later properties see siblings via `this.propName`
- Bind `module` at top level to reference the module object
- Re-add `this` and `module` as expression keywords in the parser (removed in a prior refactor)
- Update README: mark `this` keyword as Supported, remove from roadmap

## Test plan
- [x] `this_keyword_basic` -- `this.x` references sibling property
- [x] `this_keyword_nested` -- `this` in inner object refers to inner, not outer
- [x] `this_keyword_module_level` -- `this` at top level references module
- [x] `this_keyword_in_string_interpolation` -- `this.name` in `\(...)`
- [x] `module_keyword_at_top_level` -- `module.x` references top-level property
- [x] All 171 tests pass, clippy clean, fmt clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)