### PR TITLE
fix: address PR #29 feedback — dotted extends, HTTP class injection

### DIFF
--- a/src/eval.rs
+++ b/src/eval.rs
@@ -344,6 +344,15 @@ impl Evaluator {
                 if let Value::Object(m, _) = ext_val {
                     base_obj = m;
                 }
+                // Inject class definitions from HTTP base into scope
+                for entry in &ext_module.body {
+                    if let Entry::ClassDef(cls_name, parent, body) = entry {
+                        let defaults = self
+                            .eval_class_def(parent.as_deref(), body, &scope, depth)
+                            .await?;
+                        scope.set(cls_name.clone(), defaults);
+                    }
+                }
             }
         }
 
@@ -595,7 +604,7 @@ impl Evaluator {
         scope: &Scope,
         depth: usize,
     ) -> Result<Value> {
-        let parent_val = parent_name.and_then(|name| scope.get(name)).cloned();
+        let parent_val = parent_name.and_then(|name| resolve_dotted(scope, name));
 
         let mut child_scope = scope.child();
         if let Some(ref pv) = parent_val {
@@ -1540,6 +1549,19 @@ fn check_deprecated(annotations: &[Annotation], prop_name: &str) {
             }
         }
     }
+}
+
+/// Resolve a potentially dotted name (e.g. "Foo.Bar") in scope.
+fn resolve_dotted(scope: &Scope, name: &str) -> Option<Value> {
+    let parts: Vec<&str> = name.split('.').collect();
+    let mut val = scope.get(parts[0])?.clone();
+    for part in &parts[1..] {
+        val = match val {
+            Value::Object(ref map, _) => map.get(*part)?.clone(),
+            _ => return None,
+        };
+    }
+    Some(val)
 }
 
 fn has_modifier(mods: &[Modifier], target: Modifier) -> bool {

--- a/tests/fixtures/animal.pkl
+++ b/tests/fixtures/animal.pkl
@@ -1,9 +1,0 @@
-class Animal {
-    name: String = "unknown"
-    legs: Int = 4
-}
-
-class Dog extends Animal {
-    legs: Int = 4
-    breed: String = "mixed"
-}


### PR DESCRIPTION
## Summary
Follow-up fixes from #29 review:

- **HTTP extends class injection** — class definitions from HTTP-extended base modules are now injected into the child module's scope (was missing, only worked for local files)
- **Dotted parent name resolution** — `class Child extends Foo.Bar` now correctly resolves dotted names via `resolve_dotted()` helper (was doing flat string lookup which always failed)
- **Removed unused fixture** — `tests/fixtures/animal.pkl` was not referenced by any test

🤖 Generated with [Claude Code](https://claude.com/claude-code)