### PR TITLE
fix: hk.pkl compatibility — parser and eval improvements

### DIFF
--- a/src/eval.rs
+++ b/src/eval.rs
@@ -131,6 +131,7 @@ impl Evaluator {
             )));
         }
         let mut scope = Scope::default();
+        seed_builtins(&mut scope);
 
         // Process imports
         for import in &module.imports {
@@ -219,6 +220,17 @@ impl Evaluator {
                 continue;
             }
 
+            // Handle pkl: standard library imports
+            if let Some(module_name) = uri.strip_prefix("pkl:") {
+                let stdlib_val = stdlib_module(module_name);
+                let alias = import
+                    .alias
+                    .clone()
+                    .unwrap_or_else(|| module_name.to_string());
+                scope.set(alias, stdlib_val);
+                continue;
+            }
+
             // Skip other non-local imports
             if uri.contains("://") && !uri.starts_with("file://") {
                 continue;
@@ -285,7 +297,9 @@ impl Evaluator {
                         "unsupported package URI (only pkg.pkl-lang.org/github.com is supported): {uri}"
                     )));
                 }
-            } else if !uri.contains("://") || uri.starts_with("file://") {
+            } else if !uri.starts_with("pkl:")
+                && (!uri.contains("://") || uri.starts_with("file://"))
+            {
                 let amends_path = if let Some(rel) = uri.strip_prefix("file://") {
                     PathBuf::from(rel)
                 } else {
@@ -1011,6 +1025,15 @@ impl Evaluator {
                     }
                     return Ok(Value::List(items)); // treat Set as List
                 }
+                "Regex" => {
+                    if let Some(arg) = args.first() {
+                        let val = self.eval_expr(arg, scope, depth + 1).await?;
+                        let mut map = IndexMap::new();
+                        map.insert("pattern".to_string(), val);
+                        return Ok(Value::Object(map, None));
+                    }
+                    return Err(Error::Eval("Regex() requires a pattern argument".into()));
+                }
                 "Map" => {
                     // Map(k1, v1, k2, v2, ...)
                     let mut map = IndexMap::new();
@@ -1048,6 +1071,17 @@ impl Evaluator {
                 call_scope.set(param.clone(), arg);
             }
             return self.eval_expr(&body, &call_scope, depth + 1).await;
+        }
+
+        // Built-in type constructors resolved from scope (e.g. base.Regex)
+        if let Value::String(ref name) = func_val
+            && name == "Regex"
+            && let Some(arg) = args.first()
+        {
+            let val = self.eval_expr(arg, scope, depth + 1).await?;
+            let mut map = IndexMap::new();
+            map.insert("pattern".to_string(), val);
+            return Ok(Value::Object(map, None));
         }
 
         // Plain call with no args on an object — return the object
@@ -1578,7 +1612,10 @@ fn value_to_key(v: &Value) -> Result<String> {
         Value::String(s) => Ok(s.clone()),
         Value::Int(n) => Ok(n.to_string()),
         Value::Bool(b) => Ok(b.to_string()),
-        _ => Err(Error::Eval("mapping key must be a string or int".into())),
+        Value::Float(f) => Ok(f.to_string()),
+        Value::Object(_, _) | Value::List(_) | Value::Lambda(..) | Value::Null => {
+            Ok(value_to_display(v))
+        }
     }
 }
 
@@ -1755,6 +1792,28 @@ fn pathdiff_or_full(path: &Path, base: &Path) -> String {
         .unwrap_or(path)
         .to_string_lossy()
         .to_string()
+}
+
+fn stdlib_module(name: &str) -> Value {
+    let mut map = IndexMap::new();
+    if name == "base" {
+        map.insert("Regex".to_string(), Value::String("Regex".to_string()));
+    }
+    Value::Object(map, None)
+}
+
+fn seed_builtins(scope: &mut Scope) {
+    for name in [
+        "Regex",
+        "Dynamic",
+        "Annotation",
+        "Duration",
+        "DataSize",
+        "IntSeq",
+        "Pair",
+    ] {
+        scope.set(name.to_string(), Value::String(name.to_string()));
+    }
 }
 
 fn collection_to_items(v: Value) -> Vec<(Value, Value)> {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -409,6 +409,12 @@ impl<'a> Parser<'a> {
                 self.skip_declaration();
                 continue;
             }
+            // Also skip modifier-prefixed function/typealias declarations
+            if self.peek_is_modifier() && self.peek_past_modifiers_is_decl() {
+                self.skip_modifiers();
+                self.skip_declaration();
+                continue;
+            }
             if self.at_eof() || matches!(self.peek(), TokenKind::RBrace) {
                 break;
             }
@@ -452,49 +458,97 @@ impl<'a> Parser<'a> {
         Ok(())
     }
 
+    fn peek_is_modifier(&self) -> bool {
+        matches!(
+            self.peek(),
+            TokenKind::KwLocal
+                | TokenKind::KwConst
+                | TokenKind::KwFixed
+                | TokenKind::KwHidden
+                | TokenKind::KwAbstract
+                | TokenKind::KwOpen
+                | TokenKind::KwExternal
+        )
+    }
+
+    fn peek_past_modifiers_is_decl(&self) -> bool {
+        let mut i = self.pos;
+        while i < self.tokens.len() {
+            match &self.tokens[i].kind {
+                TokenKind::KwLocal
+                | TokenKind::KwConst
+                | TokenKind::KwFixed
+                | TokenKind::KwHidden
+                | TokenKind::KwAbstract
+                | TokenKind::KwOpen
+                | TokenKind::KwExternal => i += 1,
+                TokenKind::KwFunction | TokenKind::KwTypeAlias => return true,
+                _ => return false,
+            }
+        }
+        false
+    }
+
+    fn skip_modifiers(&mut self) {
+        while self.peek_is_modifier() {
+            self.advance();
+        }
+    }
+
     /// Skip a class, typealias, or function declaration.
     fn skip_declaration(&mut self) {
+        let start_line = self.peek_tok().line;
         self.advance(); // class/typealias/function keyword
-        // Skip until we find a balanced { } or = expr or next entry
-        let mut depth = 0;
+        let mut brace_depth = 0;
+        let mut paren_depth = 0;
         loop {
             if self.at_eof() {
                 break;
             }
             match self.peek() {
-                TokenKind::LBrace => {
-                    depth += 1;
+                TokenKind::LParen => {
+                    paren_depth += 1;
                     self.advance();
                 }
-                TokenKind::RBrace if depth > 0 => {
-                    depth -= 1;
+                TokenKind::RParen => {
+                    paren_depth -= 1;
                     self.advance();
-                    if depth == 0 {
+                }
+                TokenKind::LBrace => {
+                    brace_depth += 1;
+                    self.advance();
+                }
+                TokenKind::RBrace if brace_depth > 0 => {
+                    brace_depth -= 1;
+                    self.advance();
+                    if brace_depth == 0 {
                         break;
                     }
                 }
-                TokenKind::RBrace => break, // don't consume — belongs to parent
-                _ if depth == 0 => {
-                    // At top level of declaration: look for start of next entry
-                    // A declaration ends before annotations, keywords, or identifiers
-                    // that start new entries
-                    let next = self.peek().clone();
-                    if matches!(
-                        next,
-                        TokenKind::At
-                            | TokenKind::KwClass
-                            | TokenKind::KwTypeAlias
-                            | TokenKind::KwFunction
-                            | TokenKind::KwLocal
-                            | TokenKind::KwConst
-                            | TokenKind::KwFixed
-                            | TokenKind::KwHidden
-                            | TokenKind::KwAbstract
-                            | TokenKind::KwOpen
-                            | TokenKind::KwExternal
-                            | TokenKind::Ident(_)
-                    ) {
-                        break;
+                TokenKind::RBrace => break,
+                _ if brace_depth == 0 && paren_depth == 0 => {
+                    let tok = self.peek_tok();
+                    let on_new_line = tok.line > start_line && tok.line > self.last_line;
+                    if on_new_line {
+                        let next = self.peek().clone();
+                        if matches!(
+                            next,
+                            TokenKind::At
+                                | TokenKind::KwClass
+                                | TokenKind::KwTypeAlias
+                                | TokenKind::KwFunction
+                                | TokenKind::KwLocal
+                                | TokenKind::KwConst
+                                | TokenKind::KwFixed
+                                | TokenKind::KwHidden
+                                | TokenKind::KwAbstract
+                                | TokenKind::KwOpen
+                                | TokenKind::KwExternal
+                                | TokenKind::Ident(_)
+                                | TokenKind::LBracket
+                        ) {
+                            break;
+                        }
                     }
                     self.advance();
                 }
@@ -674,6 +728,24 @@ impl<'a> Parser<'a> {
 
     fn parse_type(&mut self) -> Result<TypeExpr> {
         let base = match self.peek().clone() {
+            TokenKind::LParen => {
+                self.advance();
+                let inner = self.parse_type()?;
+                self.expect(&TokenKind::RParen)?;
+                inner
+            }
+            TokenKind::StringLit(s) => {
+                self.advance();
+                TypeExpr::Named(s)
+            }
+            TokenKind::Null => {
+                self.advance();
+                TypeExpr::Named("Null".to_string())
+            }
+            TokenKind::KwModule => {
+                self.advance();
+                TypeExpr::Named("module".to_string())
+            }
             TokenKind::Ident(name) => {
                 self.advance();
                 if matches!(self.peek(), TokenKind::Lt) {


### PR DESCRIPTION
## Summary
Multiple parser and evaluator fixes to get closer to evaluating hk's real-world pkl files.

**Parser:**
- `skip_declaration` now tracks `()` depth so multi-line function params (`local function makeTest(runType: String, ...)`) are correctly skipped
- Modifier-prefixed declarations (`const function`, `local typealias`) are now detected and skipped
- Type parser supports grouped types `(String | List<String> | Regex)?`, string literal types `"git" | "patch-file"`, `null`, and `module` keyword as type

**Evaluator:**
- `pkl:` standard library imports provide built-in type stubs (`pkl:base` provides `Regex`)
- Built-in Pkl type names (`Regex`, `Dynamic`, `Annotation`, `Duration`, `DataSize`, etc.) seeded into every module scope
- `Regex(pattern)` built-in constructor creates `{pattern: "..."}` objects
- `value_to_key` accepts all value types for type-keyed dynamic properties like `[Regex] = ...`

**Status:** hk.pkl now parses, imports resolve (including circular import* chains), and evaluation proceeds through Config.pkl and all 123 builtin files. Remaining blocker: `local function` declarations in class bodies need to be evaluated as lambdas.

## Test plan
- [x] All 190 tests pass (up from 163)
- [x] Clippy clean, fmt clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)