### PR TITLE
feat: type alias declarations (typealias)

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,14 +131,14 @@ pklr implements a subset of the [Pkl language](https://pkl-lang.org/main/current
 | Annotations (`@Deprecated`, `@ModuleInfo`, `@Since`, etc.) | Supported (parsed into AST, stored on properties) |
 | `@Deprecated` warnings | Supported (emits warning to stderr) |
 | Class declarations | Parsed and evaluated (defaults extracted) |
-| Type alias declarations | Parsed and skipped |
+| Type alias declarations (`typealias`) | Supported (aliases to classes work as constructors) |
 | Function declarations | Parsed and skipped |
 
 ### Not Yet Supported
 
 The following Pkl features are not currently implemented:
 
-- **Type aliases** and **type constraints** (declarations are skipped)
+- **Type constraints** (parsed but not enforced)
 - **Type annotations** (parsed but not validated)
 - **Member predicates** (`[[...]]`)
 - **Regular expressions** (`Regex`)

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -326,11 +326,17 @@ impl Evaluator {
                     // Also evaluate the base module's scope (classes, locals) into our scope
                     // by re-processing its body entries
                     for entry in &ext_module.body {
-                        if let Entry::ClassDef(cls_name, parent, body) = entry {
-                            let defaults = self
-                                .eval_class_def(parent.as_deref(), body, &scope, depth)
-                                .await?;
-                            scope.set(cls_name.clone(), defaults);
+                        match entry {
+                            Entry::ClassDef(cls_name, parent, body) => {
+                                let defaults = self
+                                    .eval_class_def(parent.as_deref(), body, &scope, depth)
+                                    .await?;
+                                scope.set(cls_name.clone(), defaults);
+                            }
+                            Entry::TypeAlias(name, ty) => {
+                                self.eval_type_alias(name, ty, &mut scope);
+                            }
+                            _ => {}
                         }
                     }
                 }
@@ -357,13 +363,19 @@ impl Evaluator {
                 scope.set(prop.name.clone(), val);
             }
         }
-        // Collect class definitions into module scope (after locals so defaults can reference them)
+        // Collect class definitions and type aliases into module scope
         for entry in &module.body {
-            if let Entry::ClassDef(name, parent, body) = entry {
-                let defaults = self
-                    .eval_class_def(parent.as_deref(), body, &scope, depth)
-                    .await?;
-                scope.set(name.clone(), defaults);
+            match entry {
+                Entry::ClassDef(name, parent, body) => {
+                    let defaults = self
+                        .eval_class_def(parent.as_deref(), body, &scope, depth)
+                        .await?;
+                    scope.set(name.clone(), defaults);
+                }
+                Entry::TypeAlias(name, ty) => {
+                    self.eval_type_alias(name, ty, &mut scope);
+                }
+                _ => {}
             }
         }
 
@@ -477,13 +489,15 @@ impl Evaluator {
                 child_scope.set(prop.name.clone(), val);
             }
         }
-        // Collect class definitions into scope (after locals so defaults can reference them)
+        // Collect class definitions and type aliases into scope
         for entry in entries {
             if let Entry::ClassDef(name, parent, body) = entry {
                 let defaults = self
                     .eval_class_def(parent.as_deref(), body, &child_scope, depth)
                     .await?;
                 child_scope.set(name.clone(), defaults);
+            } else if let Entry::TypeAlias(name, ty) = entry {
+                self.eval_type_alias(name, ty, &mut child_scope);
             }
         }
 
@@ -572,7 +586,7 @@ impl Evaluator {
                     }
                 }
                 Entry::Elem(_) => {} // bare elements only valid in Listing bodies
-                Entry::ClassDef(..) => {} // handled in scope setup
+                Entry::ClassDef(..) | Entry::TypeAlias(..) => {} // handled in scope setup
             }
         }
         let source = ObjectSource {
@@ -645,6 +659,31 @@ impl Evaluator {
             }
         } else {
             Ok(child_defaults)
+        }
+    }
+
+    /// Evaluate a type alias declaration.
+    ///
+    /// If the aliased type is a named type that exists in scope (e.g. a class),
+    /// the alias name is bound to the same value so `new AliasName { ... }` works.
+    fn eval_type_alias(&self, name: &str, ty: &crate::parser::TypeExpr, scope: &mut Scope) {
+        match ty {
+            crate::parser::TypeExpr::Named(target) => {
+                // Alias to a class or another alias already in scope
+                if let Some(val) = scope.get(target) {
+                    scope.set(name.to_string(), val.clone());
+                }
+            }
+            crate::parser::TypeExpr::Nullable(inner) => {
+                // typealias Foo = Bar? -- alias to the inner type
+                if let crate::parser::TypeExpr::Named(target) = inner.as_ref()
+                    && let Some(val) = scope.get(target)
+                {
+                    scope.set(name.to_string(), val.clone());
+                }
+            }
+            // Union types, generics, etc. -- no runtime representation needed
+            _ => {}
         }
     }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -51,6 +51,8 @@ pub enum Entry {
     /// Class definition: `class Name [extends Parent] { properties... }`
     /// Fields: (name, optional_parent, body)
     ClassDef(String, Option<String>, Vec<Entry>),
+    /// Type alias: `typealias Name = Type`
+    TypeAlias(String, TypeExpr),
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -405,7 +407,19 @@ impl<'a> Parser<'a> {
                 }
                 continue;
             }
-            if matches!(self.peek(), TokenKind::KwTypeAlias | TokenKind::KwFunction) {
+            if matches!(self.peek(), TokenKind::KwTypeAlias) {
+                self.advance(); // consume 'typealias'
+                let name = self.expect_ident()?;
+                // Skip optional generic params
+                if matches!(self.peek(), TokenKind::Lt) {
+                    self.skip_generic_params()?;
+                }
+                self.expect(&TokenKind::Equals)?;
+                let ty = self.parse_type()?;
+                entries.push(Entry::TypeAlias(name, ty));
+                continue;
+            }
+            if matches!(self.peek(), TokenKind::KwFunction) {
                 self.skip_declaration();
                 continue;
             }
@@ -686,6 +700,26 @@ impl<'a> Parser<'a> {
                     self.expect(&TokenKind::Gt)?;
                     TypeExpr::Generic(name, args)
                 } else {
+                    // Skip optional type constraint: Type(predicate)
+                    if matches!(self.peek(), TokenKind::LParen) {
+                        self.advance();
+                        let mut depth = 1;
+                        while depth > 0 && !self.at_eof() {
+                            match self.peek() {
+                                TokenKind::LParen => {
+                                    depth += 1;
+                                    self.advance();
+                                }
+                                TokenKind::RParen => {
+                                    depth -= 1;
+                                    self.advance();
+                                }
+                                _ => {
+                                    self.advance();
+                                }
+                            }
+                        }
+                    }
                     TypeExpr::Named(name)
                 }
             }

--- a/tests/pkl_features.rs
+++ b/tests/pkl_features.rs
@@ -1948,6 +1948,112 @@ services {
 }
 
 // ============================================================
+// Type aliases
+// ============================================================
+
+#[test]
+fn typealias_to_class() {
+    // typealias acts as an alternative constructor for a class
+    let json = eval(
+        r#"
+class Server {
+    host: String = "localhost"
+    port: Int = 8080
+}
+typealias Srv = Server
+x = new Srv {
+    port = 3000
+}
+"#,
+    );
+    assert_eq!(json["x"]["host"], "localhost");
+    assert_eq!(json["x"]["port"], 3000);
+}
+
+#[test]
+fn typealias_chain() {
+    // Alias of an alias
+    let json = eval(
+        r#"
+class Base {
+    value: Int = 1
+}
+typealias A = Base
+typealias B = A
+x = new B {}
+"#,
+    );
+    assert_eq!(json["x"]["value"], 1);
+}
+
+#[test]
+fn typealias_simple_type_ignored() {
+    // typealias to a simple type (not a class) is a no-op, shouldn't error
+    let json = eval(
+        r#"
+typealias Name = String
+x = "hello"
+"#,
+    );
+    assert_eq!(json["x"], "hello");
+}
+
+#[test]
+fn typealias_with_constraint() {
+    // typealias with type constraint -- constraint is skipped but should parse
+    let json = eval(
+        r#"
+typealias Port = Int(isBetween(1, 65535))
+x = 8080
+"#,
+    );
+    assert_eq!(json["x"], 8080);
+}
+
+#[test]
+fn typealias_union_parses() {
+    // Union type alias should parse without error
+    let json = eval(
+        r#"
+typealias StringOrInt = String|Int
+x = 42
+"#,
+    );
+    assert_eq!(json["x"], 42);
+}
+
+#[test]
+fn typealias_nullable_class() {
+    // typealias Foo = Bar? should still work as constructor
+    let json = eval(
+        r#"
+class Config {
+    debug: Boolean = false
+}
+typealias MaybeConfig = Config?
+x = new MaybeConfig {
+    debug = true
+}
+"#,
+    );
+    assert_eq!(json["x"]["debug"], true);
+}
+
+#[test]
+fn typealias_generic_parses() {
+    // Generic type alias should parse without error
+    let json = eval(
+        r#"
+typealias StringMap = Mapping<String, String>
+x = new Mapping {
+    ["a"] = "b"
+}
+"#,
+    );
+    assert_eq!(json["x"]["a"], "b");
+}
+
+// ============================================================
 // Annotations
 // ============================================================
 


### PR DESCRIPTION
## Summary
- Parse `typealias Name = Type` into `Entry::TypeAlias(name, TypeExpr)` instead of skipping it
- When the aliased type is a named class in scope, bind the alias to the same value so `new AliasName { ... }` works
- Handle nullable aliases (`typealias Foo = Bar?`) by unwrapping to the inner type
- Parse type constraints like `Int(isBetween(1, 65535))` by skipping the predicate parens
- Alias chains (`typealias A = B`, `typealias B = C`) resolve transitively
- Union and generic type aliases parse without error (no runtime binding needed)

## Test plan
- [x] `typealias_to_class` -- alias acts as constructor
- [x] `typealias_chain` -- alias of alias resolves
- [x] `typealias_simple_type_ignored` -- alias to String is a no-op
- [x] `typealias_with_constraint` -- constrained type parses
- [x] `typealias_union_parses` -- union type alias parses
- [x] `typealias_nullable_class` -- nullable alias works as constructor
- [x] `typealias_generic_parses` -- generic alias parses
- [x] All 197 tests pass, clippy clean, fmt clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)