### PR TITLE
chore: release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,56 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.2.0](https://github.com/jdx/pklr/compare/v0.1.0...v0.2.0) - 2026-03-23
+
+### Added
+
+- support hk.pkl evaluation — output block, class functions, perf ([#41](https://github.com/jdx/pklr/pull/41))
+- enforce open modifier on classes ([#38](https://github.com/jdx/pklr/pull/38))
+- type constraints with runtime enforcement via is/as ([#39](https://github.com/jdx/pklr/pull/39))
+- Set() now deduplicates elements ([#37](https://github.com/jdx/pklr/pull/37))
+- implement is/as type operators ([#35](https://github.com/jdx/pklr/pull/35))
+- type alias declarations (typealias) ([#33](https://github.com/jdx/pklr/pull/33))
+- implement read() and read?() resource readers ([#36](https://github.com/jdx/pklr/pull/36))
+- class inheritance (extends) and super keyword ([#30](https://github.com/jdx/pklr/pull/30))
+- support extends for modules and classes ([#29](https://github.com/jdx/pklr/pull/29))
+- this keyword for self-referencing within objects ([#27](https://github.com/jdx/pklr/pull/27))
+- fully implement annotations (@Deprecated, @ModuleInfo, etc.) ([#25](https://github.com/jdx/pklr/pull/25))
+- late binding for object amendment ([#23](https://github.com/jdx/pklr/pull/23))
+- add import* glob import support ([#21](https://github.com/jdx/pklr/pull/21))
+- support default elements/values in objects and mappings ([#22](https://github.com/jdx/pklr/pull/22))
+- enforce property modifiers (hidden, const, abstract) ([#20](https://github.com/jdx/pklr/pull/20))
+- async evaluator with HTTP/HTTPS/package:// import support ([#17](https://github.com/jdx/pklr/pull/17))
+- add unicode escapes, NaN/Infinity, durations, and data sizes ([#16](https://github.com/jdx/pklr/pull/16))
+- integer division, exponentiation, non-null assertion, pipe operator ([#18](https://github.com/jdx/pklr/pull/18))
+- class definitions, outer keyword — v1 complete ([#15](https://github.com/jdx/pklr/pull/15))
+- v1 part 2 — object amendment, module/annotation skipping, higher-order methods ([#14](https://github.com/jdx/pklr/pull/14))
+- v1 language features ([#13](https://github.com/jdx/pklr/pull/13))
+
+### Fixed
+
+- address merged PR feedback — type aliases, depth guard, dead code ([#40](https://github.com/jdx/pklr/pull/40))
+- address PR #29 feedback — dotted extends, HTTP class injection ([#31](https://github.com/jdx/pklr/pull/31))
+- hk.pkl compatibility — parser and eval improvements ([#32](https://github.com/jdx/pklr/pull/32))
+- add import cache to break circular imports ([#28](https://github.com/jdx/pklr/pull/28))
+- *(parser)* support dotted type names in new expressions ([#26](https://github.com/jdx/pklr/pull/26))
+- *(parser)* skip generic type params in new expressions ([#19](https://github.com/jdx/pklr/pull/19))
+- *(parser)* add ?? operator and fix dynamic key parsing ([#11](https://github.com/jdx/pklr/pull/11))
+- *(test)* address PR #9 review feedback ([#10](https://github.com/jdx/pklr/pull/10))
+- *(eval)* guard integer div/mod against zero, remove unreachable Value::Mapping ([#5](https://github.com/jdx/pklr/pull/5))
+
+### Other
+
+- remove feature list and roadmap from README ([#42](https://github.com/jdx/pklr/pull/42))
+- set MSRV to 1.88 and add cargo msrv verify to CI ([#24](https://github.com/jdx/pklr/pull/24))
+- add CLAUDE.md and document supported pkl subset in README ([#12](https://github.com/jdx/pklr/pull/12))
+- remove status section from README
+- add comprehensive pkl feature test suite ([#9](https://github.com/jdx/pklr/pull/9))
+- *(deps)* add miette, remove unused serde ([#8](https://github.com/jdx/pklr/pull/8))
+- add mise.toml, CI workflow, and communique config ([#6](https://github.com/jdx/pklr/pull/6))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -557,7 +557,7 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pklr"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "async-recursion",
  "indexmap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "pklr"
-version     = "0.1.0"
+version     = "0.2.0"
 edition      = "2024"
 rust-version = "1.88"
 description = "Pure Rust pkl configuration language parser and evaluator"


### PR DESCRIPTION



## 🤖 New release

* `pklr`: 0.1.0 -> 0.2.0 (⚠ API breaking changes)

### ⚠ `pklr` breaking changes

```text
--- failure auto_trait_impl_removed: auto trait no longer implemented ---

Description:
A public type has stopped implementing one or more auto traits. This can break downstream code that depends on the traits being implemented.
        ref: https://doc.rust-lang.org/reference/special-types-and-traits.html#auto-traits
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/auto_trait_impl_removed.ron

Failed in:
  type Evaluator is no longer UnwindSafe, in /tmp/.tmptLxo3n/pklr/src/eval.rs:15
  type Evaluator is no longer RefUnwindSafe, in /tmp/.tmptLxo3n/pklr/src/eval.rs:15
  type Evaluator is no longer UnwindSafe, in /tmp/.tmptLxo3n/pklr/src/eval.rs:15
  type Evaluator is no longer RefUnwindSafe, in /tmp/.tmptLxo3n/pklr/src/eval.rs:15

--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field Property.annotations in /tmp/.tmptLxo3n/pklr/src/parser.rs:60
  field Module.extends in /tmp/.tmptLxo3n/pklr/src/parser.rs:22
  field Module.annotations in /tmp/.tmptLxo3n/pklr/src/parser.rs:24
  field Token.offset in /tmp/.tmptLxo3n/pklr/src/lexer.rs:105
  field Import.is_glob in /tmp/.tmptLxo3n/pklr/src/parser.rs:33

--- failure enum_no_repr_variant_discriminant_changed: enum variant had its discriminant change value ---

Description:
The enum's variant had its discriminant value change. This breaks downstream code that used its value via a numeric cast like `as isize`.
        ref: https://doc.rust-lang.org/reference/items/enumerations.html#assigning-discriminant-values
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_no_repr_variant_discriminant_changed.ron

Failed in:
  variant BinOp::Eq 5 -> 7 in /tmp/.tmptLxo3n/pklr/src/parser.rs:146
  variant BinOp::Ne 6 -> 8 in /tmp/.tmptLxo3n/pklr/src/parser.rs:147
  variant BinOp::Lt 7 -> 9 in /tmp/.tmptLxo3n/pklr/src/parser.rs:148
  variant BinOp::Le 8 -> 10 in /tmp/.tmptLxo3n/pklr/src/parser.rs:149
  variant BinOp::Gt 9 -> 11 in /tmp/.tmptLxo3n/pklr/src/parser.rs:150
  variant BinOp::Ge 10 -> 12 in /tmp/.tmptLxo3n/pklr/src/parser.rs:151
  variant BinOp::And 11 -> 13 in /tmp/.tmptLxo3n/pklr/src/parser.rs:152
  variant BinOp::Or 12 -> 14 in /tmp/.tmptLxo3n/pklr/src/parser.rs:153
  variant BinOp::NullCoalesce 13 -> 15 in /tmp/.tmptLxo3n/pklr/src/parser.rs:154

--- failure enum_struct_variant_field_added: pub enum struct variant field added ---

Description:
An enum's exhaustive struct variant has a new field, which has to be included when constructing or matching on this variant.
        ref: https://doc.rust-lang.org/reference/attributes/type_system.html#the-non_exhaustive-attribute
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_struct_variant_field_added.ron

Failed in:
  field src of variant Error::Lex in /tmp/.tmptLxo3n/pklr/src/error.rs:20
  field span of variant Error::Lex in /tmp/.tmptLxo3n/pklr/src/error.rs:22
  field src of variant Error::Parse in /tmp/.tmptLxo3n/pklr/src/error.rs:30
  field span of variant Error::Parse in /tmp/.tmptLxo3n/pklr/src/error.rs:32
  field src of variant Error::Lex in /tmp/.tmptLxo3n/pklr/src/error.rs:20
  field span of variant Error::Lex in /tmp/.tmptLxo3n/pklr/src/error.rs:22
  field src of variant Error::Parse in /tmp/.tmptLxo3n/pklr/src/error.rs:30
  field span of variant Error::Parse in /tmp/.tmptLxo3n/pklr/src/error.rs:32

--- failure enum_struct_variant_field_missing: pub enum struct variant's field removed or renamed ---

Description:
A publicly-visible enum has a struct variant whose field is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_struct_variant_field_missing.ron

Failed in:
  field line of variant Error::Lex, previously in file /tmp/.tmpq5RWvk/pklr/src/error.rs:12
  field col of variant Error::Lex, previously in file /tmp/.tmpq5RWvk/pklr/src/error.rs:13
  field line of variant Error::Parse, previously in file /tmp/.tmpq5RWvk/pklr/src/error.rs:19
  field col of variant Error::Parse, previously in file /tmp/.tmpq5RWvk/pklr/src/error.rs:20
  field line of variant Error::Lex, previously in file /tmp/.tmpq5RWvk/pklr/src/error.rs:12
  field col of variant Error::Lex, previously in file /tmp/.tmpq5RWvk/pklr/src/error.rs:13
  field line of variant Error::Parse, previously in file /tmp/.tmpq5RWvk/pklr/src/error.rs:19
  field col of variant Error::Parse, previously in file /tmp/.tmpq5RWvk/pklr/src/error.rs:20

--- failure enum_tuple_variant_field_added: pub enum tuple variant field added ---

Description:
An enum's exhaustive tuple variant has a new field, which has to be included when constructing or matching on this variant.
        ref: https://doc.rust-lang.org/reference/attributes/type_system.html#the-non_exhaustive-attribute
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_tuple_variant_field_added.ron

Failed in:
  field 1 of variant Value::Object in /tmp/.tmptLxo3n/pklr/src/value.rs:36
  field 1 of variant Value::Object in /tmp/.tmptLxo3n/pklr/src/value.rs:36

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_variant_added.ron

Failed in:
  variant UnOp:NonNull in /tmp/.tmptLxo3n/pklr/src/parser.rs:162
  variant Expr:StringInterpolation in /tmp/.tmptLxo3n/pklr/src/parser.rs:122
  variant Expr:NullSafeField in /tmp/.tmptLxo3n/pklr/src/parser.rs:124
  variant Expr:Lambda in /tmp/.tmptLxo3n/pklr/src/parser.rs:126
  variant Expr:ReadOrNull in /tmp/.tmptLxo3n/pklr/src/parser.rs:134
  variant TokenKind:InterpolatedString in /tmp/.tmptLxo3n/pklr/src/lexer.rs:16
  variant TokenKind:QuestionQuestion in /tmp/.tmptLxo3n/pklr/src/lexer.rs:35
  variant TokenKind:QuestionDot in /tmp/.tmptLxo3n/pklr/src/lexer.rs:36
  variant TokenKind:BangBang in /tmp/.tmptLxo3n/pklr/src/lexer.rs:38
  variant TokenKind:PipeGt in /tmp/.tmptLxo3n/pklr/src/lexer.rs:40
  variant TokenKind:TildeSlash in /tmp/.tmptLxo3n/pklr/src/lexer.rs:56
  variant TokenKind:StarStar in /tmp/.tmptLxo3n/pklr/src/lexer.rs:57
  variant TokenKind:KwSuper in /tmp/.tmptLxo3n/pklr/src/lexer.rs:80
  variant TypeExpr:Constrained in /tmp/.tmptLxo3n/pklr/src/parser.rs:87
  variant Value:Lambda in /tmp/.tmptLxo3n/pklr/src/value.rs:40
  variant Value:Lambda in /tmp/.tmptLxo3n/pklr/src/value.rs:40
  variant Entry:Elem in /tmp/.tmptLxo3n/pklr/src/parser.rs:50
  variant Entry:ClassDef in /tmp/.tmptLxo3n/pklr/src/parser.rs:53
  variant Entry:TypeAlias in /tmp/.tmptLxo3n/pklr/src/parser.rs:55
  variant BinOp:IntDiv in /tmp/.tmptLxo3n/pklr/src/parser.rs:144
  variant BinOp:Pow in /tmp/.tmptLxo3n/pklr/src/parser.rs:145
  variant BinOp:Pipe in /tmp/.tmptLxo3n/pklr/src/parser.rs:155

--- failure enum_variant_missing: pub enum variant removed or renamed ---

Description:
A publicly-visible enum has at least one variant that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_variant_missing.ron

Failed in:
  variant Value::Mapping, previously in file /tmp/.tmpq5RWvk/pklr/src/value.rs:17
  variant Value::Mapping, previously in file /tmp/.tmpq5RWvk/pklr/src/value.rs:17
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.0](https://github.com/jdx/pklr/compare/v0.1.0...v0.2.0) - 2026-03-23

### Added

- support hk.pkl evaluation — output block, class functions, perf ([#41](https://github.com/jdx/pklr/pull/41))
- enforce open modifier on classes ([#38](https://github.com/jdx/pklr/pull/38))
- type constraints with runtime enforcement via is/as ([#39](https://github.com/jdx/pklr/pull/39))
- Set() now deduplicates elements ([#37](https://github.com/jdx/pklr/pull/37))
- implement is/as type operators ([#35](https://github.com/jdx/pklr/pull/35))
- type alias declarations (typealias) ([#33](https://github.com/jdx/pklr/pull/33))
- implement read() and read?() resource readers ([#36](https://github.com/jdx/pklr/pull/36))
- class inheritance (extends) and super keyword ([#30](https://github.com/jdx/pklr/pull/30))
- support extends for modules and classes ([#29](https://github.com/jdx/pklr/pull/29))
- this keyword for self-referencing within objects ([#27](https://github.com/jdx/pklr/pull/27))
- fully implement annotations (@Deprecated, @ModuleInfo, etc.) ([#25](https://github.com/jdx/pklr/pull/25))
- late binding for object amendment ([#23](https://github.com/jdx/pklr/pull/23))
- add import* glob import support ([#21](https://github.com/jdx/pklr/pull/21))
- support default elements/values in objects and mappings ([#22](https://github.com/jdx/pklr/pull/22))
- enforce property modifiers (hidden, const, abstract) ([#20](https://github.com/jdx/pklr/pull/20))
- async evaluator with HTTP/HTTPS/package:// import support ([#17](https://github.com/jdx/pklr/pull/17))
- add unicode escapes, NaN/Infinity, durations, and data sizes ([#16](https://github.com/jdx/pklr/pull/16))
- integer division, exponentiation, non-null assertion, pipe operator ([#18](https://github.com/jdx/pklr/pull/18))
- class definitions, outer keyword — v1 complete ([#15](https://github.com/jdx/pklr/pull/15))
- v1 part 2 — object amendment, module/annotation skipping, higher-order methods ([#14](https://github.com/jdx/pklr/pull/14))
- v1 language features ([#13](https://github.com/jdx/pklr/pull/13))

### Fixed

- address merged PR feedback — type aliases, depth guard, dead code ([#40](https://github.com/jdx/pklr/pull/40))
- address PR #29 feedback — dotted extends, HTTP class injection ([#31](https://github.com/jdx/pklr/pull/31))
- hk.pkl compatibility — parser and eval improvements ([#32](https://github.com/jdx/pklr/pull/32))
- add import cache to break circular imports ([#28](https://github.com/jdx/pklr/pull/28))
- *(parser)* support dotted type names in new expressions ([#26](https://github.com/jdx/pklr/pull/26))
- *(parser)* skip generic type params in new expressions ([#19](https://github.com/jdx/pklr/pull/19))
- *(parser)* add ?? operator and fix dynamic key parsing ([#11](https://github.com/jdx/pklr/pull/11))
- *(test)* address PR #9 review feedback ([#10](https://github.com/jdx/pklr/pull/10))
- *(eval)* guard integer div/mod against zero, remove unreachable Value::Mapping ([#5](https://github.com/jdx/pklr/pull/5))

### Other

- remove feature list and roadmap from README ([#42](https://github.com/jdx/pklr/pull/42))
- set MSRV to 1.88 and add cargo msrv verify to CI ([#24](https://github.com/jdx/pklr/pull/24))
- add CLAUDE.md and document supported pkl subset in README ([#12](https://github.com/jdx/pklr/pull/12))
- remove status section from README
- add comprehensive pkl feature test suite ([#9](https://github.com/jdx/pklr/pull/9))
- *(deps)* add miette, remove unused serde ([#8](https://github.com/jdx/pklr/pull/8))
- add mise.toml, CI workflow, and communique config ([#6](https://github.com/jdx/pklr/pull/6))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).