### PR TITLE
feat: implement is/as type operators

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ pklr implements a subset of the [Pkl language](https://pkl-lang.org/main/current
 | `throw(msg)` | Supported |
 | `trace(expr)` | Supported |
 | `read(uri)` / `read?(uri)` | Supported (`file://`, `env:`, `http(s)://`, relative paths) |
-| `is` / `as` type operators | Parsed (type checks not enforced) |
+| `is` / `as` type operators | Supported |
 
 ### Variables & Scope
 

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -1042,11 +1042,22 @@ impl Evaluator {
                     }
                 }
             }
-            Expr::Is(expr, _ty) => {
-                // Simplified: just evaluate the expression, ignore type check
-                self.eval_expr(expr, scope, depth + 1).await
+            Expr::Is(expr, ty) => {
+                let val = self.eval_expr(expr, scope, depth + 1).await?;
+                Ok(Value::Bool(value_is_type(&val, ty)))
             }
-            Expr::As(expr, _ty) => self.eval_expr(expr, scope, depth + 1).await,
+            Expr::As(expr, ty) => {
+                let val = self.eval_expr(expr, scope, depth + 1).await?;
+                if value_is_type(&val, ty) {
+                    Ok(val)
+                } else {
+                    Err(Error::Eval(format!(
+                        "cannot cast {} to {}",
+                        value_type_name(&val),
+                        display_type_expr(ty)
+                    )))
+                }
+            }
             Expr::Throw(msg_expr) => {
                 let msg = self.eval_expr(msg_expr, scope, depth + 1).await?;
                 Err(Error::Eval(format!("throw: {}", value_to_display(&msg))))
@@ -1727,6 +1738,57 @@ fn value_to_display(v: &Value) -> String {
         Value::Float(f) => f.to_string(),
         Value::String(s) => s.clone(),
         _ => format!("{v:?}"),
+    }
+}
+
+/// Format a TypeExpr for user-facing error messages.
+fn display_type_expr(ty: &crate::parser::TypeExpr) -> String {
+    use crate::parser::TypeExpr;
+    match ty {
+        TypeExpr::Named(name) => name.clone(),
+        TypeExpr::Nullable(inner) => format!("{}?", display_type_expr(inner)),
+        TypeExpr::Union(variants) => variants
+            .iter()
+            .map(display_type_expr)
+            .collect::<Vec<_>>()
+            .join("|"),
+        TypeExpr::Generic(name, args) => {
+            let args_str: Vec<_> = args.iter().map(display_type_expr).collect();
+            format!("{}<{}>", name, args_str.join(", "))
+        }
+    }
+}
+
+/// Check if a value matches a Pkl type expression.
+fn value_is_type(val: &Value, ty: &crate::parser::TypeExpr) -> bool {
+    use crate::parser::TypeExpr;
+    match ty {
+        TypeExpr::Named(name) => match name.as_str() {
+            "Null" => matches!(val, Value::Null),
+            "Boolean" | "Bool" => matches!(val, Value::Bool(_)),
+            "Int" => matches!(val, Value::Int(_)),
+            "Float" => matches!(val, Value::Float(_)),
+            "Number" => matches!(val, Value::Int(_) | Value::Float(_)),
+            "String" => matches!(val, Value::String(_)),
+            "List" | "Listing" | "Set" => matches!(val, Value::List(_)),
+            "Map" | "Mapping" | "Object" | "Dynamic" => matches!(val, Value::Object(..)),
+            "Function" => matches!(val, Value::Lambda(..)),
+            "Any" => true,
+            _ => {
+                // Unknown type name -- could be a class; treat objects as matching
+                matches!(val, Value::Object(..))
+            }
+        },
+        TypeExpr::Nullable(inner) => matches!(val, Value::Null) || value_is_type(val, inner),
+        TypeExpr::Union(variants) => variants.iter().any(|v| value_is_type(val, v)),
+        TypeExpr::Generic(name, _) => {
+            // Check the base type, ignore type parameters
+            match name.as_str() {
+                "List" | "Listing" | "Set" => matches!(val, Value::List(_)),
+                "Map" | "Mapping" => matches!(val, Value::Object(..)),
+                _ => matches!(val, Value::Object(..)),
+            }
+        }
     }
 }
 

--- a/tests/pkl_features.rs
+++ b/tests/pkl_features.rs
@@ -2054,6 +2054,158 @@ x = new Mapping {
 }
 
 // ============================================================
+// is / as type operators
+// ============================================================
+
+#[test]
+fn is_operator_string() {
+    let json = eval(
+        r#"
+local x = "hello"
+a = x is String
+b = x is Int
+"#,
+    );
+    assert_eq!(json["a"], true);
+    assert_eq!(json["b"], false);
+}
+
+#[test]
+fn is_operator_int() {
+    let json = eval(
+        r#"
+local x = 42
+a = x is Int
+b = x is Number
+c = x is String
+"#,
+    );
+    assert_eq!(json["a"], true);
+    assert_eq!(json["b"], true);
+    assert_eq!(json["c"], false);
+}
+
+#[test]
+fn is_operator_null() {
+    let json = eval(
+        r#"
+local x = null
+a = x is Null
+b = x is String?
+c = x is String
+"#,
+    );
+    assert_eq!(json["a"], true);
+    assert_eq!(json["b"], true);
+    assert_eq!(json["c"], false);
+}
+
+#[test]
+fn is_operator_nullable() {
+    let json = eval(
+        r#"
+local x = "hello"
+a = x is String?
+b = x is Int?
+"#,
+    );
+    assert_eq!(json["a"], true);
+    assert_eq!(json["b"], false);
+}
+
+#[test]
+fn is_operator_union() {
+    let json = eval(
+        r#"
+local x = 42
+local y = "hello"
+a = x is String|Int
+b = y is String|Int
+c = x is String|Boolean
+"#,
+    );
+    assert_eq!(json["a"], true);
+    assert_eq!(json["b"], true);
+    assert_eq!(json["c"], false);
+}
+
+#[test]
+fn is_operator_object_and_list() {
+    let json = eval(
+        r#"
+local obj = new { x = 1 }
+local lst = List(1, 2, 3)
+a = obj is Object
+b = lst is List
+c = obj is List
+d = lst is Object
+"#,
+    );
+    assert_eq!(json["a"], true);
+    assert_eq!(json["b"], true);
+    assert_eq!(json["c"], false);
+    assert_eq!(json["d"], false);
+}
+
+#[test]
+fn is_operator_any() {
+    let json = eval(
+        r#"
+a = 42 is Any
+b = "hello" is Any
+c = null is Any
+"#,
+    );
+    assert_eq!(json["a"], true);
+    assert_eq!(json["b"], true);
+    assert_eq!(json["c"], true);
+}
+
+#[test]
+fn as_operator_success() {
+    let json = eval(
+        r#"
+local x = 42
+result = x as Int
+"#,
+    );
+    assert_eq!(json["result"], 42);
+}
+
+#[test]
+fn as_operator_failure() {
+    let msg = eval_fails(
+        r#"
+local x = "hello"
+result = x as Int
+"#,
+    );
+    assert!(msg.contains("cannot cast"));
+}
+
+#[test]
+fn as_operator_nullable() {
+    let json = eval(
+        r#"
+local x = null
+result = x as String?
+"#,
+    );
+    assert_eq!(json["result"], serde_json::Value::Null);
+}
+
+#[test]
+fn is_in_conditional() {
+    let json = eval(
+        r#"
+local x = 42
+result = if (x is Int) "integer" else "other"
+"#,
+    );
+    assert_eq!(json["result"], "integer");
+}
+
+// ============================================================
 // Annotations
 // ============================================================
 


### PR DESCRIPTION
## Summary
- `expr is Type` now returns a boolean instead of the expression value
- `expr as Type` returns the value if it matches, throws a cast error otherwise
- New `value_is_type` helper checks values against `TypeExpr` variants:
  - Primitives: `Int`, `Float`, `String`, `Boolean`, `Null`, `Number`
  - Collections: `List`, `Listing`, `Map`, `Mapping`, `Object`, `Dynamic`
  - `Function`, `Any`
  - Nullable: `Type?` (null or matches inner type)
  - Union: `Type|Type` (matches any variant)
  - Generic: `List<T>`, `Mapping<K,V>` (checks base type, ignores params)
  - Unknown class names default to Object match

## Test plan
- [x] `is_operator_string` -- string type check
- [x] `is_operator_int` -- int, Number, negative
- [x] `is_operator_null` -- null, nullable
- [x] `is_operator_nullable` -- non-null with nullable type
- [x] `is_operator_union` -- union type matching
- [x] `is_operator_object_and_list` -- Object vs List distinction
- [x] `is_operator_any` -- Any matches everything
- [x] `as_operator_success` -- successful cast
- [x] `as_operator_failure` -- failed cast throws error
- [x] `as_operator_nullable` -- null as nullable succeeds
- [x] `is_in_conditional` -- `is` used in if condition
- [x] All 201 tests pass, clippy clean, fmt clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)