### PR TITLE
feat: Set() now deduplicates elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ pklr implements a subset of the [Pkl language](https://pkl-lang.org/main/current
 | `Map(k1, v1, k2, v2)` | Supported |
 | `List(...)` / `Listing(...)` | Supported |
 | `new Listing { ... }` body syntax | Supported |
-| `Set(...)` | Parsed (treated as List) |
+| `Set(...)` | Supported (deduplicated, serialized as List) |
 | Object amendment (`(base) { overrides }`) | Supported |
 | Spread operator (`...expr`) | Supported |
 | Default elements/values (`default { ... }`) | Supported |

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -1108,9 +1108,12 @@ impl Evaluator {
                 "Set" => {
                     let mut items = Vec::new();
                     for a in args {
-                        items.push(self.eval_expr(a, scope, depth + 1).await?);
+                        let val = self.eval_expr(a, scope, depth + 1).await?;
+                        if !items.contains(&val) {
+                            items.push(val);
+                        }
                     }
-                    return Ok(Value::List(items)); // treat Set as List
+                    return Ok(Value::List(items)); // deduplicated
                 }
                 "Regex" => {
                     if let Some(arg) = args.first() {

--- a/tests/pkl_features.rs
+++ b/tests/pkl_features.rs
@@ -2289,3 +2289,25 @@ x = "hello \(read("env:PKLR_NAME"))"
     assert_eq!(json["x"], "hello world");
     unsafe { std::env::remove_var("PKLR_NAME") };
 }
+
+// ============================================================
+// Set() deduplication
+// ============================================================
+
+#[test]
+fn set_deduplicates() {
+    let json = eval(r#"x = Set(1, 2, 3, 2, 1)"#);
+    assert_eq!(json["x"], serde_json::json!([1, 2, 3]));
+}
+
+#[test]
+fn set_preserves_order() {
+    let json = eval(r#"x = Set("b", "a", "c", "a")"#);
+    assert_eq!(json["x"], serde_json::json!(["b", "a", "c"]));
+}
+
+#[test]
+fn set_empty() {
+    let json = eval(r#"x = Set()"#);
+    assert_eq!(json["x"], serde_json::json!([]));
+}


### PR DESCRIPTION
## Summary
`Set()` now properly deduplicates elements while preserving insertion order. Previously it was treated as a plain `List()`.

```pkl
x = Set(1, 2, 3, 2, 1)  // → [1, 2, 3]
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)