### PR TITLE
feat: enforce open modifier on classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ pklr implements a subset of the [Pkl language](https://pkl-lang.org/main/current
 | `abstract` modifier (must be overridden) | Supported |
 | `fixed` modifier (cannot override) | Supported |
 | `external` modifier (must be assigned) | Supported |
-| `open` modifier | Parsed (no-op at eval time) |
+| `open` modifier (allows new properties in subclasses) | Supported |
 
 ### Modules & Imports
 

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -374,9 +374,15 @@ impl Evaluator {
                     // by re-processing its body entries
                     for entry in &ext_module.body {
                         match entry {
-                            Entry::ClassDef(cls_name, parent, body) => {
+                            Entry::ClassDef(cls_name, cls_mods, parent, body) => {
                                 let defaults = self
-                                    .eval_class_def(parent.as_deref(), body, &scope, depth)
+                                    .eval_class_def(
+                                        cls_mods,
+                                        parent.as_deref(),
+                                        body,
+                                        &scope,
+                                        depth,
+                                    )
                                     .await?;
                                 scope.set(cls_name.clone(), defaults);
                             }
@@ -399,9 +405,9 @@ impl Evaluator {
                 }
                 // Inject class definitions from HTTP base into scope
                 for entry in &ext_module.body {
-                    if let Entry::ClassDef(cls_name, parent, body) = entry {
+                    if let Entry::ClassDef(cls_name, cls_mods, parent, body) = entry {
                         let defaults = self
-                            .eval_class_def(parent.as_deref(), body, &scope, depth)
+                            .eval_class_def(cls_mods, parent.as_deref(), body, &scope, depth)
                             .await?;
                         scope.set(cls_name.clone(), defaults);
                     }
@@ -422,9 +428,9 @@ impl Evaluator {
         // Collect class definitions and type aliases into module scope
         for entry in &module.body {
             match entry {
-                Entry::ClassDef(name, parent, body) => {
+                Entry::ClassDef(name, class_mods, parent, body) => {
                     let defaults = self
-                        .eval_class_def(parent.as_deref(), body, &scope, depth)
+                        .eval_class_def(class_mods, parent.as_deref(), body, &scope, depth)
                         .await?;
                     scope.set(name.clone(), defaults);
                 }
@@ -547,9 +553,9 @@ impl Evaluator {
         }
         // Collect class definitions and type aliases into scope
         for entry in entries {
-            if let Entry::ClassDef(name, parent, body) = entry {
+            if let Entry::ClassDef(name, class_mods, parent, body) = entry {
                 let defaults = self
-                    .eval_class_def(parent.as_deref(), body, &child_scope, depth)
+                    .eval_class_def(class_mods, parent.as_deref(), body, &child_scope, depth)
                     .await?;
                 child_scope.set(name.clone(), defaults);
             } else if let Entry::TypeAlias(name, ty) = entry {
@@ -648,6 +654,7 @@ impl Evaluator {
         let source = ObjectSource {
             entries: entries.to_vec(),
             scope: child_scope.flatten(),
+            is_open: true, // default: allow new properties
         };
         Ok(Value::Object(map, Some(Box::new(source))))
     }
@@ -660,6 +667,7 @@ impl Evaluator {
     #[async_recursion(?Send)]
     async fn eval_class_def(
         &mut self,
+        class_mods: &[Modifier],
         parent_name: Option<&str>,
         body: &[Entry],
         scope: &Scope,
@@ -716,6 +724,16 @@ impl Evaluator {
         } else {
             Ok(child_defaults)
         }
+        .map(|val| {
+            // Set is_open flag on the result's ObjectSource
+            let is_open = has_modifier(class_mods, Modifier::Open);
+            if let Value::Object(map, Some(mut src)) = val {
+                src.is_open = is_open;
+                Value::Object(map, Some(src))
+            } else {
+                val
+            }
+        })
     }
 
     /// Evaluate a type alias declaration.
@@ -905,7 +923,35 @@ impl Evaluator {
                             }
                             Some(val)
                         });
-                        if let Some(Value::Object(_, Some(base_src))) = &base {
+                        if let Some(Value::Object(ref base_map, Some(ref base_src))) = base {
+                            // Enforce open modifier: non-open classes reject new properties
+                            if !base_src.is_open {
+                                // Collect all declared property names from the base class
+                                // (includes those with no default value)
+                                let base_names: std::collections::HashSet<String> = base_src
+                                    .entries
+                                    .iter()
+                                    .filter_map(|e| {
+                                        if let Entry::Property(p) = e {
+                                            Some(p.name.clone())
+                                        } else {
+                                            None
+                                        }
+                                    })
+                                    .chain(base_map.keys().cloned())
+                                    .collect();
+                                for entry in entries {
+                                    if let Entry::Property(p) = entry
+                                        && !has_modifier(&p.modifiers, Modifier::Local)
+                                        && !base_names.contains(&p.name)
+                                    {
+                                        return Err(Error::Eval(format!(
+                                            "cannot add property '{}' to non-open class",
+                                            p.name
+                                        )));
+                                    }
+                                }
+                            }
                             // Late binding: re-evaluate merged base + overlay entries
                             self.eval_amended_object(
                                 &base_src.entries.clone(),

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -941,26 +941,45 @@ impl Evaluator {
                                     .chain(base_map.keys().cloned())
                                     .collect();
                                 for entry in entries {
-                                    if let Entry::Property(p) = entry
-                                        && !has_modifier(&p.modifiers, Modifier::Local)
-                                        && !base_names.contains(&p.name)
-                                    {
-                                        return Err(Error::Eval(format!(
-                                            "cannot add property '{}' to non-open class",
-                                            p.name
-                                        )));
+                                    match entry {
+                                        Entry::Property(p)
+                                            if !has_modifier(&p.modifiers, Modifier::Local)
+                                                && !base_names.contains(&p.name) =>
+                                        {
+                                            return Err(Error::Eval(format!(
+                                                "cannot add property '{}' to non-open class",
+                                                p.name
+                                            )));
+                                        }
+                                        Entry::DynProperty(Expr::String(key), _)
+                                            if !base_names.contains(key) =>
+                                        {
+                                            return Err(Error::Eval(format!(
+                                                "cannot add property '{}' to non-open class",
+                                                key
+                                            )));
+                                        }
+                                        _ => {}
                                     }
                                 }
                             }
+                            let is_open = base_src.is_open;
                             // Late binding: re-evaluate merged base + overlay entries
-                            self.eval_amended_object(
-                                &base_src.entries.clone(),
-                                &base_src.scope.clone(),
-                                entries,
-                                scope,
-                                depth,
-                            )
-                            .await
+                            let mut result = self
+                                .eval_amended_object(
+                                    &base_src.entries.clone(),
+                                    &base_src.scope.clone(),
+                                    entries,
+                                    scope,
+                                    depth,
+                                )
+                                .await?;
+                            // Preserve the base class's is_open flag so further amendments
+                            // of non-open classes continue to enforce the constraint.
+                            if let Value::Object(_, Some(ref mut src)) = result {
+                                src.is_open = is_open;
+                            }
+                            Ok(result)
                         } else if let Some(Value::Object(base_map, _)) = base {
                             // Fallback: eager merge
                             let overlay = self.eval_entries(entries, scope, depth + 1).await?;

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -48,9 +48,9 @@ pub enum Entry {
     Spread(Expr),
     /// Bare element expression (used in Listing bodies)
     Elem(Expr),
-    /// Class definition: `class Name [extends Parent] { properties... }`
-    /// Fields: (name, optional_parent, body)
-    ClassDef(String, Option<String>, Vec<Entry>),
+    /// Class definition: `[modifiers] class Name [extends Parent] { properties... }`
+    /// Fields: (name, modifiers, optional_parent, body)
+    ClassDef(String, Vec<Modifier>, Option<String>, Vec<Entry>),
     /// Type alias: `typealias Name = Type`
     TypeAlias(String, TypeExpr),
 }
@@ -374,7 +374,13 @@ impl<'a> Parser<'a> {
         let mut entries = Vec::new();
         while !self.at_eof() && !matches!(self.peek(), TokenKind::RBrace) {
             let entry_annotations = self.parse_annotations()?;
-            // Parse class definitions; skip typealias/function declarations
+            // Parse class definitions (with optional modifiers); skip typealias/function declarations
+            let class_modifiers =
+                if self.peek_is_modifier() && self.peek_past_modifiers_is(TokenKind::KwClass) {
+                    self.collect_modifiers()
+                } else {
+                    Vec::new()
+                };
             if matches!(self.peek(), TokenKind::KwClass) {
                 self.advance(); // consume 'class'
                 let name = self.expect_ident()?;
@@ -405,7 +411,7 @@ impl<'a> Parser<'a> {
                     self.advance();
                     let body = self.parse_entries()?;
                     self.expect(&TokenKind::RBrace)?;
-                    entries.push(Entry::ClassDef(name, parent, body));
+                    entries.push(Entry::ClassDef(name, class_modifiers, parent, body));
                 }
                 continue;
             }
@@ -485,6 +491,64 @@ impl<'a> Parser<'a> {
                 | TokenKind::KwOpen
                 | TokenKind::KwExternal
         )
+    }
+
+    fn peek_past_modifiers_is(&self, target: TokenKind) -> bool {
+        let mut i = self.pos;
+        while i < self.tokens.len() {
+            match &self.tokens[i].kind {
+                TokenKind::KwLocal
+                | TokenKind::KwConst
+                | TokenKind::KwFixed
+                | TokenKind::KwHidden
+                | TokenKind::KwAbstract
+                | TokenKind::KwOpen
+                | TokenKind::KwExternal => i += 1,
+                tok if std::mem::discriminant(tok) == std::mem::discriminant(&target) => {
+                    return true;
+                }
+                _ => return false,
+            }
+        }
+        false
+    }
+
+    fn collect_modifiers(&mut self) -> Vec<Modifier> {
+        let mut mods = Vec::new();
+        loop {
+            match self.peek() {
+                TokenKind::KwLocal => {
+                    self.advance();
+                    mods.push(Modifier::Local);
+                }
+                TokenKind::KwConst => {
+                    self.advance();
+                    mods.push(Modifier::Const);
+                }
+                TokenKind::KwFixed => {
+                    self.advance();
+                    mods.push(Modifier::Fixed);
+                }
+                TokenKind::KwHidden => {
+                    self.advance();
+                    mods.push(Modifier::Hidden);
+                }
+                TokenKind::KwAbstract => {
+                    self.advance();
+                    mods.push(Modifier::Abstract);
+                }
+                TokenKind::KwOpen => {
+                    self.advance();
+                    mods.push(Modifier::Open);
+                }
+                TokenKind::KwExternal => {
+                    self.advance();
+                    mods.push(Modifier::External);
+                }
+                _ => break,
+            }
+        }
+        mods
     }
 
     fn peek_past_modifiers_is_decl(&self) -> bool {

--- a/src/value.rs
+++ b/src/value.rs
@@ -11,6 +11,8 @@ use crate::parser::{Entry, Expr};
 pub struct ObjectSource {
     pub entries: Vec<Entry>,
     pub scope: IndexMap<String, Value>,
+    /// Whether the class was declared `open` (allows adding new properties)
+    pub is_open: bool,
 }
 
 /// A pkl runtime value.

--- a/tests/pkl_features.rs
+++ b/tests/pkl_features.rs
@@ -2503,6 +2503,42 @@ x = new Config {
 }
 
 #[test]
+fn non_open_class_rejects_dyn_property() {
+    let msg = eval_fails(
+        r#"
+class Config {
+    port: Int = 8080
+}
+x = new Config {
+    ["host"] = "localhost"
+}
+"#,
+    );
+    assert!(msg.contains("non-open"));
+    assert!(msg.contains("host"));
+}
+
+#[test]
+fn non_open_class_preserves_constraint_on_re_instantiation() {
+    // After instantiating a non-open class, the is_open=false flag must be
+    // preserved so that re-using the result as a base still enforces the constraint.
+    let msg = eval_fails(
+        r#"
+class Config {
+    port: Int = 8080
+}
+base = new Config { port = 9090 }
+x = new Config {
+    port = base.port
+    host = "bad"
+}
+"#,
+    );
+    assert!(msg.contains("non-open"));
+    assert!(msg.contains("host"));
+}
+
+#[test]
 fn non_open_class_allows_overrides() {
     let json = eval(
         r#"

--- a/tests/pkl_features.rs
+++ b/tests/pkl_features.rs
@@ -2463,3 +2463,59 @@ fn set_empty() {
     let json = eval(r#"x = Set()"#);
     assert_eq!(json["x"], serde_json::json!([]));
 }
+
+// ============================================================
+// open modifier
+// ============================================================
+
+#[test]
+fn open_class_allows_new_properties() {
+    let json = eval(
+        r#"
+open class Config {
+    port: Int = 8080
+}
+x = new Config {
+    port = 9090
+    host = "localhost"
+}
+"#,
+    );
+    assert_eq!(json["x"]["port"], 9090);
+    assert_eq!(json["x"]["host"], "localhost");
+}
+
+#[test]
+fn non_open_class_rejects_new_properties() {
+    let msg = eval_fails(
+        r#"
+class Config {
+    port: Int = 8080
+}
+x = new Config {
+    port = 9090
+    host = "localhost"
+}
+"#,
+    );
+    assert!(msg.contains("non-open"));
+    assert!(msg.contains("host"));
+}
+
+#[test]
+fn non_open_class_allows_overrides() {
+    let json = eval(
+        r#"
+class Config {
+    port: Int = 8080
+    debug: Boolean = false
+}
+x = new Config {
+    port = 9090
+    debug = true
+}
+"#,
+    );
+    assert_eq!(json["x"]["port"], 9090);
+    assert_eq!(json["x"]["debug"], true);
+}


### PR DESCRIPTION
## Summary
Non-open classes now reject new properties when instantiated.

```pkl
open class Foo { port = 8080 }
new Foo { port = 9090; host = "localhost" }  // ok

class Bar { port = 8080 }
new Bar { host = "localhost" }  // error: cannot add 'host' to non-open class
```

**Implementation:**
- `ClassDef` now stores `Vec<Modifier>` for class-level modifiers (`open`, `abstract`, etc.)
- `ObjectSource.is_open` flag set by `eval_class_def` based on class modifiers
- Enforcement checks declared entry names (not just map keys) to handle properties with no default value
- New `collect_modifiers()` and `peek_past_modifiers_is()` parser helpers

🤖 Generated with [Claude Code](https://claude.com/claude-code)