### PR TITLE
feat: type constraints with runtime enforcement via is/as

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ pklr implements a subset of the [Pkl language](https://pkl-lang.org/main/current
 
 The following Pkl features are not currently implemented:
 
-- **Type constraints** (parsed but not enforced)
+- **Type constraints** on property annotations (constraints enforced only via `is`/`as`, not on assignment)
 - **Type annotations** (parsed but not validated)
 - **Member predicates** (`[[...]]`)
 - **Regular expressions** (`Regex`)

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -723,6 +723,8 @@ impl Evaluator {
     /// If the aliased type is a named type that exists in scope (e.g. a class),
     /// the alias name is bound to the same value so `new AliasName { ... }` works.
     fn eval_type_alias(&self, name: &str, ty: &crate::parser::TypeExpr, scope: &mut Scope) {
+        // Store the TypeExpr so `is`/`as` can resolve alias names to their definitions
+        scope.set_type_alias(name.to_string(), ty.clone());
         match ty {
             crate::parser::TypeExpr::Named(target) => {
                 // Alias to a class or another alias already in scope
@@ -738,8 +740,84 @@ impl Evaluator {
                     scope.set(name.to_string(), val.clone());
                 }
             }
+            crate::parser::TypeExpr::Constrained(base, _) => {
+                // Alias to a constrained type -- also bind as the base class if available
+                if let Some(val) = scope.get(base) {
+                    scope.set(name.to_string(), val.clone());
+                }
+            }
             // Union types, generics, etc. -- no runtime representation needed
             _ => {}
+        }
+    }
+
+    /// Check if a value matches a type expression, including constraint evaluation.
+    #[async_recursion(?Send)]
+    async fn eval_type_check(
+        &mut self,
+        val: &Value,
+        ty: &crate::parser::TypeExpr,
+        scope: &Scope,
+        depth: usize,
+    ) -> Result<bool> {
+        use crate::parser::TypeExpr;
+        match ty {
+            TypeExpr::Named(name) => {
+                // Check if name is a type alias; if so, resolve to the aliased type
+                if let Some(resolved) = scope.get_type_alias(name) {
+                    let resolved = resolved.clone();
+                    return self.eval_type_check(val, &resolved, scope, depth).await;
+                }
+                // Otherwise, plain type check
+                Ok(value_is_type(val, ty))
+            }
+            TypeExpr::Constrained(base_name, constraint) => {
+                // First check the base type
+                if !value_is_type(val, &TypeExpr::Named(base_name.clone())) {
+                    return Ok(false);
+                }
+                // Evaluate the constraint with `this` bound to the value
+                let mut constraint_scope = scope.child();
+                constraint_scope.set("this".into(), val.clone());
+                // Also bind common properties directly so `length`, `isEmpty` etc. work
+                match val {
+                    Value::String(s) => {
+                        constraint_scope.set("length".into(), Value::Int(s.chars().count() as i64));
+                        constraint_scope.set("isEmpty".into(), Value::Bool(s.is_empty()));
+                    }
+                    Value::Int(n) => {
+                        constraint_scope.set("this".into(), Value::Int(*n));
+                    }
+                    Value::Float(f) => {
+                        constraint_scope.set("this".into(), Value::Float(*f));
+                    }
+                    Value::List(items) => {
+                        constraint_scope.set("length".into(), Value::Int(items.len() as i64));
+                        constraint_scope.set("isEmpty".into(), Value::Bool(items.is_empty()));
+                    }
+                    _ => {}
+                }
+                let result = self
+                    .eval_expr(constraint, &constraint_scope, depth + 1)
+                    .await?;
+                Ok(is_truthy(&result))
+            }
+            TypeExpr::Nullable(inner) => {
+                if matches!(val, Value::Null) {
+                    return Ok(true);
+                }
+                self.eval_type_check(val, inner, scope, depth).await
+            }
+            TypeExpr::Union(variants) => {
+                for v in variants {
+                    if self.eval_type_check(val, v, scope, depth).await? {
+                        return Ok(true);
+                    }
+                }
+                Ok(false)
+            }
+            // Non-constrained types: delegate to the simple check
+            _ => Ok(value_is_type(val, ty)),
         }
     }
 
@@ -1044,11 +1122,13 @@ impl Evaluator {
             }
             Expr::Is(expr, ty) => {
                 let val = self.eval_expr(expr, scope, depth + 1).await?;
-                Ok(Value::Bool(value_is_type(&val, ty)))
+                let matches = self.eval_type_check(&val, ty, scope, depth).await?;
+                Ok(Value::Bool(matches))
             }
             Expr::As(expr, ty) => {
                 let val = self.eval_expr(expr, scope, depth + 1).await?;
-                if value_is_type(&val, ty) {
+                let matches = self.eval_type_check(&val, ty, scope, depth).await?;
+                if matches {
                     Ok(val)
                 } else {
                     Err(Error::Eval(format!(
@@ -1618,6 +1698,7 @@ impl Evaluator {
 #[derive(Debug, Default, Clone)]
 struct Scope {
     vars: IndexMap<String, Value>,
+    type_aliases: IndexMap<String, crate::parser::TypeExpr>,
     parent: Option<Box<Scope>>,
 }
 
@@ -1625,12 +1706,23 @@ impl Scope {
     fn child(&self) -> Self {
         Self {
             vars: IndexMap::new(),
+            type_aliases: IndexMap::new(),
             parent: Some(Box::new(self.clone())),
         }
     }
 
     fn set(&mut self, name: String, val: Value) {
         self.vars.insert(name, val);
+    }
+
+    fn set_type_alias(&mut self, name: String, ty: crate::parser::TypeExpr) {
+        self.type_aliases.insert(name, ty);
+    }
+
+    fn get_type_alias(&self, name: &str) -> Option<&crate::parser::TypeExpr> {
+        self.type_aliases
+            .get(name)
+            .or_else(|| self.parent.as_ref().and_then(|p| p.get_type_alias(name)))
     }
 
     fn get(&self, name: &str) -> Option<&Value> {
@@ -1756,10 +1848,12 @@ fn display_type_expr(ty: &crate::parser::TypeExpr) -> String {
             let args_str: Vec<_> = args.iter().map(display_type_expr).collect();
             format!("{}<{}>", name, args_str.join(", "))
         }
+        TypeExpr::Constrained(name, _) => format!("{name}(...)"),
     }
 }
 
-/// Check if a value matches a Pkl type expression.
+/// Check if a value matches a Pkl type expression (non-constrained types only).
+/// For constrained types, use `Evaluator::eval_type_check` instead.
 fn value_is_type(val: &Value, ty: &crate::parser::TypeExpr) -> bool {
     use crate::parser::TypeExpr;
     match ty {
@@ -1788,6 +1882,10 @@ fn value_is_type(val: &Value, ty: &crate::parser::TypeExpr) -> bool {
                 "Map" | "Mapping" => matches!(val, Value::Object(..)),
                 _ => matches!(val, Value::Object(..)),
             }
+        }
+        TypeExpr::Constrained(base_name, _) => {
+            // Just check the base type; constraint requires async eval
+            value_is_type(val, &TypeExpr::Named(base_name.clone()))
         }
     }
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -83,6 +83,8 @@ pub enum TypeExpr {
     Nullable(Box<TypeExpr>),
     Union(Vec<TypeExpr>),
     Generic(String, Vec<TypeExpr>),
+    /// Constrained type: `Type(predicate)` e.g. `Int(this >= 0)`
+    Constrained(String, Box<Expr>),
 }
 
 /// An expression.
@@ -774,27 +776,15 @@ impl<'a> Parser<'a> {
                     self.expect(&TokenKind::Gt)?;
                     TypeExpr::Generic(name, args)
                 } else {
-                    // Skip optional type constraint: Type(predicate)
+                    // Parse optional type constraint: Type(predicate)
                     if matches!(self.peek(), TokenKind::LParen) {
                         self.advance();
-                        let mut depth = 1;
-                        while depth > 0 && !self.at_eof() {
-                            match self.peek() {
-                                TokenKind::LParen => {
-                                    depth += 1;
-                                    self.advance();
-                                }
-                                TokenKind::RParen => {
-                                    depth -= 1;
-                                    self.advance();
-                                }
-                                _ => {
-                                    self.advance();
-                                }
-                            }
-                        }
+                        let constraint = self.parse_expr()?;
+                        self.expect(&TokenKind::RParen)?;
+                        TypeExpr::Constrained(name, Box::new(constraint))
+                    } else {
+                        TypeExpr::Named(name)
                     }
-                    TypeExpr::Named(name)
                 }
             }
             tok => {

--- a/tests/pkl_features.rs
+++ b/tests/pkl_features.rs
@@ -2206,6 +2206,121 @@ result = if (x is Int) "integer" else "other"
 }
 
 // ============================================================
+// Type constraints
+// ============================================================
+
+#[test]
+fn constraint_is_check_pass() {
+    let json = eval(
+        r#"
+local x = 42
+result = x is Int(this >= 0)
+"#,
+    );
+    assert_eq!(json["result"], true);
+}
+
+#[test]
+fn constraint_is_check_fail() {
+    let json = eval(
+        r#"
+local x = -1
+result = x is Int(this >= 0)
+"#,
+    );
+    assert_eq!(json["result"], false);
+}
+
+#[test]
+fn constraint_is_wrong_base_type() {
+    let json = eval(
+        r#"
+local x = "hello"
+result = x is Int(this >= 0)
+"#,
+    );
+    assert_eq!(json["result"], false);
+}
+
+#[test]
+fn constraint_as_pass() {
+    let json = eval(
+        r#"
+local x = 42
+result = x as Int(this > 0)
+"#,
+    );
+    assert_eq!(json["result"], 42);
+}
+
+#[test]
+fn constraint_as_fail() {
+    let msg = eval_fails(
+        r#"
+local x = -1
+result = x as Int(this > 0)
+"#,
+    );
+    assert!(msg.contains("cannot cast"));
+}
+
+#[test]
+fn constraint_string_not_empty() {
+    let json = eval(
+        r#"
+local a = "hello"
+local b = ""
+x = a is String(!isEmpty)
+y = b is String(!isEmpty)
+"#,
+    );
+    assert_eq!(json["x"], true);
+    assert_eq!(json["y"], false);
+}
+
+#[test]
+fn constraint_string_length() {
+    let json = eval(
+        r#"
+local x = "hi"
+a = x is String(length <= 5)
+b = x is String(length > 10)
+"#,
+    );
+    assert_eq!(json["a"], true);
+    assert_eq!(json["b"], false);
+}
+
+#[test]
+fn constraint_comparison() {
+    let json = eval(
+        r#"
+local x = 8080
+a = x is Int(this >= 1 && this <= 65535)
+b = x is Int(this < 0)
+"#,
+    );
+    assert_eq!(json["a"], true);
+    assert_eq!(json["b"], false);
+}
+
+#[test]
+fn typealias_with_constraint_enforced() {
+    // typealias with constraint, checked via is
+    let json = eval(
+        r#"
+typealias PositiveInt = Int(this > 0)
+local x = 42
+local y = -1
+a = x is PositiveInt
+b = y is PositiveInt
+"#,
+    );
+    assert_eq!(json["a"], true);
+    assert_eq!(json["b"], false);
+}
+
+// ============================================================
 // Annotations
 // ============================================================
 


### PR DESCRIPTION
## Summary
- Parse `Type(predicate)` constraint expressions into `TypeExpr::Constrained(base, Box<Expr>)` instead of skipping them
- Constraints are evaluated at runtime when checked via `is` or `as`:
  - `this` is bound to the value being checked
  - Common properties (`length`, `isEmpty`) are available in the constraint scope
  - The predicate expression must evaluate to a truthy value
- Type alias names now resolve through a `type_aliases` map on Scope, so `typealias PositiveInt = Int(this > 0)` works with `is`/`as`
- `eval_type_alias` stores constrained types in scope for both value binding (class constructor) and alias resolution

## Test plan
- [x] `constraint_is_check_pass` -- `42 is Int(this >= 0)` = true
- [x] `constraint_is_check_fail` -- `-1 is Int(this >= 0)` = false
- [x] `constraint_is_wrong_base_type` -- `"hello" is Int(this >= 0)` = false
- [x] `constraint_as_pass` -- `42 as Int(this > 0)` succeeds
- [x] `constraint_as_fail` -- `-1 as Int(this > 0)` throws
- [x] `constraint_string_not_empty` -- `String(!isEmpty)` constraint
- [x] `constraint_string_length` -- `String(length <= 5)` constraint
- [x] `constraint_comparison` -- `Int(this >= 1 && this <= 65535)` compound
- [x] `typealias_with_constraint_enforced` -- alias with constraint checked via `is`
- [x] All 223 tests pass, clippy clean, fmt clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)