### PR TITLE
fix: address merged PR feedback — type aliases, depth guard, dead code

### DIFF
--- a/src/eval.rs
+++ b/src/eval.rs
@@ -766,7 +766,7 @@ impl Evaluator {
                 // Check if name is a type alias; if so, resolve to the aliased type
                 if let Some(resolved) = scope.get_type_alias(name) {
                     let resolved = resolved.clone();
-                    return self.eval_type_check(val, &resolved, scope, depth).await;
+                    return self.eval_type_check(val, &resolved, scope, depth + 1).await;
                 }
                 // Otherwise, plain type check
                 Ok(value_is_type(val, ty))
@@ -785,12 +785,7 @@ impl Evaluator {
                         constraint_scope.set("length".into(), Value::Int(s.chars().count() as i64));
                         constraint_scope.set("isEmpty".into(), Value::Bool(s.is_empty()));
                     }
-                    Value::Int(n) => {
-                        constraint_scope.set("this".into(), Value::Int(*n));
-                    }
-                    Value::Float(f) => {
-                        constraint_scope.set("this".into(), Value::Float(*f));
-                    }
+                    Value::Int(_) | Value::Float(_) => {}
                     Value::List(items) => {
                         constraint_scope.set("length".into(), Value::Int(items.len() as i64));
                         constraint_scope.set("isEmpty".into(), Value::Bool(items.is_empty()));
@@ -877,6 +872,10 @@ impl Evaluator {
         // Layer in current scope values (imports, module-level locals, etc.)
         for (k, v) in current_scope.flatten() {
             eval_scope.set(k, v);
+        }
+        // Propagate type aliases so `is`/`as` constraints work inside amended objects
+        for (k, ty) in current_scope.flatten_type_aliases() {
+            eval_scope.set_type_alias(k, ty);
         }
 
         // Evaluate the merged entries (eval_entries handles locals, classes,
@@ -1741,6 +1740,16 @@ impl Scope {
             .map(|p| p.flatten())
             .unwrap_or_default();
         result.extend(self.vars.clone());
+        result
+    }
+
+    fn flatten_type_aliases(&self) -> IndexMap<String, crate::parser::TypeExpr> {
+        let mut result = self
+            .parent
+            .as_ref()
+            .map(|p| p.flatten_type_aliases())
+            .unwrap_or_default();
+        result.extend(self.type_aliases.clone());
         result
     }
 }

--- a/tests/pkl_features.rs
+++ b/tests/pkl_features.rs
@@ -2320,6 +2320,41 @@ b = y is PositiveInt
     assert_eq!(json["b"], false);
 }
 
+#[test]
+fn typealias_constraint_works_inside_amended_object() {
+    // type aliases must be available inside amended/extended objects
+    // (regression: flatten() used to drop type_aliases)
+    let json = eval(
+        r#"
+typealias PositiveInt = Int(this > 0)
+base {
+    port = 8080
+}
+result = (base) {
+    check = 42 is PositiveInt
+}
+"#,
+    );
+    assert_eq!(json["result"]["check"], true);
+}
+
+#[test]
+fn typealias_constraint_inside_amended_object_rejects_invalid() {
+    let json = eval(
+        r#"
+typealias PositiveInt = Int(this > 0)
+local neg = 0 - 5
+base {
+    port = 8080
+}
+result = (base) {
+    check = neg is PositiveInt
+}
+"#,
+    );
+    assert_eq!(json["result"]["check"], false);
+}
+
 // ============================================================
 // Annotations
 // ============================================================


### PR DESCRIPTION
## Summary

Addresses greptile feedback from merged PR #39 (type constraints):

- **`flatten()` drops `type_aliases`**: `Scope::flatten()` only collected `vars`, so type aliases registered at module level disappeared when `eval_amended_object` reconstructed its scope. Added `flatten_type_aliases()` and propagate aliases into the eval scope, ensuring `is`/`as` constraint checks work correctly inside amended/extended objects.
- **Infinite loop risk on circular type aliases**: `eval_type_check` recursed with `depth` unchanged when resolving a type alias. Changed to pass `depth + 1` so the existing max-depth guard fires on circular alias chains.
- **Dead code in `eval_type_check`**: `this` was already bound unconditionally before the `match val` block; the re-assignments inside `Value::Int` and `Value::Float` arms were no-ops. Removed them.

## Test plan

- [ ] `cargo test` — all 211 tests pass
- [ ] New tests `typealias_constraint_works_inside_amended_object` and `typealias_constraint_inside_amended_object_rejects_invalid` cover the flatten regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)