### PR TITLE
feat: support hk.pkl evaluation — output block, class functions, perf

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,21 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
+]
+
+[[package]]
 name = "async-recursion"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -66,6 +81,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -87,6 +128,16 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "form_urlencoded"
@@ -460,6 +511,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
+
+[[package]]
 name = "mio"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -505,6 +566,7 @@ dependencies = [
  "serde_json",
  "thiserror",
  "tokio",
+ "zip",
 ]
 
 [[package]]
@@ -798,6 +860,12 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
 
 [[package]]
 name = "slab"
@@ -1441,7 +1509,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "zip"
+version = "2.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fabe6324e908f85a1c52063ce7aa26b68dcb7eb6dbc83a2d148403c9bc3eba50"
+dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "crossbeam-utils",
+ "displaydoc",
+ "flate2",
+ "indexmap",
+ "memchr",
+ "thiserror",
+ "zopfli",
+]
+
+[[package]]
 name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zopfli"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "log",
+ "simd-adler32",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ thiserror  = "2"
 async-recursion = "1"
 reqwest         = { version = "0.12", default-features = false, features = ["rustls-tls"] }
 tokio           = { version = "1", features = ["rt"] }
+zip             = { version = "2", default-features = false, features = ["deflate"] }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,3 +1,7 @@
+// The Lex/Parse variant fields are read by miette's Diagnostic derive macro,
+// but rustc can't see through the proc-macro expansion.
+#![allow(unused_assignments)]
+
 use std::path::PathBuf;
 
 use miette::NamedSource;

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -598,14 +598,16 @@ impl Evaluator {
             }
         }
 
-        // Remove class definitions and lambdas from output — they're schema/functions,
-        // not data. They remain accessible via scope for `new ClassName { ... }` and via
-        // imported module objects for dotted paths like `helpers.ClassName`.
-        for name in &class_names {
-            out.shift_remove(name);
+        // At the top level (depth 0), strip class definitions and lambdas from
+        // the serialized output — they're schema/functions, not data.
+        // Imported modules (depth > 0) keep them so dotted access works
+        // (e.g., `helpers.ClassName`).
+        if depth == 0 {
+            for name in &class_names {
+                out.shift_remove(name);
+            }
+            out.retain(|_, v| !matches!(v, Value::Lambda(..)));
         }
-        // Also remove lambda values (function definitions) from output
-        out.retain(|_, v| !matches!(v, Value::Lambda(..)));
         Ok(Value::Object(out, None))
     }
 
@@ -638,25 +640,35 @@ impl Evaluator {
         // Set `outer` to a snapshot of the parent scope's variables as an object
         let outer_obj = Value::Object(scope.flatten(), None);
         child_scope.set("outer".into(), outer_obj);
-        // First pass: collect locals
+        // First pass: collect locals, class definitions, and type aliases in
+        // declaration order so they can reference each other correctly.
+        // Non-lambda locals are evaluated eagerly; lambda locals are deferred
+        // to a second pass so they capture the fully-populated scope.
+        let mut deferred_lambdas: Vec<(String, &crate::parser::Expr)> = Vec::new();
         for entry in entries {
-            if let Entry::Property(prop) = entry
-                && has_modifier(&prop.modifiers, Modifier::Local)
-                && let Some(expr) = &prop.value
-            {
-                let val = self.eval_expr(expr, &child_scope, depth).await?;
-                child_scope.set(prop.name.clone(), val);
-            }
-        }
-        // Collect class definitions and type aliases into scope
-        for entry in entries {
-            if let Entry::ClassDef(name, class_mods, parent, body) = entry {
-                let defaults = self
-                    .eval_class_def(class_mods, parent.as_deref(), body, &child_scope, depth)
-                    .await?;
-                child_scope.set(name.clone(), defaults);
-            } else if let Entry::TypeAlias(name, ty) = entry {
-                self.eval_type_alias(name, ty, &mut child_scope);
+            match entry {
+                Entry::Property(prop)
+                    if has_modifier(&prop.modifiers, Modifier::Local) && prop.value.is_some() =>
+                {
+                    let expr = prop.value.as_ref().unwrap();
+                    if matches!(expr, crate::parser::Expr::Lambda(..)) {
+                        // Defer lambda locals so they capture the final scope
+                        deferred_lambdas.push((prop.name.clone(), expr));
+                    } else {
+                        let val = self.eval_expr(expr, &child_scope, depth).await?;
+                        child_scope.set(prop.name.clone(), val);
+                    }
+                }
+                Entry::ClassDef(name, class_mods, parent, body) => {
+                    let defaults = self
+                        .eval_class_def(class_mods, parent.as_deref(), body, &child_scope, depth)
+                        .await?;
+                    child_scope.set(name.clone(), defaults);
+                }
+                Entry::TypeAlias(name, ty) => {
+                    self.eval_type_alias(name, ty, &mut child_scope);
+                }
+                _ => {}
             }
         }
 
@@ -747,6 +759,12 @@ impl Evaluator {
                 Entry::Elem(_) => {} // bare elements only valid in Listing bodies
                 Entry::ClassDef(..) | Entry::TypeAlias(..) => {} // handled in scope setup
             }
+        }
+        // Evaluate deferred local lambdas (function definitions) AFTER all
+        // properties so they capture overridden values (late binding).
+        for (name, expr) in deferred_lambdas {
+            let val = self.eval_expr(expr, &child_scope, depth).await?;
+            child_scope.set(name, val);
         }
         let source = ObjectSource {
             entries: entries.to_vec(),
@@ -1354,6 +1372,30 @@ impl Evaluator {
             {
                 return Ok(result);
             }
+            // If the field is a Lambda on an Object (class method), invoke it
+            // with the object's properties layered into the call scope so that
+            // overridden properties are visible to the function body and any
+            // local functions it calls.
+            if let Value::Object(ref map, _) = obj
+                && let Some(Value::Lambda(params, body, captured)) = map.get(method)
+            {
+                let mut call_scope = Scope::default();
+                for (k, v) in captured {
+                    call_scope.set(k.clone(), v.clone());
+                }
+                // Layer in ALL of the instance's properties including lambdas,
+                // so local functions called by this method also see overrides
+                for (k, v) in map {
+                    call_scope.set(k.clone(), v.clone());
+                }
+                call_scope.set("this".into(), obj.clone());
+                for (i, param) in params.iter().enumerate() {
+                    if let Some(arg) = evaled_args.get(i) {
+                        call_scope.set(param.clone(), arg.clone());
+                    }
+                }
+                return self.eval_expr(body, &call_scope, depth + 1).await;
+            }
         }
 
         // Handle built-in functions: List(), Listing(), Map()
@@ -1412,6 +1454,13 @@ impl Evaluator {
             // Restore captured scope
             for (k, v) in captured {
                 call_scope.set(k, v);
+            }
+            // If we're inside a method call context (scope has `this` as an Object),
+            // layer the instance's properties so local functions see overridden values
+            if let Some(Value::Object(this_map, _)) = scope.get("this") {
+                for (k, v) in this_map {
+                    call_scope.set(k.clone(), v.clone());
+                }
             }
             // Bind arguments to parameters
             let mut evaled_args = Vec::new();

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -22,6 +22,8 @@ pub struct Evaluator {
     import_cache: HashMap<PathBuf, Value>,
     /// Reusable HTTP client for connection pooling
     http_client: reqwest::Client,
+    /// Extracted package zip directories (zip URL → temp dir path)
+    package_dirs: HashMap<String, PathBuf>,
 }
 
 impl Default for Evaluator {
@@ -32,6 +34,7 @@ impl Default for Evaluator {
             http_cache: HashMap::new(),
             import_cache: HashMap::new(),
             http_client: reqwest::Client::new(),
+            package_dirs: HashMap::new(),
         }
     }
 }
@@ -95,6 +98,36 @@ impl Evaluator {
             .map_err(|e| Error::Eval(format!("HTTP read failed for {url}: {e}")))?;
         self.http_cache.insert(url.to_string(), body.clone());
         Ok(body)
+    }
+
+    /// Download a package zip and extract it to a temp directory.
+    /// Returns the path to the extracted directory. Caches by zip URL.
+    async fn extract_package_zip(&mut self, zip_url: &str) -> Result<PathBuf> {
+        // Check if already extracted
+        if let Some(dir) = self.package_dirs.get(zip_url) {
+            return Ok(dir.clone());
+        }
+        let bytes = self
+            .http_client
+            .get(zip_url)
+            .send()
+            .await
+            .map_err(|e| Error::Eval(format!("HTTP fetch failed for {zip_url}: {e}")))?
+            .error_for_status()
+            .map_err(|e| Error::Eval(format!("HTTP error for {zip_url}: {e}")))?
+            .bytes()
+            .await
+            .map_err(|e| Error::Eval(format!("HTTP read failed for {zip_url}: {e}")))?;
+        let cursor = std::io::Cursor::new(bytes);
+        let mut archive =
+            zip::ZipArchive::new(cursor).map_err(|e| Error::Eval(format!("zip error: {e}")))?;
+        let dir = std::env::temp_dir().join(format!("pklr-pkg-{}", self.package_dirs.len()));
+        std::fs::create_dir_all(&dir).map_err(|e| Error::Eval(format!("mkdir error: {e}")))?;
+        archive
+            .extract(&dir)
+            .map_err(|e| Error::Eval(format!("zip extract error: {e}")))?;
+        self.package_dirs.insert(zip_url.to_string(), dir.clone());
+        Ok(dir)
     }
 
     pub async fn eval_source(&mut self, source: &str, path: &Path) -> Result<Value> {
@@ -217,9 +250,30 @@ impl Evaluator {
             }
 
             if uri.starts_with("package://") {
-                let url = package_uri_to_url(uri)?;
+                let pkg = resolve_package_uri(uri)?;
                 let fragment = uri.split_once('#').map(|(_, f)| f).unwrap_or("");
                 let file_path = fragment.strip_prefix('/').unwrap_or(fragment);
+                // For zip packages, extract to temp dir and eval as local file
+                if let PackageSource::Zip(zip_url, _) = &pkg {
+                    let pkg_dir = self.extract_package_zip(zip_url).await?;
+                    let local_path = pkg_dir.join(file_path);
+                    let imported_val = self.eval_file(&local_path, depth + 1).await?;
+                    let alias = import.alias.clone().unwrap_or_else(|| {
+                        file_path
+                            .rsplit('/')
+                            .next()
+                            .unwrap_or(file_path)
+                            .strip_suffix(".pkl")
+                            .unwrap_or(file_path)
+                            .to_string()
+                    });
+                    scope.set(alias, imported_val);
+                    continue;
+                }
+                let url = match &pkg {
+                    PackageSource::Direct(url) => url.clone(),
+                    PackageSource::Zip(..) => unreachable!(),
+                };
                 let source = self.fetch_source(&url).await?;
                 let imported_val = {
                     let tokens = lexer::lex_named(&source, &url)?;
@@ -294,16 +348,24 @@ impl Evaluator {
                     base_obj = m;
                 }
             } else if uri.starts_with("package://") {
-                // Convert package URI to GitHub release URL
-                let url = package_uri_to_url(uri)?;
-                let source = self.fetch_source(&url).await?;
-                let tokens = lexer::lex_named(&source, &url)?;
-                let base_module = parser::parse_named(&tokens, &source, &url)?;
-                let base_val = self
-                    .eval_module(&base_module, Path::new(&url), depth + 1)
-                    .await?;
-                if let Value::Object(m, _) = base_val {
-                    base_obj = m;
+                let pkg = resolve_package_uri(uri)?;
+                if let PackageSource::Zip(zip_url, entry) = &pkg {
+                    let pkg_dir = self.extract_package_zip(zip_url).await?;
+                    let local_path = pkg_dir.join(entry);
+                    let base_val = self.eval_file(&local_path, depth + 1).await?;
+                    if let Value::Object(m, _) = base_val {
+                        base_obj = m;
+                    }
+                } else if let PackageSource::Direct(url) = &pkg {
+                    let source = self.fetch_source(url).await?;
+                    let tokens = lexer::lex_named(&source, url)?;
+                    let base_module = parser::parse_named(&tokens, &source, url)?;
+                    let base_val = self
+                        .eval_module(&base_module, Path::new(url.as_str()), depth + 1)
+                        .await?;
+                    if let Value::Object(m, _) = base_val {
+                        base_obj = m;
+                    }
                 }
             } else if !uri.starts_with("pkl:")
                 && (!uri.contains("://") || uri.starts_with("file://"))
@@ -1865,24 +1927,35 @@ impl Scope {
 
 // --- Helpers ---
 
-/// Convert a `package://` URI to an HTTPS download URL.
-fn package_uri_to_url(uri: &str) -> Result<String> {
+/// Resolved package info: either a direct file URL or a zip archive + entry path.
+enum PackageSource {
+    /// Direct file download (pkg.pkl-lang.org format)
+    Direct(String),
+    /// Zip archive URL + path within the archive
+    Zip(String, String),
+}
+
+/// Resolve a `package://` URI to a download source.
+fn resolve_package_uri(uri: &str) -> Result<PackageSource> {
     // Format 1: package://pkg.pkl-lang.org/github.com/owner/repo@version#/path.pkl
+    // These resolve to direct file downloads from GitHub releases
     if let Some(rest) = uri.strip_prefix("package://pkg.pkl-lang.org/github.com/")
         && let Some((repo_ver, fragment)) = rest.split_once('#')
         && let Some((repo, version)) = repo_ver.split_once('@')
     {
         let file_path = fragment.strip_prefix('/').unwrap_or(fragment);
-        return Ok(format!(
+        return Ok(PackageSource::Direct(format!(
             "https://github.com/{repo}/releases/download/{version}/{file_path}"
-        ));
+        )));
     }
     // Format 2: package://github.com/owner/repo/releases/download/v1.0/name@1.0#/path.pkl
+    // These are zip archives; the fragment is a path within the zip
     if let Some(rest) = uri.strip_prefix("package://github.com/")
         && let Some((base, fragment)) = rest.split_once('#')
     {
         let file_path = fragment.strip_prefix('/').unwrap_or(fragment);
-        return Ok(format!("https://github.com/{base}/{file_path}"));
+        let zip_url = format!("https://github.com/{base}.zip");
+        return Ok(PackageSource::Zip(zip_url, file_path.to_string()));
     }
     Err(Error::Eval(format!("unsupported package URI: {uri}")))
 }

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -342,20 +342,19 @@ impl Evaluator {
                 } else {
                     None
                 };
-                if let Some(src) = base_source {
-                    if let Ok(tokens) = lexer::lex(&src)
-                        && let Ok(base_module) = parser::parse(&tokens)
-                    {
-                        for entry in &base_module.body {
-                            if let Entry::ClassDef(name, ..) = entry {
-                                if let Some(val) = base_obj.shift_remove(name) {
-                                    scope.set(name.clone(), val);
-                                }
-                            }
+                if let Some(src) = base_source
+                    && let Ok(tokens) = lexer::lex(&src)
+                    && let Ok(base_module) = parser::parse(&tokens)
+                {
+                    for entry in &base_module.body {
+                        if let Entry::ClassDef(name, ..) = entry
+                            && let Some(val) = base_obj.shift_remove(name)
+                        {
+                            scope.set(name.clone(), val);
                         }
-                        // Also remove function values from base output
-                        base_obj.retain(|_, v| !matches!(v, Value::Lambda(..)));
                     }
+                    // Also remove function values from base output
+                    base_obj.retain(|_, v| !matches!(v, Value::Lambda(..)));
                 }
             }
         }
@@ -457,11 +456,11 @@ impl Evaluator {
         // Track class names to exclude from serialized output.
         let mut class_names: std::collections::HashSet<String> = std::collections::HashSet::new();
         for entry in &module.body {
-            if let Entry::ClassDef(name, ..) = entry {
-                if let Some(cls_val) = scope.get(name) {
-                    base_obj.insert(name.clone(), cls_val.clone());
-                    class_names.insert(name.clone());
-                }
+            if let Entry::ClassDef(name, ..) = entry
+                && let Some(cls_val) = scope.get(name)
+            {
+                base_obj.insert(name.clone(), cls_val.clone());
+                class_names.insert(name.clone());
             }
         }
 
@@ -1096,13 +1095,13 @@ impl Evaluator {
                                 .await?;
                             // Preserve the base class's is_open flag so further amendments
                             // of non-open classes continue to enforce the constraint.
-                            if let Value::Object(_, Some(ref src)) = result {
-                                if src.is_open != is_open {
-                                    let mut new_src = (**src).clone();
-                                    new_src.is_open = is_open;
-                                    if let Value::Object(_, ref mut src_slot) = result {
-                                        *src_slot = Some(std::sync::Arc::new(new_src));
-                                    }
+                            if let Value::Object(_, Some(ref src)) = result
+                                && src.is_open != is_open
+                            {
+                                let mut new_src = (**src).clone();
+                                new_src.is_open = is_open;
+                                if let Value::Object(_, ref mut src_slot) = result {
+                                    *src_slot = Some(std::sync::Arc::new(new_src));
                                 }
                             }
                             Ok(result)

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -217,39 +217,26 @@ impl Evaluator {
             }
 
             if uri.starts_with("package://") {
-                // Convert package URI to GitHub release URL
-                // Format: package://pkg.pkl-lang.org/github.com/owner/repo@version#/path.pkl
-                // → https://github.com/owner/repo/releases/download/version/path.pkl
-                if let Some(rest) = uri.strip_prefix("package://pkg.pkl-lang.org/github.com/")
-                    && let Some((repo_ver, fragment)) = rest.split_once('#')
-                    && let Some((repo, version)) = repo_ver.split_once('@')
-                {
-                    let file_path = fragment.strip_prefix('/').unwrap_or(fragment);
-                    let url = format!(
-                        "https://github.com/{repo}/releases/download/{version}/{file_path}"
-                    );
-                    let source = self.fetch_source(&url).await?;
-                    let imported_val = {
-                        let tokens = lexer::lex_named(&source, &url)?;
-                        let imp_module = parser::parse_named(&tokens, &source, &url)?;
-                        self.eval_module(&imp_module, Path::new(&url), depth + 1)
-                            .await?
-                    };
-                    let alias = import.alias.clone().unwrap_or_else(|| {
-                        file_path
-                            .rsplit('/')
-                            .next()
-                            .unwrap_or(file_path)
-                            .strip_suffix(".pkl")
-                            .unwrap_or(file_path)
-                            .to_string()
-                    });
-                    scope.set(alias, imported_val);
-                } else {
-                    return Err(Error::Eval(format!(
-                        "unsupported package URI (only pkg.pkl-lang.org/github.com is supported): {uri}"
-                    )));
-                }
+                let url = package_uri_to_url(uri)?;
+                let fragment = uri.split_once('#').map(|(_, f)| f).unwrap_or("");
+                let file_path = fragment.strip_prefix('/').unwrap_or(fragment);
+                let source = self.fetch_source(&url).await?;
+                let imported_val = {
+                    let tokens = lexer::lex_named(&source, &url)?;
+                    let imp_module = parser::parse_named(&tokens, &source, &url)?;
+                    self.eval_module(&imp_module, Path::new(&url), depth + 1)
+                        .await?
+                };
+                let alias = import.alias.clone().unwrap_or_else(|| {
+                    file_path
+                        .rsplit('/')
+                        .next()
+                        .unwrap_or(file_path)
+                        .strip_suffix(".pkl")
+                        .unwrap_or(file_path)
+                        .to_string()
+                });
+                scope.set(alias, imported_val);
                 continue;
             }
 
@@ -308,27 +295,15 @@ impl Evaluator {
                 }
             } else if uri.starts_with("package://") {
                 // Convert package URI to GitHub release URL
-                if let Some(rest) = uri.strip_prefix("package://pkg.pkl-lang.org/github.com/")
-                    && let Some((repo_ver, fragment)) = rest.split_once('#')
-                    && let Some((repo, version)) = repo_ver.split_once('@')
-                {
-                    let file_path = fragment.strip_prefix('/').unwrap_or(fragment);
-                    let url = format!(
-                        "https://github.com/{repo}/releases/download/{version}/{file_path}"
-                    );
-                    let source = self.fetch_source(&url).await?;
-                    let tokens = lexer::lex_named(&source, &url)?;
-                    let base_module = parser::parse_named(&tokens, &source, &url)?;
-                    let base_val = self
-                        .eval_module(&base_module, Path::new(&url), depth + 1)
-                        .await?;
-                    if let Value::Object(m, _) = base_val {
-                        base_obj = m;
-                    }
-                } else {
-                    return Err(Error::Eval(format!(
-                        "unsupported package URI (only pkg.pkl-lang.org/github.com is supported): {uri}"
-                    )));
+                let url = package_uri_to_url(uri)?;
+                let source = self.fetch_source(&url).await?;
+                let tokens = lexer::lex_named(&source, &url)?;
+                let base_module = parser::parse_named(&tokens, &source, &url)?;
+                let base_val = self
+                    .eval_module(&base_module, Path::new(&url), depth + 1)
+                    .await?;
+                if let Value::Object(m, _) = base_val {
+                    base_obj = m;
                 }
             } else if !uri.starts_with("pkl:")
                 && (!uri.contains("://") || uri.starts_with("file://"))
@@ -343,6 +318,43 @@ impl Evaluator {
                     let base_val = self.eval_file(&amends_path, depth + 1).await?;
                     if let Value::Object(m, _) = base_val {
                         base_obj = m;
+                    }
+                }
+            }
+        }
+
+        // Inject class definitions from amends base into scope so the amending
+        // module can reference them (e.g., `new Step { ... }`), then remove
+        // them from base_obj so they don't appear in the final output.
+        if module.amends.is_some() {
+            // Parse the base module to find its class names
+            if let Some(uri) = &module.amends {
+                let base_source = if !uri.starts_with("pkl:")
+                    && (!uri.contains("://") || uri.starts_with("file://"))
+                {
+                    let amends_path = if let Some(rel) = uri.strip_prefix("file://") {
+                        PathBuf::from(rel)
+                    } else {
+                        let base = path.parent().unwrap_or(Path::new("."));
+                        base.join(uri)
+                    };
+                    std::fs::read_to_string(&amends_path).ok()
+                } else {
+                    None
+                };
+                if let Some(src) = base_source {
+                    if let Ok(tokens) = lexer::lex(&src)
+                        && let Ok(base_module) = parser::parse(&tokens)
+                    {
+                        for entry in &base_module.body {
+                            if let Entry::ClassDef(name, ..) = entry {
+                                if let Some(val) = base_obj.shift_remove(name) {
+                                    scope.set(name.clone(), val);
+                                }
+                            }
+                        }
+                        // Also remove function values from base output
+                        base_obj.retain(|_, v| !matches!(v, Value::Lambda(..)));
                     }
                 }
             }
@@ -415,19 +427,18 @@ impl Evaluator {
             }
         }
 
-        // First pass: collect all `local` variable definitions into scope
-        for entry in &module.body {
-            if let Entry::Property(prop) = entry
-                && has_modifier(&prop.modifiers, Modifier::Local)
-                && let Some(expr) = &prop.value
-            {
-                let val = self.eval_expr(expr, &scope, depth).await?;
-                scope.set(prop.name.clone(), val);
-            }
-        }
-        // Collect class definitions and type aliases into module scope
+        // First pass: collect locals, class definitions, and type aliases in
+        // declaration order so they can reference each other
         for entry in &module.body {
             match entry {
+                Entry::Property(prop)
+                    if has_modifier(&prop.modifiers, Modifier::Local) && prop.value.is_some() =>
+                {
+                    let val = self
+                        .eval_expr(prop.value.as_ref().unwrap(), &scope, depth)
+                        .await?;
+                    scope.set(prop.name.clone(), val);
+                }
                 Entry::ClassDef(name, class_mods, parent, body) => {
                     let defaults = self
                         .eval_class_def(class_mods, parent.as_deref(), body, &scope, depth)
@@ -438,6 +449,19 @@ impl Evaluator {
                     self.eval_type_alias(name, ty, &mut scope);
                 }
                 _ => {}
+            }
+        }
+
+        // Export class definitions so they're accessible via dotted paths
+        // (e.g., `import "helpers.pkl"` → `helpers.ClassName`).
+        // Track class names to exclude from serialized output.
+        let mut class_names: std::collections::HashSet<String> = std::collections::HashSet::new();
+        for entry in &module.body {
+            if let Entry::ClassDef(name, ..) = entry {
+                if let Some(cls_val) = scope.get(name) {
+                    base_obj.insert(name.clone(), cls_val.clone());
+                    class_names.insert(name.clone());
+                }
             }
         }
 
@@ -456,6 +480,10 @@ impl Evaluator {
                     continue; // already collected
                 }
                 check_deprecated(&prop.annotations, &prop.name);
+                // Skip Pkl's `output` rendering block — pklr uses Value::to_json()
+                if prop.name == "output" {
+                    continue;
+                }
                 // abstract/external properties must have a value (or be overridden)
                 if (has_modifier(mods, Modifier::Abstract)
                     || has_modifier(mods, Modifier::External))
@@ -509,6 +537,14 @@ impl Evaluator {
             }
         }
 
+        // Remove class definitions and lambdas from output — they're schema/functions,
+        // not data. They remain accessible via scope for `new ClassName { ... }` and via
+        // imported module objects for dotted paths like `helpers.ClassName`.
+        for name in &class_names {
+            out.shift_remove(name);
+        }
+        // Also remove lambda values (function definitions) from output
+        out.retain(|_, v| !matches!(v, Value::Lambda(..)));
         Ok(Value::Object(out, None))
     }
 
@@ -584,6 +620,10 @@ impl Evaluator {
                     if prop.name == "default" && default_template.is_some() {
                         continue;
                     }
+                    // Skip Pkl's `output` rendering block — pklr uses Value::to_json()
+                    if prop.name == "output" {
+                        continue;
+                    }
                     if has_modifier(mods, Modifier::Abstract)
                         && prop.value.is_none()
                         && prop.body.is_none()
@@ -656,7 +696,7 @@ impl Evaluator {
             scope: child_scope.flatten(),
             is_open: true, // default: allow new properties
         };
-        Ok(Value::Object(map, Some(Box::new(source))))
+        Ok(Value::Object(map, Some(std::sync::Arc::new(source))))
     }
 
     /// Evaluate a class definition, optionally inheriting from a parent class.
@@ -691,7 +731,8 @@ impl Evaluator {
                 }
                 // Preserve the child's ObjectSource for late binding,
                 // but prepend parent entries so inherited props are available
-                let source = if let Some(mut src) = child_src.map(|s| *s) {
+                let source = if let Some(child_arc) = child_src {
+                    let mut src = (*child_arc).clone();
                     // Collect child property names (including dynamic string-key entries)
                     let child_names: std::collections::HashSet<String> = body
                         .iter()
@@ -713,7 +754,7 @@ impl Evaluator {
                         combined_entries.extend(src.entries);
                         src.entries = combined_entries;
                     }
-                    Some(Box::new(src))
+                    Some(std::sync::Arc::new(src))
                 } else {
                     None
                 };
@@ -727,9 +768,10 @@ impl Evaluator {
         .map(|val| {
             // Set is_open flag on the result's ObjectSource
             let is_open = has_modifier(class_mods, Modifier::Open);
-            if let Value::Object(map, Some(mut src)) = val {
-                src.is_open = is_open;
-                Value::Object(map, Some(src))
+            if let Value::Object(map, Some(src)) = val {
+                let mut new_src = (*src).clone();
+                new_src.is_open = is_open;
+                Value::Object(map, Some(std::sync::Arc::new(new_src)))
             } else {
                 val
             }
@@ -987,6 +1029,7 @@ impl Evaluator {
                             .await?;
                         Ok(Value::Object(map, None))
                     }
+                    Some("Dynamic") => self.eval_entries(entries, scope, depth + 1).await,
                     _ => {
                         // Check if type name matches a class in scope (supports dotted names)
                         let base = type_name.as_ref().and_then(|name| {
@@ -1053,8 +1096,14 @@ impl Evaluator {
                                 .await?;
                             // Preserve the base class's is_open flag so further amendments
                             // of non-open classes continue to enforce the constraint.
-                            if let Value::Object(_, Some(ref mut src)) = result {
-                                src.is_open = is_open;
+                            if let Value::Object(_, Some(ref src)) = result {
+                                if src.is_open != is_open {
+                                    let mut new_src = (**src).clone();
+                                    new_src.is_open = is_open;
+                                    if let Value::Object(_, ref mut src_slot) = result {
+                                        *src_slot = Some(std::sync::Arc::new(new_src));
+                                    }
+                                }
                             }
                             Ok(result)
                         } else if let Some(Value::Object(base_map, _)) = base {
@@ -1820,6 +1869,28 @@ impl Scope {
 }
 
 // --- Helpers ---
+
+/// Convert a `package://` URI to an HTTPS download URL.
+fn package_uri_to_url(uri: &str) -> Result<String> {
+    // Format 1: package://pkg.pkl-lang.org/github.com/owner/repo@version#/path.pkl
+    if let Some(rest) = uri.strip_prefix("package://pkg.pkl-lang.org/github.com/")
+        && let Some((repo_ver, fragment)) = rest.split_once('#')
+        && let Some((repo, version)) = repo_ver.split_once('@')
+    {
+        let file_path = fragment.strip_prefix('/').unwrap_or(fragment);
+        return Ok(format!(
+            "https://github.com/{repo}/releases/download/{version}/{file_path}"
+        ));
+    }
+    // Format 2: package://github.com/owner/repo/releases/download/v1.0/name@1.0#/path.pkl
+    if let Some(rest) = uri.strip_prefix("package://github.com/")
+        && let Some((base, fragment)) = rest.split_once('#')
+    {
+        let file_path = fragment.strip_prefix('/').unwrap_or(fragment);
+        return Ok(format!("https://github.com/{base}/{file_path}"));
+    }
+    Err(Error::Eval(format!("unsupported package URI: {uri}")))
+}
 
 fn check_deprecated(annotations: &[Annotation], prop_name: &str) {
     for ann in annotations {

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -324,39 +324,39 @@ impl Evaluator {
         }
 
         // Inject class definitions from amends base into scope so the amending
-        // module can reference them (e.g., `new Step { ... }`), then remove
-        // them from base_obj so they don't appear in the final output.
-        if module.amends.is_some() {
-            // Parse the base module to find its class names
-            if let Some(uri) = &module.amends {
-                let base_source = if !uri.starts_with("pkl:")
-                    && (!uri.contains("://") || uri.starts_with("file://"))
-                {
-                    let amends_path = if let Some(rel) = uri.strip_prefix("file://") {
-                        PathBuf::from(rel)
-                    } else {
-                        let base = path.parent().unwrap_or(Path::new("."));
-                        base.join(uri)
-                    };
-                    std::fs::read_to_string(&amends_path).ok()
+        // module can reference them (e.g., `new Step { ... }`).
+        // We re-parse the base module to find ClassDef entries, then evaluate
+        // them directly (similar to extends handling), because eval_module strips
+        // class definitions from its return value.
+        if let Some(uri) = &module.amends {
+            let base_source = if !uri.starts_with("pkl:")
+                && (!uri.contains("://") || uri.starts_with("file://"))
+            {
+                let amends_path = if let Some(rel) = uri.strip_prefix("file://") {
+                    PathBuf::from(rel)
                 } else {
-                    None
+                    let base = path.parent().unwrap_or(Path::new("."));
+                    base.join(uri)
                 };
-                if let Some(src) = base_source
-                    && let Ok(tokens) = lexer::lex(&src)
-                    && let Ok(base_module) = parser::parse(&tokens)
-                {
-                    for entry in &base_module.body {
-                        if let Entry::ClassDef(name, ..) = entry
-                            && let Some(val) = base_obj.shift_remove(name)
-                        {
-                            scope.set(name.clone(), val);
-                        }
+                std::fs::read_to_string(&amends_path).ok()
+            } else {
+                None
+            };
+            if let Some(src) = base_source
+                && let Ok(tokens) = lexer::lex(&src)
+                && let Ok(base_module) = parser::parse(&tokens)
+            {
+                for entry in &base_module.body {
+                    if let Entry::ClassDef(name, class_mods, parent, body) = entry {
+                        let defaults = self
+                            .eval_class_def(class_mods, parent.as_deref(), body, &scope, depth)
+                            .await?;
+                        scope.set(name.clone(), defaults);
                     }
-                    // Also remove function values from base output
-                    base_obj.retain(|_, v| !matches!(v, Value::Lambda(..)));
                 }
             }
+            // Remove function values from base output (not data)
+            base_obj.retain(|_, v| !matches!(v, Value::Lambda(..)));
         }
 
         // Process extends: load base module, inherit all members and scope
@@ -617,10 +617,6 @@ impl Evaluator {
                     check_deprecated(&prop.annotations, &prop.name);
                     // Skip the `default` property — it's a template, not an output entry
                     if prop.name == "default" && default_template.is_some() {
-                        continue;
-                    }
-                    // Skip Pkl's `output` rendering block — pklr uses Value::to_json()
-                    if prop.name == "output" {
                         continue;
                     }
                     if has_modifier(mods, Modifier::Abstract)

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -430,13 +430,22 @@ impl<'a> Parser<'a> {
                 continue;
             }
             if matches!(self.peek(), TokenKind::KwFunction) {
-                self.skip_declaration();
+                if let Some(entry) = self.try_parse_function_def(Vec::new())? {
+                    entries.push(entry);
+                }
                 continue;
             }
-            // Also skip modifier-prefixed function/typealias declarations
+            // Also handle modifier-prefixed function/typealias declarations
             if self.peek_is_modifier() && self.peek_past_modifiers_is_decl() {
-                self.skip_modifiers();
-                self.skip_declaration();
+                let mods = self.collect_modifiers();
+                if matches!(self.peek(), TokenKind::KwFunction) {
+                    if let Some(entry) = self.try_parse_function_def(mods)? {
+                        entries.push(entry);
+                    }
+                } else {
+                    // typealias — skip as before
+                    self.skip_declaration();
+                }
                 continue;
             }
             if self.at_eof() || matches!(self.peek(), TokenKind::RBrace) {
@@ -571,10 +580,67 @@ impl<'a> Parser<'a> {
         false
     }
 
-    fn skip_modifiers(&mut self) {
-        while self.peek_is_modifier() {
-            self.advance();
+    /// Parse `function name(params...): ReturnType = body` into a Property with Lambda value.
+    /// Returns None if the function body can't be parsed (falls back to skip).
+    fn try_parse_function_def(&mut self, modifiers: Vec<Modifier>) -> Result<Option<Entry>> {
+        let saved_pos = self.pos;
+        let saved_last_line = self.last_line;
+        self.advance(); // consume `function`
+        let name = match self.peek() {
+            TokenKind::Ident(_) => self.expect_ident()?,
+            _ => {
+                // Not a named function — restore and skip
+                self.pos = saved_pos;
+                self.last_line = saved_last_line;
+                self.skip_declaration();
+                return Ok(None);
+            }
+        };
+        // Parse parameter list: (param1: Type, param2: Type, ...)
+        if !matches!(self.peek(), TokenKind::LParen) {
+            self.pos = saved_pos;
+            self.last_line = saved_last_line;
+            self.skip_declaration();
+            return Ok(None);
         }
+        self.advance(); // consume (
+        let mut params = Vec::new();
+        while !matches!(self.peek(), TokenKind::RParen | TokenKind::Eof) {
+            let param_name = self.expect_ident()?;
+            params.push(param_name);
+            // Skip optional type annotation: `: Type`
+            if matches!(self.peek(), TokenKind::Colon) {
+                self.advance();
+                let _ = self.parse_type()?;
+            }
+            if matches!(self.peek(), TokenKind::Comma) {
+                self.advance();
+            }
+        }
+        self.expect(&TokenKind::RParen)?;
+        // Skip optional return type annotation: `: ReturnType`
+        if matches!(self.peek(), TokenKind::Colon) {
+            self.advance();
+            let _ = self.parse_type()?;
+        }
+        // Parse body: `= expr`
+        if !matches!(self.peek(), TokenKind::Equals) {
+            // No body — skip rest
+            self.pos = saved_pos;
+            self.last_line = saved_last_line;
+            self.skip_declaration();
+            return Ok(None);
+        }
+        self.advance(); // consume =
+        let body = self.parse_expr()?;
+        Ok(Some(Entry::Property(Property {
+            name,
+            type_ann: None,
+            value: Some(Expr::Lambda(params, Box::new(body))),
+            body: None,
+            modifiers,
+            annotations: Vec::new(),
+        })))
     }
 
     /// Skip a class, typealias, or function declaration.

--- a/src/value.rs
+++ b/src/value.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use indexmap::IndexMap;
 use serde_json::json;
 
@@ -31,7 +33,7 @@ pub enum Value {
     /// Object (ordered string-keyed map). Represents both pkl objects and
     /// string-keyed Mappings.  The optional [`ObjectSource`] stores the
     /// original entry definitions so late binding works on amendment.
-    Object(IndexMap<String, Value>, Option<Box<ObjectSource>>),
+    Object(IndexMap<String, Value>, Option<Arc<ObjectSource>>),
     /// Listing (ordered list).
     List(Vec<Value>),
     /// Lambda function: param names + body expression + captured scope values

--- a/tests/pkl_features.rs
+++ b/tests/pkl_features.rs
@@ -2705,3 +2705,221 @@ x = new Config {
     assert_eq!(json["x"]["port"], 9090);
     assert_eq!(json["x"]["debug"], true);
 }
+
+// ============================================================
+// Output block handling
+// ============================================================
+
+#[test]
+fn output_block_is_skipped() {
+    let json = eval(
+        r#"
+x = 1
+output {
+    renderer {
+        converters {
+            ["test"] = "hello"
+        }
+    }
+}
+"#,
+    );
+    assert_eq!(json["x"], 1);
+    assert!(
+        json.get("output").is_none(),
+        "output should be skipped, got: {}",
+        serde_json::to_string_pretty(&json).unwrap()
+    );
+}
+
+// ============================================================
+// new Dynamic
+// ============================================================
+
+#[test]
+fn new_dynamic_creates_object() {
+    let json = eval(
+        r#"
+x = new Dynamic {
+    _type = "step"
+    name = "test"
+}
+"#,
+    );
+    assert_eq!(json["x"]["_type"], "step");
+    assert_eq!(json["x"]["name"], "test");
+}
+
+#[test]
+fn new_dynamic_with_spread() {
+    let json = eval(
+        r#"
+base {
+    port = 8080
+}
+x = new Dynamic {
+    _type = "config"
+    ...base
+}
+"#,
+    );
+    assert_eq!(json["x"]["_type"], "config");
+    assert_eq!(json["x"]["port"], 8080);
+}
+
+// ============================================================
+// Class functions
+// ============================================================
+
+#[test]
+fn class_function_basic() {
+    let json = eval(
+        r#"
+class Greeter {
+    name: String = "World"
+    function greet(prefix: String): String = prefix + " " + name
+}
+g = new Greeter {}
+result = g.greet("Hello")
+"#,
+    );
+    assert_eq!(json["result"], "Hello World");
+}
+
+#[test]
+fn class_function_testmaker_pattern() {
+    // First check: does the class itself have checkFail?
+    let json1 = eval(
+        r#"
+class TestMaker {
+    filename: String = "file.txt"
+    function checkFail(contents: String, code: Int): String = "check:" + filename
+}
+local testMaker = new TestMaker {}
+result = testMaker.checkFail("bad", 1)
+"#,
+    );
+    assert_eq!(json1["result"], "check:file.txt");
+
+    // Second check: does it survive property override?
+    let json2 = eval(
+        r#"
+class TestMaker {
+    filename: String = "file.txt"
+    function checkFail(contents: String, code: Int): String = "check:" + filename
+}
+local testMaker = new TestMaker { filename = "main.rs" }
+result = testMaker.checkFail("bad", 1)
+"#,
+    );
+    assert_eq!(json2["result"], "check:main.rs");
+}
+
+#[test]
+fn class_function_with_local() {
+    let json = eval(
+        r#"
+class Calc {
+    base: Int = 10
+    local function helper(x: Int): Int = x + base
+    function compute(x: Int): Int = helper(x)
+}
+c = new Calc {}
+result = c.compute(5)
+"#,
+    );
+    assert_eq!(json["result"], 15);
+}
+
+// ============================================================
+// hk.pkl compatibility
+// ============================================================
+
+#[tokio::test]
+async fn eval_amends_perf() {
+    // Minimal amends test to check performance
+    let dir = std::path::Path::new("/tmp/pklr_test_perf");
+    std::fs::create_dir_all(dir).unwrap();
+    std::fs::write(
+        dir.join("Base.pkl"),
+        r#"
+class Step {
+    glob: (String | List<String>)?
+    check: String?
+    fix: String?
+    check_first: Boolean = true
+    batch: Boolean = false
+}
+class Hook {
+    fix: Boolean?
+    steps: Mapping<String, Step> = new Mapping<String, Step> {}
+}
+hooks: Mapping<String, Hook> = new Mapping<String, Hook> {}
+"#,
+    )
+    .unwrap();
+    std::fs::write(
+        dir.join("test.pkl"),
+        r#"
+amends "Base.pkl"
+hooks = new {
+    ["pre-commit"] {
+        fix = true
+        steps = new {
+            ["lint"] { check = "lint" }
+        }
+    }
+}
+"#,
+    )
+    .unwrap();
+    let path = dir.join("test.pkl");
+    let start = std::time::Instant::now();
+    let val = pklr::eval_to_json(&path).await.unwrap();
+    let elapsed = start.elapsed();
+    eprintln!("eval_amends_perf: {:?}", elapsed);
+    assert!(
+        elapsed.as_secs() < 5,
+        "amends eval took too long: {:?}",
+        elapsed
+    );
+    assert!(val["hooks"]["pre-commit"]["fix"] == true);
+}
+
+#[tokio::test]
+async fn class_function_cross_module() {
+    let dir = std::path::Path::new("/tmp/pklr_test_cross_module");
+    std::fs::create_dir_all(dir).unwrap();
+    std::fs::write(
+        dir.join("helpers.pkl"),
+        r#"
+class TestMaker {
+    filename: String = "file.txt"
+    local function makeTest(runType: String, code: Int): String = runType + ":" + filename
+    function checkFail(contents: String, code: Int): String = makeTest("check", code)
+}
+"#,
+    )
+    .unwrap();
+    std::fs::write(
+        dir.join("main.pkl"),
+        r#"
+import "helpers.pkl"
+local const testMaker = new helpers.TestMaker { filename = "main.rs" }
+result = testMaker.checkFail("bad", 1)
+"#,
+    )
+    .unwrap();
+    let path = dir.join("main.pkl");
+    match pklr::eval_to_json(&path).await {
+        Ok(val) => {
+            assert!(val["result"].is_string());
+            assert!(val["result"].as_str().unwrap().starts_with("check:"));
+        }
+        Err(e) => {
+            // Known limitation: class functions with property overrides across
+            // module boundaries may not resolve correctly during re-evaluation
+            eprintln!("cross-module class function: {}", e);
+        }
+    }
+}

--- a/tests/pkl_features.rs
+++ b/tests/pkl_features.rs
@@ -2886,11 +2886,41 @@ hooks = new {
     assert!(val["hooks"]["pre-commit"]["fix"] == true);
 }
 
-/// Cross-module class functions with property overrides don't resolve correctly
-/// during late-binding re-evaluation: the local function captures scope at class
-/// definition time, so overridden properties aren't visible to the function body.
 #[tokio::test]
-#[ignore]
+async fn class_function_nested_in_new() {
+    // Matches the hk builtin pattern: testMaker.checkFail() inside new Config.Step { tests { ... } }
+    let dir = std::path::Path::new("/tmp/pklr_test_nested");
+    std::fs::create_dir_all(dir).unwrap();
+    std::fs::write(
+        dir.join("helpers.pkl"),
+        r#"
+class TestMaker {
+    filename: String = "file.txt"
+    local function makeTest(runType: String, code: Int): String = runType + ":" + filename
+    function checkFail(contents: String, code: Int): String = makeTest("check", code)
+}
+"#,
+    )
+    .unwrap();
+    std::fs::write(
+        dir.join("main.pkl"),
+        r#"
+import "helpers.pkl"
+local const testMaker = new helpers.TestMaker { filename = "src/main.rs" }
+x {
+    tests {
+        ["check bad file"] = testMaker.checkFail("bad", 1)
+    }
+}
+"#,
+    )
+    .unwrap();
+    let path = dir.join("main.pkl");
+    let val = pklr::eval_to_json(&path).await.unwrap();
+    assert_eq!(val["x"]["tests"]["check bad file"], "check:src/main.rs");
+}
+
+#[tokio::test]
 async fn class_function_cross_module() {
     let dir = std::path::Path::new("/tmp/pklr_test_cross_module");
     std::fs::create_dir_all(dir).unwrap();

--- a/tests/pkl_features.rs
+++ b/tests/pkl_features.rs
@@ -2886,7 +2886,11 @@ hooks = new {
     assert!(val["hooks"]["pre-commit"]["fix"] == true);
 }
 
+/// Cross-module class functions with property overrides don't resolve correctly
+/// during late-binding re-evaluation: the local function captures scope at class
+/// definition time, so overridden properties aren't visible to the function body.
 #[tokio::test]
+#[ignore]
 async fn class_function_cross_module() {
     let dir = std::path::Path::new("/tmp/pklr_test_cross_module");
     std::fs::create_dir_all(dir).unwrap();
@@ -2911,15 +2915,6 @@ result = testMaker.checkFail("bad", 1)
     )
     .unwrap();
     let path = dir.join("main.pkl");
-    match pklr::eval_to_json(&path).await {
-        Ok(val) => {
-            assert!(val["result"].is_string());
-            assert!(val["result"].as_str().unwrap().starts_with("check:"));
-        }
-        Err(e) => {
-            // Known limitation: class functions with property overrides across
-            // module boundaries may not resolve correctly during re-evaluation
-            eprintln!("cross-module class function: {}", e);
-        }
-    }
+    let val = pklr::eval_to_json(&path).await.unwrap();
+    assert_eq!(val["result"], "check:main.rs");
 }


### PR DESCRIPTION
## Summary

- Skip Pkl's `output` rendering block at module level (pklr uses `Value::to_json()`, not Pkl's built-in renderer)
- Parse `function` declarations as `Property` entries with `Lambda` values, enabling class methods like `TestMaker.checkFail()`
- Add explicit `new Dynamic { ... }` handling alongside `Listing`/`Mapping`/`Map`
- Support direct GitHub `package://` URIs (e.g., `package://github.com/jdx/hk/releases/...`)
- Wrap `ObjectSource` in `Arc` for O(1) cloning — fixes quadratic `scope.flatten()` cost that caused 75s+ eval times (now <1s)
- Export class definitions to module scope for cross-module dotted access while excluding them from serialized output
- Evaluate locals, classes, and type aliases in declaration order so locals can reference class definitions
- Inject amends base class definitions into scope so the amending module can instantiate them
- Suppress miette diagnostic false-positive warnings, remove dead code

## Test plan

- [x] `cargo test` — 224 tests pass
- [x] `cargo build` — zero warnings
- [x] `cargo fmt --check` — clean
- [x] New unit tests: `output_block_is_skipped`, `new_dynamic_creates_object`, `new_dynamic_with_spread`, `class_function_basic`, `class_function_with_local`, `class_function_testmaker_pattern`, `eval_amends_perf`, `class_function_cross_module`

🤖 Generated with [Claude Code](https://claude.com/claude-code)