### PR TITLE
feat: expose set_http_client and eval_to_json_with_client

### DIFF
--- a/src/eval.rs
+++ b/src/eval.rs
@@ -48,6 +48,12 @@ impl Evaluator {
         self.base_path = path.to_path_buf();
     }
 
+    /// Set a custom HTTP client for fetching remote imports and packages.
+    /// Use this to configure proxy settings, CA certificates, timeouts, etc.
+    pub fn set_http_client(&mut self, client: reqwest::Client) {
+        self.http_client = client;
+    }
+
     /// Read a resource by URI scheme.
     async fn read_resource(&mut self, uri: &str) -> Result<Value> {
         if let Some(path) = uri.strip_prefix("file://") {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,14 +8,28 @@ pub use error::{Error, Result};
 pub use eval::Evaluator;
 pub use value::Value;
 
+/// Re-export reqwest so consumers can build a Client without a separate dependency.
+pub use reqwest;
+
 use std::path::Path;
 
 /// Evaluate a pkl file and return its contents as a JSON value.
 /// This is the primary entry point for use in tools like hk.
 pub async fn eval_to_json(path: &Path) -> Result<serde_json::Value> {
+    eval_to_json_with_client(path, None).await
+}
+
+/// Evaluate a pkl file with a custom HTTP client for proxy/CA configuration.
+pub async fn eval_to_json_with_client(
+    path: &Path,
+    client: Option<reqwest::Client>,
+) -> Result<serde_json::Value> {
     let source = std::fs::read_to_string(path).map_err(|e| Error::Io(path.to_path_buf(), e))?;
     let mut evaluator = Evaluator::new();
     evaluator.set_base_path(path.parent().unwrap_or(Path::new(".")));
+    if let Some(client) = client {
+        evaluator.set_http_client(client);
+    }
     let value = evaluator.eval_source(&source, path).await?;
     Ok(value.to_json())
 }


### PR DESCRIPTION
## Summary

- Add `Evaluator::set_http_client()` to configure proxy, CA certs, timeouts, etc.
- Add `eval_to_json_with_client(path, client)` convenience function
- Re-export `reqwest` so consumers can build a `Client` without adding reqwest as a separate dependency

This lets hk pass its proxy/CA certificate configuration through to pklr when using the pklr backend.

## Test plan

- [x] `cargo test` -- all 225 tests pass