### PR TITLE
fix: strip inherited class definitions from amends output

### DIFF
--- a/src/eval.rs
+++ b/src/eval.rs
@@ -420,6 +420,10 @@ impl Evaluator {
                             .eval_class_def(class_mods, parent.as_deref(), body, &scope, depth)
                             .await?;
                         scope.set(name.clone(), defaults);
+                        // Remove inherited class definitions from base output —
+                        // they were included at depth > 0 for dotted access but
+                        // should not appear in the amending module's data output.
+                        base_obj.shift_remove(name);
                     }
                 }
             }

--- a/tests/fixtures/base_with_class.pkl
+++ b/tests/fixtures/base_with_class.pkl
@@ -1,0 +1,6 @@
+class Script {
+  linux: String?
+  macos: String?
+}
+
+name = "default"

--- a/tests/pkl_features.rs
+++ b/tests/pkl_features.rs
@@ -949,6 +949,26 @@ name = "override"
     assert_eq!(json["enabled"], true);
 }
 
+#[tokio::test]
+async fn amends_strips_inherited_class_definitions() {
+    let mut ev = pklr::eval::Evaluator::new();
+    let base = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures");
+    ev.set_base_path(&base);
+    let src = r#"
+amends "base_with_class.pkl"
+name = "override"
+"#;
+    let path = base.join("test_amends_class.pkl");
+    let val = ev.eval_source(src, &path).await.unwrap();
+    let json = val.to_json();
+    assert_eq!(json["name"], "override");
+    // Class definitions from the amended base should NOT appear in the output
+    assert!(
+        json.get("Script").is_none(),
+        "inherited class 'Script' should be stripped from output, got: {json}"
+    );
+}
+
 // ============================================================
 // Circular imports
 // ============================================================


### PR DESCRIPTION
## Summary
- When a module amends a base that defines classes (e.g., `class Script`), the class values were included in the JSON output at the top level
- This broke consumers using serde's `deny_unknown_fields` (e.g., hk's `Config` struct)
- Fix: remove inherited class definitions from `base_obj` during the amends class injection pass

## Test plan
- [x] Added `amends_strips_inherited_class_definitions` test
- [x] All 226 existing tests pass

*This PR was generated by Claude Code.*