### PR TITLE
chore: release v0.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.2](https://github.com/jdx/pklr/compare/v0.2.1...v0.2.2) - 2026-03-24
+
+### Added
+
+- add HTTP URL rewrite support ([#46](https://github.com/jdx/pklr/pull/46))
+
+### Fixed
+
+- strip inherited class definitions from extends and remote amends ([#48](https://github.com/jdx/pklr/pull/48))
+- strip inherited class definitions from amends output ([#45](https://github.com/jdx/pklr/pull/45))
+
 ## [0.2.1](https://github.com/jdx/pklr/compare/v0.2.0...v0.2.1) - 2026-03-23
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -557,7 +557,7 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pklr"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "async-recursion",
  "indexmap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "pklr"
-version     = "0.2.1"
+version     = "0.2.2"
 edition      = "2024"
 rust-version = "1.88"
 description = "Pure Rust pkl configuration language parser and evaluator"


### PR DESCRIPTION



## 🤖 New release

* `pklr`: 0.2.1 -> 0.2.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.2](https://github.com/jdx/pklr/compare/v0.2.1...v0.2.2) - 2026-03-24

### Added

- add HTTP URL rewrite support ([#46](https://github.com/jdx/pklr/pull/46))

### Fixed

- strip inherited class definitions from extends and remote amends ([#48](https://github.com/jdx/pklr/pull/48))
- strip inherited class definitions from amends output ([#45](https://github.com/jdx/pklr/pull/45))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).