### PR TITLE
feat: implement output.renderer.converters support

### DIFF
--- a/src/eval.rs
+++ b/src/eval.rs
@@ -196,6 +196,7 @@ impl Evaluator {
     }
 
     pub async fn eval_source(&mut self, source: &str, path: &Path) -> Result<Value> {
+        self.converters.clear();
         // Seed import cache for the entry file so circular back-references work
         if let Ok(canonical) = path.canonicalize() {
             self.import_cache
@@ -2031,7 +2032,6 @@ impl Evaluator {
     /// Looks for the structure: `output { renderer { converters { [Type] = (x) -> ... } } }`.
     /// Converter keys are type identifiers (e.g., `[Regex]`), which we preserve as
     /// strings for matching against `ObjectSource.type_name`.
-    #[async_recursion(?Send)]
     async fn extract_converters_from_ast(
         &mut self,
         output_prop: &Property,
@@ -2041,44 +2041,43 @@ impl Evaluator {
         let Some(output_body) = &output_prop.body else {
             return;
         };
-        // Find `renderer { ... }` inside output
-        for entry in output_body {
-            let Entry::Property(renderer_prop) = entry else {
-                continue;
-            };
-            if renderer_prop.name != "renderer" {
-                continue;
+        // Find `renderer { converters { ... } }` inside output
+        let Some(renderer_body) = output_body.iter().find_map(|entry| {
+            if let Entry::Property(p) = entry
+                && p.name == "renderer"
+            {
+                p.body.as_ref()
+            } else {
+                None
             }
-            let Some(renderer_body) = &renderer_prop.body else {
-                continue;
-            };
-            // Find `converters { ... }` inside renderer
-            for rentry in renderer_body {
-                let Entry::Property(converters_prop) = rentry else {
-                    continue;
+        }) else {
+            return;
+        };
+        let Some(converters_body) = renderer_body.iter().find_map(|entry| {
+            if let Entry::Property(p) = entry
+                && p.name == "converters"
+            {
+                p.body.as_ref()
+            } else {
+                None
+            }
+        }) else {
+            return;
+        };
+        // Each converter is a DynProperty: [ClassName] = (x) -> expr
+        for centry in converters_body {
+            if let Entry::DynProperty(key_expr, val_expr) = centry {
+                // Extract the class name from the key expression
+                let class_name = match key_expr {
+                    Expr::Ident(name) => name.clone(),
+                    Expr::Field(_, name) => name.clone(),
+                    Expr::String(s) => s.clone(),
+                    _ => continue,
                 };
-                if converters_prop.name != "converters" {
-                    continue;
-                }
-                let Some(converters_body) = &converters_prop.body else {
-                    continue;
-                };
-                // Each converter is a DynProperty: [ClassName] = (x) -> expr
-                for centry in converters_body {
-                    if let Entry::DynProperty(key_expr, val_expr) = centry {
-                        // Extract the class name from the key expression
-                        let class_name = match key_expr {
-                            Expr::Ident(name) => name.clone(),
-                            Expr::Field(_, name) => name.clone(),
-                            Expr::String(s) => s.clone(),
-                            _ => continue,
-                        };
-                        // Evaluate the lambda value
-                        if let Ok(lambda) = self.eval_expr(val_expr, scope, depth).await {
-                            if matches!(lambda, Value::Lambda(..)) {
-                                self.converters.push((class_name, lambda));
-                            }
-                        }
+                // Evaluate the lambda value
+                if let Ok(lambda) = self.eval_expr(val_expr, scope, depth).await {
+                    if matches!(lambda, Value::Lambda(..)) {
+                        self.converters.push((class_name, lambda));
                     }
                 }
             }
@@ -2110,11 +2109,15 @@ impl Evaluator {
 
                 if let Some(tn) = type_name {
                     for (conv_name, lambda) in converters {
-                        // Match against the last component of the type name
-                        // (e.g., "Step" matches both "Step" and "Config.Step")
+                        // Match exact name, or as a dotted suffix
+                        // (e.g., converter "Step" matches type "Step" or "Config.Step")
                         let matches = conv_name == tn
-                            || tn.ends_with(&format!(".{conv_name}"))
-                            || conv_name.ends_with(&format!(".{tn}"));
+                            || (tn.len() > conv_name.len()
+                                && tn.ends_with(conv_name.as_str())
+                                && tn.as_bytes()[tn.len() - conv_name.len() - 1] == b'.')
+                            || (conv_name.len() > tn.len()
+                                && conv_name.ends_with(tn)
+                                && conv_name.as_bytes()[conv_name.len() - tn.len() - 1] == b'.');
                         if matches {
                             if let Value::Lambda(params, body, captured) = lambda {
                                 let mut call_scope = Scope::default();

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -27,6 +27,9 @@ pub struct Evaluator {
     /// HTTP URL rewrite rules (source_prefix → target_prefix).
     /// Longest matching prefix wins.
     http_rewrites: Vec<(String, String)>,
+    /// Converters extracted from `output.renderer.converters`.
+    /// Each entry maps a class name to a converter lambda.
+    converters: Vec<(String, Value)>,
 }
 
 impl Default for Evaluator {
@@ -39,6 +42,7 @@ impl Default for Evaluator {
             http_client: reqwest::Client::new(),
             package_dirs: HashMap::new(),
             http_rewrites: Vec::new(),
+            converters: Vec::new(),
         }
     }
 }
@@ -628,8 +632,13 @@ impl Evaluator {
                     continue; // already collected
                 }
                 check_deprecated(&prop.annotations, &prop.name);
-                // Skip Pkl's `output` rendering block — pklr uses Value::to_json()
+                // Extract renderer converters from the `output` block AST,
+                // then skip it (it's not included in the output).
                 if prop.name == "output" {
+                    if depth == 0 {
+                        self.extract_converters_from_ast(prop, &scope, depth)
+                            .await;
+                    }
                     continue;
                 }
                 // abstract/external properties must have a value (or be overridden)
@@ -857,6 +866,7 @@ impl Evaluator {
             entries: entries.to_vec(),
             scope: child_scope.flatten(),
             is_open: true, // default: allow new properties
+            type_name: None,
         };
         Ok(Value::Object(map, Some(std::sync::Arc::new(source))))
     }
@@ -1256,16 +1266,26 @@ impl Evaluator {
                                     depth,
                                 )
                                 .await?;
-                            // Preserve the base class's is_open flag so further amendments
-                            // of non-open classes continue to enforce the constraint.
-                            if let Value::Object(_, Some(ref src)) = result
-                                && src.is_open != is_open
-                            {
-                                let mut new_src = (**src).clone();
-                                new_src.is_open = is_open;
-                                if let Value::Object(_, ref mut src_slot) = result {
-                                    *src_slot = Some(std::sync::Arc::new(new_src));
-                                }
+                            // Preserve the base class's is_open flag and tag the
+                            // type_name so output.renderer.converters can match it.
+                            if let Value::Object(_, ref mut src_slot) = result {
+                                let tn = type_name.clone();
+                                let new_src = if let Some(src) = src_slot.as_ref() {
+                                    let mut s = (**src).clone();
+                                    if s.is_open != is_open {
+                                        s.is_open = is_open;
+                                    }
+                                    s.type_name = tn;
+                                    s
+                                } else {
+                                    ObjectSource {
+                                        entries: Vec::new(),
+                                        scope: IndexMap::new(),
+                                        is_open,
+                                        type_name: tn,
+                                    }
+                                };
+                                *src_slot = Some(std::sync::Arc::new(new_src));
                             }
                             Ok(result)
                         } else if let Some(Value::Object(base_map, _)) = base {
@@ -1275,7 +1295,13 @@ impl Evaluator {
                             if let Value::Object(overlay_map, _) = overlay {
                                 merged.extend(overlay_map);
                             }
-                            Ok(Value::Object(merged, None))
+                            let src = ObjectSource {
+                                entries: Vec::new(),
+                                scope: IndexMap::new(),
+                                is_open: true,
+                                type_name: type_name.clone(),
+                            };
+                            Ok(Value::Object(merged, Some(std::sync::Arc::new(src))))
                         } else {
                             self.eval_entries(entries, scope, depth + 1).await
                         }
@@ -1999,6 +2025,141 @@ impl Evaluator {
             }
         }
         Ok(())
+    }
+
+    /// Walk the AST of the `output` property to extract converter lambdas.
+    /// Looks for the structure: `output { renderer { converters { [Type] = (x) -> ... } } }`.
+    /// Converter keys are type identifiers (e.g., `[Regex]`), which we preserve as
+    /// strings for matching against `ObjectSource.type_name`.
+    #[async_recursion(?Send)]
+    async fn extract_converters_from_ast(
+        &mut self,
+        output_prop: &Property,
+        scope: &Scope,
+        depth: usize,
+    ) {
+        let Some(output_body) = &output_prop.body else {
+            return;
+        };
+        // Find `renderer { ... }` inside output
+        for entry in output_body {
+            let Entry::Property(renderer_prop) = entry else {
+                continue;
+            };
+            if renderer_prop.name != "renderer" {
+                continue;
+            }
+            let Some(renderer_body) = &renderer_prop.body else {
+                continue;
+            };
+            // Find `converters { ... }` inside renderer
+            for rentry in renderer_body {
+                let Entry::Property(converters_prop) = rentry else {
+                    continue;
+                };
+                if converters_prop.name != "converters" {
+                    continue;
+                }
+                let Some(converters_body) = &converters_prop.body else {
+                    continue;
+                };
+                // Each converter is a DynProperty: [ClassName] = (x) -> expr
+                for centry in converters_body {
+                    if let Entry::DynProperty(key_expr, val_expr) = centry {
+                        // Extract the class name from the key expression
+                        let class_name = match key_expr {
+                            Expr::Ident(name) => name.clone(),
+                            Expr::Field(_, name) => name.clone(),
+                            Expr::String(s) => s.clone(),
+                            _ => continue,
+                        };
+                        // Evaluate the lambda value
+                        if let Ok(lambda) = self.eval_expr(val_expr, scope, depth).await {
+                            if matches!(lambda, Value::Lambda(..)) {
+                                self.converters.push((class_name, lambda));
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /// Apply `output.renderer.converters` to a value tree.
+    /// Walks recursively, replacing typed objects with their converter output.
+    pub async fn apply_converters(&mut self, value: Value) -> Result<Value> {
+        if self.converters.is_empty() {
+            return Ok(value);
+        }
+        let converters = self.converters.clone();
+        self.apply_converters_recursive(value, &converters).await
+    }
+
+    #[async_recursion(?Send)]
+    async fn apply_converters_recursive(
+        &mut self,
+        value: Value,
+        converters: &[(String, Value)],
+    ) -> Result<Value> {
+        match value {
+            Value::Object(map, ref src) => {
+                // Check if this object has a type_name that matches a converter
+                let type_name = src
+                    .as_ref()
+                    .and_then(|s| s.type_name.as_deref());
+
+                if let Some(tn) = type_name {
+                    for (conv_name, lambda) in converters {
+                        // Match against the last component of the type name
+                        // (e.g., "Step" matches both "Step" and "Config.Step")
+                        let matches = conv_name == tn
+                            || tn.ends_with(&format!(".{conv_name}"))
+                            || conv_name.ends_with(&format!(".{tn}"));
+                        if matches {
+                            if let Value::Lambda(params, body, captured) = lambda {
+                                let mut call_scope = Scope::default();
+                                for (k, v) in captured {
+                                    call_scope.set(k.clone(), v.clone());
+                                }
+                                // Bind the object as the first parameter
+                                if let Some(param) = params.first() {
+                                    call_scope.set(
+                                        param.clone(),
+                                        Value::Object(map.clone(), src.clone()),
+                                    );
+                                }
+                                let result =
+                                    self.eval_expr(body, &call_scope, 0).await?;
+                                // Recursively apply converters to the result
+                                return self
+                                    .apply_converters_recursive(result, converters)
+                                    .await;
+                            }
+                        }
+                    }
+                }
+
+                // No converter matched — recurse into children
+                let mut new_map = IndexMap::new();
+                for (k, v) in map {
+                    new_map.insert(
+                        k,
+                        self.apply_converters_recursive(v, converters).await?,
+                    );
+                }
+                Ok(Value::Object(new_map, src.clone()))
+            }
+            Value::List(items) => {
+                let mut new_items = Vec::with_capacity(items.len());
+                for item in items {
+                    new_items.push(
+                        self.apply_converters_recursive(item, converters).await?,
+                    );
+                }
+                Ok(Value::List(new_items))
+            }
+            other => Ok(other),
+        }
     }
 }
 

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -637,8 +637,7 @@ impl Evaluator {
                 // then skip it (it's not included in the output).
                 if prop.name == "output" {
                     if depth == 0 {
-                        self.extract_converters_from_ast(prop, &scope, depth)
-                            .await;
+                        self.extract_converters_from_ast(prop, &scope, depth).await;
                     }
                     continue;
                 }
@@ -2075,10 +2074,10 @@ impl Evaluator {
                     _ => continue,
                 };
                 // Evaluate the lambda value
-                if let Ok(lambda) = self.eval_expr(val_expr, scope, depth).await {
-                    if matches!(lambda, Value::Lambda(..)) {
-                        self.converters.push((class_name, lambda));
-                    }
+                if let Ok(lambda) = self.eval_expr(val_expr, scope, depth).await
+                    && matches!(lambda, Value::Lambda(..))
+                {
+                    self.converters.push((class_name, lambda));
                 }
             }
         }
@@ -2103,9 +2102,7 @@ impl Evaluator {
         match value {
             Value::Object(map, ref src) => {
                 // Check if this object has a type_name that matches a converter
-                let type_name = src
-                    .as_ref()
-                    .and_then(|s| s.type_name.as_deref());
+                let type_name = src.as_ref().and_then(|s| s.type_name.as_deref());
 
                 if let Some(tn) = type_name {
                     for (conv_name, lambda) in converters {
@@ -2118,26 +2115,19 @@ impl Evaluator {
                             || (conv_name.len() > tn.len()
                                 && conv_name.ends_with(tn)
                                 && conv_name.as_bytes()[conv_name.len() - tn.len() - 1] == b'.');
-                        if matches {
-                            if let Value::Lambda(params, body, captured) = lambda {
-                                let mut call_scope = Scope::default();
-                                for (k, v) in captured {
-                                    call_scope.set(k.clone(), v.clone());
-                                }
-                                // Bind the object as the first parameter
-                                if let Some(param) = params.first() {
-                                    call_scope.set(
-                                        param.clone(),
-                                        Value::Object(map.clone(), src.clone()),
-                                    );
-                                }
-                                let result =
-                                    self.eval_expr(body, &call_scope, 0).await?;
-                                // Recursively apply converters to the result
-                                return self
-                                    .apply_converters_recursive(result, converters)
-                                    .await;
+                        if matches && let Value::Lambda(params, body, captured) = lambda {
+                            let mut call_scope = Scope::default();
+                            for (k, v) in captured {
+                                call_scope.set(k.clone(), v.clone());
                             }
+                            // Bind the object as the first parameter
+                            if let Some(param) = params.first() {
+                                call_scope
+                                    .set(param.clone(), Value::Object(map.clone(), src.clone()));
+                            }
+                            let result = self.eval_expr(body, &call_scope, 0).await?;
+                            // Recursively apply converters to the result
+                            return self.apply_converters_recursive(result, converters).await;
                         }
                     }
                 }
@@ -2145,19 +2135,14 @@ impl Evaluator {
                 // No converter matched — recurse into children
                 let mut new_map = IndexMap::new();
                 for (k, v) in map {
-                    new_map.insert(
-                        k,
-                        self.apply_converters_recursive(v, converters).await?,
-                    );
+                    new_map.insert(k, self.apply_converters_recursive(v, converters).await?);
                 }
                 Ok(Value::Object(new_map, src.clone()))
             }
             Value::List(items) => {
                 let mut new_items = Vec::with_capacity(items.len());
                 for item in items {
-                    new_items.push(
-                        self.apply_converters_recursive(item, converters).await?,
-                    );
+                    new_items.push(self.apply_converters_recursive(item, converters).await?);
                 }
                 Ok(Value::List(new_items))
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,6 +59,7 @@ pub async fn eval_to_json_with_options(
         evaluator.set_http_rewrites(&options.http_rewrites);
     }
     let value = evaluator.eval_source(&source, path).await?;
+    let value = evaluator.apply_converters(value).await?;
     Ok(value.to_json())
 }
 

--- a/src/value.rs
+++ b/src/value.rs
@@ -15,6 +15,9 @@ pub struct ObjectSource {
     pub scope: IndexMap<String, Value>,
     /// Whether the class was declared `open` (allows adding new properties)
     pub is_open: bool,
+    /// The pkl class name this object was instantiated from (e.g., "Step", "Group").
+    /// Used by `output.renderer.converters` to apply type-specific transforms.
+    pub type_name: Option<String>,
 }
 
 /// A pkl runtime value.

--- a/tests/pkl_features.rs
+++ b/tests/pkl_features.rs
@@ -15,6 +15,18 @@ fn eval(src: &str) -> serde_json::Value {
     })
 }
 
+/// Like eval(), but also applies output.renderer.converters (full pipeline).
+fn eval_with_converters(src: &str) -> serde_json::Value {
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    rt.block_on(async {
+        let mut ev = Evaluator::new();
+        let path = std::path::Path::new("test.pkl");
+        let val = ev.eval_source(src, path).await.unwrap();
+        let val = ev.apply_converters(val).await.unwrap();
+        val.to_json()
+    })
+}
+
 fn eval_fails(src: &str) -> String {
     let rt = tokio::runtime::Runtime::new().unwrap();
     rt.block_on(async {
@@ -3022,4 +3034,157 @@ fn rewrite_url_no_rules_is_identity() {
         ev.rewrite_url("https://example.com/foo.pkl"),
         "https://example.com/foo.pkl"
     );
+}
+
+// ============================================================
+// output.renderer.converters
+// ============================================================
+
+#[test]
+fn converter_injects_type_tag() {
+    let json = eval_with_converters(
+        r#"
+class Step {
+    check: String = ""
+}
+
+output {
+    renderer {
+        converters {
+            [Step] = (s) -> new Dynamic {
+                _type = "step"
+                ...s.toMap().toDynamic()
+            }
+        }
+    }
+}
+
+myStep = new Step {
+    check = "cargo test"
+}
+"#,
+    );
+    assert_eq!(json["myStep"]["_type"], "step");
+    assert_eq!(json["myStep"]["check"], "cargo test");
+}
+
+#[test]
+fn converter_coerces_values() {
+    let json = eval_with_converters(
+        r#"
+class Step {
+    depends: String|List<String> = ""
+    stash: Boolean|String = false
+}
+
+output {
+    renderer {
+        converters {
+            [Step] = (s) -> new Dynamic {
+                _type = "step"
+                ...s
+                    .toMap()
+                    .mapValues((k, v) ->
+                        if (k == "depends" && v is String)
+                            List(v)
+                        else if (k == "stash" && v is Boolean)
+                            if (v) "git" else "none"
+                        else
+                            v
+                    )
+                    .toDynamic()
+            }
+        }
+    }
+}
+
+myStep = new Step {
+    depends = "other"
+    stash = true
+}
+"#,
+    );
+    assert_eq!(json["myStep"]["_type"], "step");
+    assert_eq!(json["myStep"]["depends"], serde_json::json!(["other"]));
+    assert_eq!(json["myStep"]["stash"], "git");
+}
+
+#[test]
+fn converter_multiple_types() {
+    let json = eval_with_converters(
+        r#"
+class Group {
+    steps: Mapping<String, Step> = new Mapping<String, Step> {}
+}
+
+class Step {
+    check: String = ""
+}
+
+output {
+    renderer {
+        converters {
+            [Group] = (g) -> new Dynamic {
+                _type = "group"
+                ...g.toDynamic()
+            }
+            [Step] = (s) -> new Dynamic {
+                _type = "step"
+                ...s.toDynamic()
+            }
+        }
+    }
+}
+
+myGroup = new Group {
+    steps {
+        ["lint"] = new Step {
+            check = "eslint"
+        }
+    }
+}
+"#,
+    );
+    assert_eq!(json["myGroup"]["_type"], "group");
+    assert_eq!(json["myGroup"]["steps"]["lint"]["_type"], "step");
+    assert_eq!(json["myGroup"]["steps"]["lint"]["check"], "eslint");
+}
+
+#[test]
+fn converter_no_converters_is_noop() {
+    let json = eval_with_converters(
+        r#"
+x = 1
+y = "hello"
+"#,
+    );
+    assert_eq!(json["x"], 1);
+    assert_eq!(json["y"], "hello");
+}
+
+#[test]
+fn converter_output_not_in_result() {
+    let json = eval_with_converters(
+        r#"
+class Foo {
+    x: Int = 0
+}
+
+output {
+    renderer {
+        converters {
+            [Foo] = (f) -> new Dynamic {
+                _type = "foo"
+                ...f.toDynamic()
+            }
+        }
+    }
+}
+
+item = new Foo { x = 42 }
+"#,
+    );
+    assert!(json.get("output").is_none());
+    assert_eq!(json["item"]["_type"], "foo");
+    assert_eq!(json["item"]["x"], 42);
 }


### PR DESCRIPTION
## Summary

pklr previously skipped pkl's `output` block entirely, which meant converter functions were never applied. This caused consumers like hk to need [post-processing workarounds](https://github.com/jdx/hk/pull/769) (`pklr_normalize_step_or_group`) to normalize the JSON output.

This PR implements `output.renderer.converters` support:

- Track which pkl class each object was instantiated from via `ObjectSource.type_name`
- Parse the `output.renderer.converters` block from the AST and evaluate converter lambdas
- Add `Evaluator::apply_converters()` which recursively walks the value tree and applies matching converter functions
- Call `apply_converters()` in `eval_to_json_with_options()` before serializing to JSON

This enables pkl files like hk's `Config.pkl` to use converters for:
- Type discrimination (`_type` tags for serde tagged enums)
- Value coercion (string → array, bool → string)
- Custom serialization (Regex objects)

Without this, hk needed ~100 lines of Rust to replicate what pkl's converters do natively.

## Test plan

- [x] All 229 existing tests pass unchanged
- [x] 5 new tests covering converter functionality:
  - `converter_injects_type_tag` — basic _type injection
  - `converter_coerces_values` — string→array and bool→string coercion
  - `converter_multiple_types` — Group + Step converters with nesting
  - `converter_no_converters_is_noop` — no converters = unchanged output
  - `converter_output_not_in_result` — output block excluded from JSON

*This comment was generated by Claude Code.*