### PR TITLE
fix: inject _type field in JSON output for typed class instances

### DIFF
--- a/src/eval.rs
+++ b/src/eval.rs
@@ -492,7 +492,7 @@ impl Evaluator {
                 for entry in &base_module.body {
                     if let Entry::ClassDef(name, class_mods, parent, body) = entry {
                         let defaults = self
-                            .eval_class_def(class_mods, parent.as_deref(), body, &scope, depth)
+                            .eval_class_def(name, class_mods, parent.as_deref(), body, &scope, depth)
                             .await?;
                         scope.set(name.clone(), defaults);
                         // Remove inherited class definitions from base output —
@@ -535,6 +535,7 @@ impl Evaluator {
                             Entry::ClassDef(cls_name, cls_mods, parent, body) => {
                                 let defaults = self
                                     .eval_class_def(
+                                        cls_name,
                                         cls_mods,
                                         parent.as_deref(),
                                         body,
@@ -566,7 +567,7 @@ impl Evaluator {
                 for entry in &ext_module.body {
                     if let Entry::ClassDef(cls_name, cls_mods, parent, body) = entry {
                         let defaults = self
-                            .eval_class_def(cls_mods, parent.as_deref(), body, &scope, depth)
+                            .eval_class_def(cls_name, cls_mods, parent.as_deref(), body, &scope, depth)
                             .await?;
                         scope.set(cls_name.clone(), defaults);
                         base_obj.shift_remove(cls_name);
@@ -589,7 +590,7 @@ impl Evaluator {
                 }
                 Entry::ClassDef(name, class_mods, parent, body) => {
                     let defaults = self
-                        .eval_class_def(class_mods, parent.as_deref(), body, &scope, depth)
+                        .eval_class_def(name, class_mods, parent.as_deref(), body, &scope, depth)
                         .await?;
                     scope.set(name.clone(), defaults);
                 }
@@ -748,7 +749,7 @@ impl Evaluator {
                 }
                 Entry::ClassDef(name, class_mods, parent, body) => {
                     let defaults = self
-                        .eval_class_def(class_mods, parent.as_deref(), body, &child_scope, depth)
+                        .eval_class_def(name, class_mods, parent.as_deref(), body, &child_scope, depth)
                         .await?;
                     child_scope.set(name.clone(), defaults);
                 }
@@ -857,6 +858,7 @@ impl Evaluator {
             entries: entries.to_vec(),
             scope: child_scope.flatten(),
             is_open: true, // default: allow new properties
+            class_name: None,
         };
         Ok(Value::Object(map, Some(std::sync::Arc::new(source))))
     }
@@ -869,6 +871,7 @@ impl Evaluator {
     #[async_recursion(?Send)]
     async fn eval_class_def(
         &mut self,
+        class_name: &str,
         class_mods: &[Modifier],
         parent_name: Option<&str>,
         body: &[Entry],
@@ -928,12 +931,21 @@ impl Evaluator {
             Ok(child_defaults)
         }
         .map(|val| {
-            // Set is_open flag on the result's ObjectSource
+            // Set is_open flag and class_name on the result's ObjectSource
             let is_open = has_modifier(class_mods, Modifier::Open);
             if let Value::Object(map, Some(src)) = val {
                 let mut new_src = (*src).clone();
                 new_src.is_open = is_open;
+                new_src.class_name = Some(class_name.to_string());
                 Value::Object(map, Some(std::sync::Arc::new(new_src)))
+            } else if let Value::Object(map, None) = val {
+                let src = ObjectSource {
+                    entries: vec![],
+                    scope: IndexMap::new(),
+                    is_open,
+                    class_name: Some(class_name.to_string()),
+                };
+                Value::Object(map, Some(std::sync::Arc::new(src)))
             } else {
                 val
             }
@@ -1246,6 +1258,7 @@ impl Evaluator {
                                 }
                             }
                             let is_open = base_src.is_open;
+                            let class_name = base_src.class_name.clone();
                             // Late binding: re-evaluate merged base + overlay entries
                             let mut result = self
                                 .eval_amended_object(
@@ -1256,15 +1269,17 @@ impl Evaluator {
                                     depth,
                                 )
                                 .await?;
-                            // Preserve the base class's is_open flag so further amendments
-                            // of non-open classes continue to enforce the constraint.
-                            if let Value::Object(_, Some(ref src)) = result
-                                && src.is_open != is_open
-                            {
-                                let mut new_src = (**src).clone();
-                                new_src.is_open = is_open;
-                                if let Value::Object(_, ref mut src_slot) = result {
-                                    *src_slot = Some(std::sync::Arc::new(new_src));
+                            // Preserve the base class's is_open flag and class_name
+                            // so further amendments continue to enforce constraints
+                            // and typed objects get _type in JSON output.
+                            if let Value::Object(_, Some(ref src)) = result {
+                                if src.is_open != is_open || src.class_name != class_name {
+                                    let mut new_src = (**src).clone();
+                                    new_src.is_open = is_open;
+                                    new_src.class_name = class_name;
+                                    if let Value::Object(_, ref mut src_slot) = result {
+                                        *src_slot = Some(std::sync::Arc::new(new_src));
+                                    }
                                 }
                             }
                             Ok(result)

--- a/src/value.rs
+++ b/src/value.rs
@@ -15,6 +15,9 @@ pub struct ObjectSource {
     pub scope: IndexMap<String, Value>,
     /// Whether the class was declared `open` (allows adding new properties)
     pub is_open: bool,
+    /// The class name this object was instantiated from (e.g., "Step", "Group").
+    /// Used to inject `_type` in JSON output, matching pkl's output converter behavior.
+    pub class_name: Option<String>,
 }
 
 /// A pkl runtime value.
@@ -48,8 +51,19 @@ impl Value {
             Value::Int(n) => json!(n),
             Value::Float(f) => json!(f),
             Value::String(s) => json!(s),
-            Value::Object(map, _) => {
+            Value::Object(map, src) => {
                 let mut obj = serde_json::Map::new();
+                // Inject _type for typed objects (instances of user-defined classes),
+                // matching pkl's output converter convention.
+                if let Some(s) = src
+                    && let Some(ref name) = s.class_name
+                    && !map.contains_key("_type")
+                {
+                    obj.insert(
+                        "_type".to_string(),
+                        json!(name.to_ascii_lowercase()),
+                    );
+                }
                 for (k, v) in map {
                     obj.insert(k.clone(), v.to_json());
                 }

--- a/tests/pkl_features.rs
+++ b/tests/pkl_features.rs
@@ -2806,6 +2806,62 @@ x = new Dynamic {
 }
 
 // ============================================================
+// Class _type injection
+// ============================================================
+
+#[test]
+fn class_instance_gets_type_in_json() {
+    let json = eval(
+        r#"
+class Step {
+    check: String = ""
+}
+x = new Step {
+    check = "echo ok"
+}
+"#,
+    );
+    assert_eq!(json["x"]["_type"], "step");
+    assert_eq!(json["x"]["check"], "echo ok");
+}
+
+#[test]
+fn class_instance_explicit_type_not_overwritten() {
+    let json = eval(
+        r#"
+class MyClass {
+    _type: String = "custom"
+    name: String = ""
+}
+x = new MyClass {
+    name = "test"
+}
+"#,
+    );
+    assert_eq!(json["x"]["_type"], "custom");
+}
+
+#[test]
+fn class_extends_gets_child_type() {
+    let json = eval(
+        r#"
+class Base {
+    name: String = ""
+}
+class Child extends Base {
+    extra: String = ""
+}
+x = new Child {
+    name = "test"
+    extra = "val"
+}
+"#,
+    );
+    assert_eq!(json["x"]["_type"], "child");
+    assert_eq!(json["x"]["name"], "test");
+}
+
+// ============================================================
 // Class functions
 // ============================================================
 


### PR DESCRIPTION
## Summary
- Track class names on `ObjectSource` and inject lowercase `_type` field in JSON output for instances of user-defined classes
- Fixes `missing field '_type'` deserialization errors when pklr is used as the pkl backend in hk (see https://github.com/jdx/hk/pull/769)
- Explicit `_type` values set in pkl source are preserved (not overwritten)

## Test plan
- [x] Added `class_instance_gets_type_in_json` test - verifies `_type` is injected
- [x] Added `class_instance_explicit_type_not_overwritten` test - verifies explicit `_type` is preserved
- [x] Added `class_extends_gets_child_type` test - verifies child class name is used
- [x] All 232 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)