### PR TITLE
fix: extract converters from amends/extends base modules

### DIFF
--- a/src/eval.rs
+++ b/src/eval.rs
@@ -2185,7 +2185,11 @@ impl Evaluator {
                             iter_scope.set(kv.clone(), k);
                         }
                         self.eval_mapping_entries_with_type_default(
-                            &fgen.body, &iter_scope, depth + 1, map, type_default,
+                            &fgen.body,
+                            &iter_scope,
+                            depth + 1,
+                            map,
+                            type_default,
                         )
                         .await?;
                     }

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -2176,44 +2176,6 @@ impl Evaluator {
                         map.extend(m);
                     }
                 }
-                _ => {}
-            }
-        }
-        Ok(())
-    }
-
-    #[async_recursion(?Send)]
-    async fn eval_mapping_entries(
-        &mut self,
-        entries: &[crate::parser::Entry],
-        scope: &Scope,
-        depth: usize,
-        map: &mut IndexMap<String, Value>,
-    ) -> Result<()> {
-        let default_template = self.find_default_template(entries, scope, depth).await?;
-
-        for entry in entries {
-            match entry {
-                Entry::DynProperty(key_expr, val_expr) => {
-                    let key = self.eval_expr(key_expr, scope, depth + 1).await?;
-                    let mut val = self.eval_expr(val_expr, scope, depth + 1).await?;
-                    if let Some(ref tpl) = default_template {
-                        val = merge_values(tpl.clone(), val);
-                    }
-                    map.insert(value_to_key(&key)?, val);
-                }
-                Entry::Property(prop) if has_modifier(&prop.modifiers, Modifier::Local) => {
-                    // skip locals in mapping
-                }
-                Entry::Property(prop) if prop.name == "default" && default_template.is_some() => {
-                    // skip default — it's a template
-                }
-                Entry::Spread(e) => {
-                    let v = self.eval_expr(e, scope, depth + 1).await?;
-                    if let Value::Object(m, _) = v {
-                        map.extend(m);
-                    }
-                }
                 Entry::ForGenerator(fgen) => {
                     let collection = self.eval_expr(&fgen.collection, scope, depth + 1).await?;
                     for (k, v) in collection_to_items(collection) {
@@ -2222,8 +2184,10 @@ impl Evaluator {
                         if let Some(kv) = &fgen.key_var {
                             iter_scope.set(kv.clone(), k);
                         }
-                        self.eval_mapping_entries(&fgen.body, &iter_scope, depth + 1, map)
-                            .await?;
+                        self.eval_mapping_entries_with_type_default(
+                            &fgen.body, &iter_scope, depth + 1, map, type_default,
+                        )
+                        .await?;
                     }
                 }
                 _ => {}

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -505,6 +505,16 @@ impl Evaluator {
                         // should not appear in the amending module's data output.
                         base_obj.shift_remove(name);
                     }
+                    // Extract converters from the base module's output block
+                    // (the amending module inherits them).
+                    if let Entry::Property(prop) = entry
+                        && prop.name == "output"
+                        && depth == 0
+                        && self.converters.is_empty()
+                    {
+                        self.extract_converters_from_ast(prop, &scope, depth)
+                            .await;
+                    }
                 }
             }
             // Remove function values from base output (not data)
@@ -552,6 +562,14 @@ impl Evaluator {
                             }
                             Entry::TypeAlias(name, ty) => {
                                 self.eval_type_alias(name, ty, &mut scope);
+                            }
+                            Entry::Property(prop)
+                                if prop.name == "output"
+                                    && depth == 0
+                                    && self.converters.is_empty() =>
+                            {
+                                self.extract_converters_from_ast(prop, &scope, depth)
+                                    .await;
                             }
                             _ => {}
                         }

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -506,11 +506,10 @@ impl Evaluator {
                         base_obj.shift_remove(name);
                     }
                     // Extract converters from the base module's output block
-                    // (the amending module inherits them).
+                    // (the amending module inherits them; child overrides if present).
                     if let Entry::Property(prop) = entry
                         && prop.name == "output"
                         && depth == 0
-                        && self.converters.is_empty()
                     {
                         self.extract_converters_from_ast(prop, &scope, depth)
                             .await;
@@ -564,9 +563,7 @@ impl Evaluator {
                                 self.eval_type_alias(name, ty, &mut scope);
                             }
                             Entry::Property(prop)
-                                if prop.name == "output"
-                                    && depth == 0
-                                    && self.converters.is_empty() =>
+                                if prop.name == "output" && depth == 0 =>
                             {
                                 self.extract_converters_from_ast(prop, &scope, depth)
                                     .await;
@@ -653,8 +650,10 @@ impl Evaluator {
                 check_deprecated(&prop.annotations, &prop.name);
                 // Extract renderer converters from the `output` block AST,
                 // then skip it (it's not included in the output).
+                // Clear any base-inherited converters so child overrides take precedence.
                 if prop.name == "output" {
                     if depth == 0 {
+                        self.converters.clear();
                         self.extract_converters_from_ast(prop, &scope, depth).await;
                     }
                     continue;

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -497,7 +497,14 @@ impl Evaluator {
                 for entry in &base_module.body {
                     if let Entry::ClassDef(name, class_mods, parent, body) = entry {
                         let defaults = self
-                            .eval_class_def(name, class_mods, parent.as_deref(), body, &scope, depth)
+                            .eval_class_def(
+                                name,
+                                class_mods,
+                                parent.as_deref(),
+                                body,
+                                &scope,
+                                depth,
+                            )
                             .await?;
                         scope.set(name.clone(), defaults);
                         // Remove inherited class definitions from base output —
@@ -511,8 +518,7 @@ impl Evaluator {
                         && prop.name == "output"
                         && depth == 0
                     {
-                        self.extract_converters_from_ast(prop, &scope, depth)
-                            .await;
+                        self.extract_converters_from_ast(prop, &scope, depth).await;
                     }
                 }
             }
@@ -563,11 +569,8 @@ impl Evaluator {
                             Entry::TypeAlias(name, ty) => {
                                 self.eval_type_alias(name, ty, &mut scope);
                             }
-                            Entry::Property(prop)
-                                if prop.name == "output" && depth == 0 =>
-                            {
-                                self.extract_converters_from_ast(prop, &scope, depth)
-                                    .await;
+                            Entry::Property(prop) if prop.name == "output" && depth == 0 => {
+                                self.extract_converters_from_ast(prop, &scope, depth).await;
                             }
                             _ => {}
                         }
@@ -587,7 +590,14 @@ impl Evaluator {
                 for entry in &ext_module.body {
                     if let Entry::ClassDef(cls_name, cls_mods, parent, body) = entry {
                         let defaults = self
-                            .eval_class_def(cls_name, cls_mods, parent.as_deref(), body, &scope, depth)
+                            .eval_class_def(
+                                cls_name,
+                                cls_mods,
+                                parent.as_deref(),
+                                body,
+                                &scope,
+                                depth,
+                            )
                             .await?;
                         scope.set(cls_name.clone(), defaults);
                         base_obj.shift_remove(cls_name);
@@ -791,7 +801,14 @@ impl Evaluator {
                 }
                 Entry::ClassDef(name, class_mods, parent, body) => {
                     let defaults = self
-                        .eval_class_def(name, class_mods, parent.as_deref(), body, &child_scope, depth)
+                        .eval_class_def(
+                            name,
+                            class_mods,
+                            parent.as_deref(),
+                            body,
+                            &child_scope,
+                            depth,
+                        )
                         .await?;
                     child_scope.set(name.clone(), defaults);
                 }
@@ -846,27 +863,33 @@ impl Evaluator {
                     {
                         // Default template has ObjectSource — use eval_amended_object
                         // so nested property amendments work properly.
-                        let mut result = self.eval_amended_object(
-                            &src.entries, &src.scope, body, &child_scope, depth,
-                        ).await?;
+                        let mut result = self
+                            .eval_amended_object(
+                                &src.entries,
+                                &src.scope,
+                                body,
+                                &child_scope,
+                                depth,
+                            )
+                            .await?;
                         // Propagate the template's type_name so converters can match.
-                        if let Some(ref tn) = src.type_name {
-                            if let Value::Object(_, ref mut result_src) = result {
-                                let new_src = match result_src.as_ref() {
-                                    Some(s) => {
-                                        let mut ns = (**s).clone();
-                                        ns.type_name = Some(tn.clone());
-                                        ns
-                                    }
-                                    None => ObjectSource {
-                                        entries: vec![],
-                                        scope: IndexMap::new(),
-                                        is_open: true,
-                                        type_name: Some(tn.clone()),
-                                    },
-                                };
-                                *result_src = Some(std::sync::Arc::new(new_src));
-                            }
+                        if let Some(ref tn) = src.type_name
+                            && let Value::Object(_, ref mut result_src) = result
+                        {
+                            let new_src = match result_src.as_ref() {
+                                Some(s) => {
+                                    let mut ns = (**s).clone();
+                                    ns.type_name = Some(tn.clone());
+                                    ns
+                                }
+                                None => ObjectSource {
+                                    entries: vec![],
+                                    scope: IndexMap::new(),
+                                    is_open: true,
+                                    type_name: Some(tn.clone()),
+                                },
+                            };
+                            *result_src = Some(std::sync::Arc::new(new_src));
                         }
                         result
                     } else {
@@ -1276,12 +1299,16 @@ impl Evaluator {
                     Some("Mapping") | Some("Map") => {
                         // If the Mapping has a value type param (e.g., Mapping<String, Step>),
                         // resolve it as a default template so entries inherit the class type.
-                        let value_type_default = generic_params.get(1).and_then(|name| {
-                            resolve_dotted(scope, name)
-                        });
+                        let value_type_default = generic_params
+                            .get(1)
+                            .and_then(|name| resolve_dotted(scope, name));
                         let mut map = IndexMap::new();
                         self.eval_mapping_entries_with_type_default(
-                            entries, scope, depth, &mut map, value_type_default.as_ref(),
+                            entries,
+                            scope,
+                            depth,
+                            &mut map,
+                            value_type_default.as_ref(),
                         )
                         .await?;
                         // Build ObjectSource with a synthetic `default` entry so that
@@ -1289,7 +1316,9 @@ impl Evaluator {
                         // with the value type class, preserving type_name for converters.
                         let mut src_entries = entries.to_vec();
                         if value_type_default.is_some()
-                            && !entries.iter().any(|e| matches!(e, Entry::Property(p) if p.name == "default"))
+                            && !entries
+                                .iter()
+                                .any(|e| matches!(e, Entry::Property(p) if p.name == "default"))
                         {
                             // Inject a synthetic default property referencing the value type
                             let vt_name = generic_params[1].clone();
@@ -1298,11 +1327,7 @@ impl Evaluator {
                                 modifiers: vec![],
                                 name: "default".into(),
                                 type_ann: None,
-                                value: Some(Expr::New(
-                                    Some(vt_name),
-                                    vec![],
-                                    vec![],
-                                )),
+                                value: Some(Expr::New(Some(vt_name), vec![], vec![])),
                                 body: None,
                             }));
                         }
@@ -2112,26 +2137,26 @@ impl Evaluator {
                     let val = if let Some(Value::Object(_, Some(src))) = default_template
                         && let Expr::ObjectBody(body) = val_expr
                     {
-                        let mut result = self.eval_amended_object(
-                            &src.entries, &src.scope, body, scope, depth,
-                        ).await?;
-                        if let Some(ref tn) = src.type_name {
-                            if let Value::Object(_, ref mut result_src) = result {
-                                let new_src = match result_src.as_ref() {
-                                    Some(s) => {
-                                        let mut ns = (**s).clone();
-                                        ns.type_name = Some(tn.clone());
-                                        ns
-                                    }
-                                    None => ObjectSource {
-                                        entries: vec![],
-                                        scope: IndexMap::new(),
-                                        is_open: true,
-                                        type_name: Some(tn.clone()),
-                                    },
-                                };
-                                *result_src = Some(std::sync::Arc::new(new_src));
-                            }
+                        let mut result = self
+                            .eval_amended_object(&src.entries, &src.scope, body, scope, depth)
+                            .await?;
+                        if let Some(ref tn) = src.type_name
+                            && let Value::Object(_, ref mut result_src) = result
+                        {
+                            let new_src = match result_src.as_ref() {
+                                Some(s) => {
+                                    let mut ns = (**s).clone();
+                                    ns.type_name = Some(tn.clone());
+                                    ns
+                                }
+                                None => ObjectSource {
+                                    entries: vec![],
+                                    scope: IndexMap::new(),
+                                    is_open: true,
+                                    type_name: Some(tn.clone()),
+                                },
+                            };
+                            *result_src = Some(std::sync::Arc::new(new_src));
                         }
                         result
                     } else {

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -497,7 +497,7 @@ impl Evaluator {
                 for entry in &base_module.body {
                     if let Entry::ClassDef(name, class_mods, parent, body) = entry {
                         let defaults = self
-                            .eval_class_def(class_mods, parent.as_deref(), body, &scope, depth)
+                            .eval_class_def(name, class_mods, parent.as_deref(), body, &scope, depth)
                             .await?;
                         scope.set(name.clone(), defaults);
                         // Remove inherited class definitions from base output —
@@ -549,6 +549,7 @@ impl Evaluator {
                             Entry::ClassDef(cls_name, cls_mods, parent, body) => {
                                 let defaults = self
                                     .eval_class_def(
+                                        cls_name,
                                         cls_mods,
                                         parent.as_deref(),
                                         body,
@@ -586,7 +587,7 @@ impl Evaluator {
                 for entry in &ext_module.body {
                     if let Entry::ClassDef(cls_name, cls_mods, parent, body) = entry {
                         let defaults = self
-                            .eval_class_def(cls_mods, parent.as_deref(), body, &scope, depth)
+                            .eval_class_def(cls_name, cls_mods, parent.as_deref(), body, &scope, depth)
                             .await?;
                         scope.set(cls_name.clone(), defaults);
                         base_obj.shift_remove(cls_name);
@@ -609,7 +610,7 @@ impl Evaluator {
                 }
                 Entry::ClassDef(name, class_mods, parent, body) => {
                     let defaults = self
-                        .eval_class_def(class_mods, parent.as_deref(), body, &scope, depth)
+                        .eval_class_def(name, class_mods, parent.as_deref(), body, &scope, depth)
                         .await?;
                     scope.set(name.clone(), defaults);
                 }
@@ -774,7 +775,7 @@ impl Evaluator {
                 }
                 Entry::ClassDef(name, class_mods, parent, body) => {
                     let defaults = self
-                        .eval_class_def(class_mods, parent.as_deref(), body, &child_scope, depth)
+                        .eval_class_def(name, class_mods, parent.as_deref(), body, &child_scope, depth)
                         .await?;
                     child_scope.set(name.clone(), defaults);
                 }
@@ -896,6 +897,7 @@ impl Evaluator {
     #[async_recursion(?Send)]
     async fn eval_class_def(
         &mut self,
+        class_name: &str,
         class_mods: &[Modifier],
         parent_name: Option<&str>,
         body: &[Entry],
@@ -955,11 +957,12 @@ impl Evaluator {
             Ok(child_defaults)
         }
         .map(|val| {
-            // Set is_open flag on the result's ObjectSource
+            // Set is_open flag and class_name on the result's ObjectSource
             let is_open = has_modifier(class_mods, Modifier::Open);
             if let Value::Object(map, Some(src)) = val {
                 let mut new_src = (*src).clone();
                 new_src.is_open = is_open;
+                new_src.type_name = Some(class_name.to_string());
                 Value::Object(map, Some(std::sync::Arc::new(new_src)))
             } else {
                 val
@@ -1165,7 +1168,7 @@ impl Evaluator {
                 let captured = scope.flatten();
                 Ok(Value::Lambda(params.clone(), (**body).clone(), captured))
             }
-            Expr::New(type_name, entries) => {
+            Expr::New(type_name, entries, generic_params) => {
                 match type_name.as_deref() {
                     Some("Listing") => {
                         let mut items = Vec::new();
@@ -1213,9 +1216,16 @@ impl Evaluator {
                         Ok(Value::List(items))
                     }
                     Some("Mapping") | Some("Map") => {
+                        // If the Mapping has a value type param (e.g., Mapping<String, Step>),
+                        // resolve it as a default template so entries inherit the class type.
+                        let value_type_default = generic_params.get(1).and_then(|name| {
+                            resolve_dotted(scope, name)
+                        });
                         let mut map = IndexMap::new();
-                        self.eval_mapping_entries(entries, scope, depth, &mut map)
-                            .await?;
+                        self.eval_mapping_entries_with_type_default(
+                            entries, scope, depth, &mut map, value_type_default.as_ref(),
+                        )
+                        .await?;
                         Ok(Value::Object(map, None))
                     }
                     Some("Dynamic") => self.eval_entries(entries, scope, depth + 1).await,
@@ -1995,6 +2005,42 @@ impl Evaluator {
     }
 
     #[async_recursion(?Send)]
+    async fn eval_mapping_entries_with_type_default(
+        &mut self,
+        entries: &[crate::parser::Entry],
+        scope: &Scope,
+        depth: usize,
+        map: &mut IndexMap<String, Value>,
+        type_default: Option<&Value>,
+    ) -> Result<()> {
+        let explicit_default = self.find_default_template(entries, scope, depth).await?;
+        let default_template = explicit_default.as_ref().or(type_default);
+
+        for entry in entries {
+            match entry {
+                Entry::DynProperty(key_expr, val_expr) => {
+                    let key = self.eval_expr(key_expr, scope, depth + 1).await?;
+                    let mut val = self.eval_expr(val_expr, scope, depth + 1).await?;
+                    if let Some(tpl) = default_template {
+                        val = merge_values(tpl.clone(), val);
+                    }
+                    map.insert(value_to_key(&key)?, val);
+                }
+                Entry::Property(prop) if has_modifier(&prop.modifiers, Modifier::Local) => {}
+                Entry::Property(prop) if prop.name == "default" && default_template.is_some() => {}
+                Entry::Spread(e) => {
+                    let val = self.eval_expr(e, scope, depth + 1).await?;
+                    if let Value::Object(m, _) = val {
+                        map.extend(m);
+                    }
+                }
+                _ => {}
+            }
+        }
+        Ok(())
+    }
+
+    #[async_recursion(?Send)]
     async fn eval_mapping_entries(
         &mut self,
         entries: &[crate::parser::Entry],
@@ -2497,7 +2543,7 @@ fn value_cmp(a: &Value, b: &Value) -> Result<std::cmp::Ordering> {
 
 fn merge_values(base: Value, overlay: Value) -> Value {
     match (base, overlay) {
-        (Value::Object(mut b, _), Value::Object(o, _)) => {
+        (Value::Object(mut b, base_src), Value::Object(o, _)) => {
             for (k, v) in o {
                 if let Some(existing) = b.shift_remove(&k) {
                     b.insert(k, merge_values(existing, v));
@@ -2505,7 +2551,7 @@ fn merge_values(base: Value, overlay: Value) -> Value {
                     b.insert(k, v);
                 }
             }
-            Value::Object(b, None)
+            Value::Object(b, base_src)
         }
         (_, overlay) => overlay,
     }

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -638,6 +638,12 @@ impl Evaluator {
         let mut out = base_obj;
         // all_props includes hidden properties — used for `this`/`module` snapshots
         let mut all_props = out.clone();
+        // Seed scope with base properties so body amendments can find them
+        // (e.g., `hooks { ... }` needs to find the base hooks Mapping in scope
+        // to properly amend it with type-aware merging).
+        for (k, v) in &out {
+            scope.set(k.clone(), v.clone());
+        }
         // Bind `this` at module level so properties can reference the module object
         scope.set("this".into(), Value::Object(all_props.clone(), None));
         // Also bind `module` to the same value
@@ -736,7 +742,17 @@ impl Evaluator {
             return Ok(Some(self.eval_expr(expr, scope, depth).await?));
         }
         if let Some(body) = &prop.body {
-            // `foo { ... }` — object body amendment
+            // `foo { ... }` — object body amendment.
+            // If the property already has a value in scope (e.g., from a base class),
+            // amend that value so its ObjectSource (type info, default template) is preserved.
+            if let Some(Value::Object(_, Some(src))) = scope.get(&prop.name) {
+                let base_entries = src.entries.clone();
+                let base_scope = src.scope.clone();
+                return Ok(Some(
+                    self.eval_amended_object(&base_entries, &base_scope, body, scope, depth)
+                        .await?,
+                ));
+            }
             let val = self.eval_entries(body, scope, depth).await?;
             return Ok(Some(val));
         }
@@ -825,11 +841,41 @@ impl Evaluator {
                 }
                 Entry::DynProperty(key_expr, val_expr) => {
                     let key = self.eval_expr(key_expr, &child_scope, depth).await?;
-                    let mut val = self.eval_expr(val_expr, &child_scope, depth).await?;
-                    // Merge with default template if available
-                    if let Some(ref tpl) = default_template {
-                        val = merge_values(tpl.clone(), val);
-                    }
+                    let val = if let Some(Value::Object(_, Some(src))) = &default_template
+                        && let Expr::ObjectBody(body) = val_expr
+                    {
+                        // Default template has ObjectSource — use eval_amended_object
+                        // so nested property amendments work properly.
+                        let mut result = self.eval_amended_object(
+                            &src.entries, &src.scope, body, &child_scope, depth,
+                        ).await?;
+                        // Propagate the template's type_name so converters can match.
+                        if let Some(ref tn) = src.type_name {
+                            if let Value::Object(_, ref mut result_src) = result {
+                                let new_src = match result_src.as_ref() {
+                                    Some(s) => {
+                                        let mut ns = (**s).clone();
+                                        ns.type_name = Some(tn.clone());
+                                        ns
+                                    }
+                                    None => ObjectSource {
+                                        entries: vec![],
+                                        scope: IndexMap::new(),
+                                        is_open: true,
+                                        type_name: Some(tn.clone()),
+                                    },
+                                };
+                                *result_src = Some(std::sync::Arc::new(new_src));
+                            }
+                        }
+                        result
+                    } else {
+                        let mut val = self.eval_expr(val_expr, &child_scope, depth).await?;
+                        if let Some(ref tpl) = default_template {
+                            val = merge_values(tpl.clone(), val);
+                        }
+                        val
+                    };
                     let key_str = value_to_key(&key)?;
                     map.insert(key_str, val);
                 }
@@ -1093,12 +1139,24 @@ impl Evaluator {
             }
         }
 
-        // Walk base entries: substitute overridden properties in-place
+        // Walk base entries: substitute overridden properties in-place.
+        // If the overlay has a body amendment (no `=`), keep the base entry first
+        // so its value is in scope, then add the overlay body entry after.
         let mut used_overlay: std::collections::HashSet<String> = std::collections::HashSet::new();
         for entry in base_entries {
             if let Entry::Property(prop) = entry
                 && let Some(replacement) = overlay_by_name.get(&prop.name)
             {
+                if let Entry::Property(overlay_prop) = replacement
+                    && overlay_prop.body.is_some()
+                    && overlay_prop.value.is_none()
+                    && (prop.value.is_some() || prop.body.is_some())
+                {
+                    // Body amendment: keep base entry (for its value) AND overlay
+                    // entry (for body amendment). eval_property will see the base
+                    // value in scope and amend it.
+                    merged.push(entry.clone());
+                }
                 merged.push((*replacement).clone());
                 used_overlay.insert(prop.name.clone());
                 continue;
@@ -1226,7 +1284,35 @@ impl Evaluator {
                             entries, scope, depth, &mut map, value_type_default.as_ref(),
                         )
                         .await?;
-                        Ok(Value::Object(map, None))
+                        // Build ObjectSource with a synthetic `default` entry so that
+                        // body amendments (`steps { ["x"] { ... } }`) merge new entries
+                        // with the value type class, preserving type_name for converters.
+                        let mut src_entries = entries.to_vec();
+                        if value_type_default.is_some()
+                            && !entries.iter().any(|e| matches!(e, Entry::Property(p) if p.name == "default"))
+                        {
+                            // Inject a synthetic default property referencing the value type
+                            let vt_name = generic_params[1].clone();
+                            src_entries.push(Entry::Property(Property {
+                                annotations: vec![],
+                                modifiers: vec![],
+                                name: "default".into(),
+                                type_ann: None,
+                                value: Some(Expr::New(
+                                    Some(vt_name),
+                                    vec![],
+                                    vec![],
+                                )),
+                                body: None,
+                            }));
+                        }
+                        let source = ObjectSource {
+                            entries: src_entries,
+                            scope: scope.flatten(),
+                            is_open: true,
+                            type_name: None,
+                        };
+                        Ok(Value::Object(map, Some(std::sync::Arc::new(source))))
                     }
                     Some("Dynamic") => self.eval_entries(entries, scope, depth + 1).await,
                     _ => {
@@ -2020,10 +2106,41 @@ impl Evaluator {
             match entry {
                 Entry::DynProperty(key_expr, val_expr) => {
                     let key = self.eval_expr(key_expr, scope, depth + 1).await?;
-                    let mut val = self.eval_expr(val_expr, scope, depth + 1).await?;
-                    if let Some(tpl) = default_template {
-                        val = merge_values(tpl.clone(), val);
-                    }
+                    // If the default template has ObjectSource, use eval_amended_object
+                    // so nested property amendments work (e.g., `steps { ["x"] { ... } }`
+                    // inside a Hook default properly amends the Hook's steps Mapping).
+                    let val = if let Some(Value::Object(_, Some(src))) = default_template
+                        && let Expr::ObjectBody(body) = val_expr
+                    {
+                        let mut result = self.eval_amended_object(
+                            &src.entries, &src.scope, body, scope, depth,
+                        ).await?;
+                        if let Some(ref tn) = src.type_name {
+                            if let Value::Object(_, ref mut result_src) = result {
+                                let new_src = match result_src.as_ref() {
+                                    Some(s) => {
+                                        let mut ns = (**s).clone();
+                                        ns.type_name = Some(tn.clone());
+                                        ns
+                                    }
+                                    None => ObjectSource {
+                                        entries: vec![],
+                                        scope: IndexMap::new(),
+                                        is_open: true,
+                                        type_name: Some(tn.clone()),
+                                    },
+                                };
+                                *result_src = Some(std::sync::Arc::new(new_src));
+                            }
+                        }
+                        result
+                    } else {
+                        let mut val = self.eval_expr(val_expr, scope, depth + 1).await?;
+                        if let Some(tpl) = default_template {
+                            val = merge_values(tpl.clone(), val);
+                        }
+                        val
+                    };
                     map.insert(value_to_key(&key)?, val);
                 }
                 Entry::Property(prop) if has_modifier(&prop.modifiers, Modifier::Local) => {}

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -97,7 +97,8 @@ pub enum Expr {
     String(String),
     Ident(String),
     /// `new TypeName? { entries... }`
-    New(Option<String>, Vec<Entry>),
+    /// The third field holds optional generic type parameter names (e.g., `<String, Step>`).
+    New(Option<String>, Vec<Entry>, Vec<String>),
     /// `expr.field`
     Field(Box<Expr>, String),
     /// `expr[key]`
@@ -461,6 +462,42 @@ impl<'a> Parser<'a> {
             entries.push(entry);
         }
         Ok(entries)
+    }
+
+    /// Collect top-level generic type parameter names: `<Type, Type<Nested>, ...>`
+    /// Returns the simple names of each top-level param (e.g., `["String", "Step"]`).
+    fn collect_generic_params(&mut self) -> Result<Vec<String>> {
+        let mut params = Vec::new();
+        let mut depth = 0;
+        loop {
+            match self.peek() {
+                TokenKind::Lt => {
+                    depth += 1;
+                    self.advance();
+                }
+                TokenKind::Gt => {
+                    depth -= 1;
+                    self.advance();
+                    if depth == 0 {
+                        break;
+                    }
+                }
+                TokenKind::Comma if depth == 1 => {
+                    self.advance();
+                }
+                TokenKind::Ident(name) if depth == 1 => {
+                    params.push(name.clone());
+                    self.advance();
+                }
+                TokenKind::Eof => {
+                    return Err(self.parse_error("unclosed generic type parameters"));
+                }
+                _ => {
+                    self.advance();
+                }
+            }
+        }
+        Ok(params)
     }
 
     /// Skip generic type parameters: `<Type, Type<Nested>, ...>`
@@ -1213,14 +1250,16 @@ impl<'a> Parser<'a> {
                 } else {
                     None
                 };
-                // Skip optional generic type params: <Type, Type, ...>
-                if matches!(self.peek(), TokenKind::Lt) {
-                    self.skip_generic_params()?;
-                }
+                // Collect optional generic type params: <Type, Type, ...>
+                let generic_params = if matches!(self.peek(), TokenKind::Lt) {
+                    self.collect_generic_params()?
+                } else {
+                    Vec::new()
+                };
                 self.expect(&TokenKind::LBrace)?;
                 let entries = self.parse_entries()?;
                 self.expect(&TokenKind::RBrace)?;
-                Ok(Expr::New(type_name, entries))
+                Ok(Expr::New(type_name, entries, generic_params))
             }
             TokenKind::KwIf => {
                 self.advance();

--- a/tests/pkl_features.rs
+++ b/tests/pkl_features.rs
@@ -3192,7 +3192,10 @@ item = new Foo { x = 42 }
 #[test]
 fn converter_inherited_from_amends_base() {
     use std::io::Write;
-    let dir = std::env::temp_dir().join("pklr_test_amends_converter");
+    let dir = std::env::temp_dir().join(format!(
+        "pklr_test_amends_converter_{}",
+        std::process::id()
+    ));
     let _ = std::fs::remove_dir_all(&dir);
     std::fs::create_dir_all(&dir).unwrap();
 
@@ -3246,4 +3249,64 @@ myStep = new Step {{
     });
     assert_eq!(json["myStep"]["_type"], "step");
     assert_eq!(json["myStep"]["check"], "cargo test");
+}
+
+#[test]
+fn converter_inherited_from_extends_base() {
+    use std::io::Write;
+    let dir = std::env::temp_dir().join(format!(
+        "pklr_test_extends_converter_{}",
+        std::process::id()
+    ));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+
+    let base_path = dir.join("Base.pkl");
+    let mut base_file = std::fs::File::create(&base_path).unwrap();
+    write!(
+        base_file,
+        r#"
+open class Step {{
+    check: String = ""
+}}
+
+output {{
+    renderer {{
+        converters {{
+            [Step] = (s) -> new Dynamic {{
+                _type = "step"
+                ...s.toDynamic()
+            }}
+        }}
+    }}
+}}
+"#
+    )
+    .unwrap();
+
+    let child_path = dir.join("child.pkl");
+    let mut child_file = std::fs::File::create(&child_path).unwrap();
+    write!(
+        child_file,
+        r#"extends "Base.pkl"
+
+myStep = new Step {{
+    check = "make test"
+}}
+"#
+    )
+    .unwrap();
+
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    let json = rt.block_on(async {
+        let mut ev = Evaluator::new();
+        let val = ev.eval_source(
+            &std::fs::read_to_string(&child_path).unwrap(),
+            &child_path,
+        ).await.unwrap();
+        let val = ev.apply_converters(val).await.unwrap();
+        val.to_json()
+    });
+    assert_eq!(json["myStep"]["_type"], "step");
+    assert_eq!(json["myStep"]["check"], "make test");
 }

--- a/tests/pkl_features.rs
+++ b/tests/pkl_features.rs
@@ -3188,3 +3188,62 @@ item = new Foo { x = 42 }
     assert_eq!(json["item"]["_type"], "foo");
     assert_eq!(json["item"]["x"], 42);
 }
+
+#[test]
+fn converter_inherited_from_amends_base() {
+    use std::io::Write;
+    let dir = std::env::temp_dir().join("pklr_test_amends_converter");
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+
+    // Base module with class + converter
+    let base_path = dir.join("Base.pkl");
+    let mut base_file = std::fs::File::create(&base_path).unwrap();
+    write!(
+        base_file,
+        r#"
+class Step {{
+    check: String = ""
+}}
+
+output {{
+    renderer {{
+        converters {{
+            [Step] = (s) -> new Dynamic {{
+                _type = "step"
+                ...s.toDynamic()
+            }}
+        }}
+    }}
+}}
+"#
+    )
+    .unwrap();
+
+    // Amending module
+    let child_path = dir.join("child.pkl");
+    let mut child_file = std::fs::File::create(&child_path).unwrap();
+    write!(
+        child_file,
+        r#"amends "Base.pkl"
+
+myStep = new Step {{
+    check = "cargo test"
+}}
+"#
+    )
+    .unwrap();
+
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    let json = rt.block_on(async {
+        let mut ev = Evaluator::new();
+        let val = ev.eval_source(
+            &std::fs::read_to_string(&child_path).unwrap(),
+            &child_path,
+        ).await.unwrap();
+        let val = ev.apply_converters(val).await.unwrap();
+        val.to_json()
+    });
+    assert_eq!(json["myStep"]["_type"], "step");
+    assert_eq!(json["myStep"]["check"], "cargo test");
+}

--- a/tests/pkl_features.rs
+++ b/tests/pkl_features.rs
@@ -3192,10 +3192,8 @@ item = new Foo { x = 42 }
 #[test]
 fn converter_inherited_from_amends_base() {
     use std::io::Write;
-    let dir = std::env::temp_dir().join(format!(
-        "pklr_test_amends_converter_{}",
-        std::process::id()
-    ));
+    let dir =
+        std::env::temp_dir().join(format!("pklr_test_amends_converter_{}", std::process::id()));
     let _ = std::fs::remove_dir_all(&dir);
     std::fs::create_dir_all(&dir).unwrap();
 
@@ -3240,10 +3238,10 @@ myStep = new Step {{
     let rt = tokio::runtime::Runtime::new().unwrap();
     let json = rt.block_on(async {
         let mut ev = Evaluator::new();
-        let val = ev.eval_source(
-            &std::fs::read_to_string(&child_path).unwrap(),
-            &child_path,
-        ).await.unwrap();
+        let val = ev
+            .eval_source(&std::fs::read_to_string(&child_path).unwrap(), &child_path)
+            .await
+            .unwrap();
         let val = ev.apply_converters(val).await.unwrap();
         val.to_json()
     });
@@ -3300,10 +3298,10 @@ myStep = new Step {{
     let rt = tokio::runtime::Runtime::new().unwrap();
     let json = rt.block_on(async {
         let mut ev = Evaluator::new();
-        let val = ev.eval_source(
-            &std::fs::read_to_string(&child_path).unwrap(),
-            &child_path,
-        ).await.unwrap();
+        let val = ev
+            .eval_source(&std::fs::read_to_string(&child_path).unwrap(), &child_path)
+            .await
+            .unwrap();
         let val = ev.apply_converters(val).await.unwrap();
         val.to_json()
     });
@@ -3314,7 +3312,8 @@ myStep = new Step {{
 /// Simple: amends with bare object in a typed Mapping property
 #[test]
 fn converter_amends_simple_typed_mapping() {
-    let json = eval_with_converters(r#"
+    let json = eval_with_converters(
+        r#"
 open class Step {
     check: String = ""
 }
@@ -3337,8 +3336,12 @@ steps {
         check = "echo ok"
     }
 }
-"#);
-    eprintln!("simple JSON: {}", serde_json::to_string_pretty(&json).unwrap());
+"#,
+    );
+    eprintln!(
+        "simple JSON: {}",
+        serde_json::to_string_pretty(&json).unwrap()
+    );
     assert_eq!(json["steps"]["echo"]["_type"], "step");
     assert_eq!(json["steps"]["echo"]["check"], "echo ok");
 }
@@ -3348,16 +3351,15 @@ steps {
 #[test]
 fn converter_amends_bare_object_in_mapping() {
     use std::io::Write;
-    let dir = std::env::temp_dir().join(format!(
-        "pklr_test_bare_mapping_{}",
-        std::process::id()
-    ));
+    let dir = std::env::temp_dir().join(format!("pklr_test_bare_mapping_{}", std::process::id()));
     let _ = std::fs::remove_dir_all(&dir);
     std::fs::create_dir_all(&dir).unwrap();
 
     let base_path = dir.join("Config.pkl");
     let mut f = std::fs::File::create(&base_path).unwrap();
-    write!(f, r#"
+    write!(
+        f,
+        r#"
 open class Step {{
     check: String = ""
     fix: String = ""
@@ -3379,11 +3381,15 @@ output {{
         }}
     }}
 }}
-"#).unwrap();
+"#
+    )
+    .unwrap();
 
     let child_path = dir.join("hk.pkl");
     let mut f = std::fs::File::create(&child_path).unwrap();
-    write!(f, r#"amends "Config.pkl"
+    write!(
+        f,
+        r#"amends "Config.pkl"
 
 hooks {{
     ["check"] {{
@@ -3394,15 +3400,17 @@ hooks {{
         }}
     }}
 }}
-"#).unwrap();
+"#
+    )
+    .unwrap();
 
     let rt = tokio::runtime::Runtime::new().unwrap();
     let json = rt.block_on(async {
         let mut ev = Evaluator::new();
-        let val = ev.eval_source(
-            &std::fs::read_to_string(&child_path).unwrap(),
-            &child_path,
-        ).await.unwrap();
+        let val = ev
+            .eval_source(&std::fs::read_to_string(&child_path).unwrap(), &child_path)
+            .await
+            .unwrap();
         let val = ev.apply_converters(val).await.unwrap();
         val.to_json()
     });

--- a/tests/pkl_features.rs
+++ b/tests/pkl_features.rs
@@ -3310,3 +3310,103 @@ myStep = new Step {{
     assert_eq!(json["myStep"]["_type"], "step");
     assert_eq!(json["myStep"]["check"], "make test");
 }
+
+/// Simple: amends with bare object in a typed Mapping property
+#[test]
+fn converter_amends_simple_typed_mapping() {
+    let json = eval_with_converters(r#"
+open class Step {
+    check: String = ""
+}
+
+steps: Mapping<String, Step> = new Mapping<String, Step> {}
+
+output {
+    renderer {
+        converters {
+            [Step] = (s) -> new Dynamic {
+                _type = "step"
+                ...s.toDynamic()
+            }
+        }
+    }
+}
+
+steps {
+    ["echo"] {
+        check = "echo ok"
+    }
+}
+"#);
+    eprintln!("simple JSON: {}", serde_json::to_string_pretty(&json).unwrap());
+    assert_eq!(json["steps"]["echo"]["_type"], "step");
+    assert_eq!(json["steps"]["echo"]["check"], "echo ok");
+}
+
+/// Reproduces the hk pattern: base defines classes + typed Mappings + converters,
+/// child amends with bare object bodies (no `new Step`).
+#[test]
+fn converter_amends_bare_object_in_mapping() {
+    use std::io::Write;
+    let dir = std::env::temp_dir().join(format!(
+        "pklr_test_bare_mapping_{}",
+        std::process::id()
+    ));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+
+    let base_path = dir.join("Config.pkl");
+    let mut f = std::fs::File::create(&base_path).unwrap();
+    write!(f, r#"
+open class Step {{
+    check: String = ""
+    fix: String = ""
+}}
+
+open class Hook {{
+    steps: Mapping<String, Step> = new Mapping<String, Step> {{}}
+}}
+
+hooks: Mapping<String, Hook> = new Mapping<String, Hook> {{}}
+
+output {{
+    renderer {{
+        converters {{
+            [Step] = (s) -> new Dynamic {{
+                _type = "step"
+                ...s.toDynamic()
+            }}
+        }}
+    }}
+}}
+"#).unwrap();
+
+    let child_path = dir.join("hk.pkl");
+    let mut f = std::fs::File::create(&child_path).unwrap();
+    write!(f, r#"amends "Config.pkl"
+
+hooks {{
+    ["check"] {{
+        steps {{
+            ["echo"] {{
+                check = "echo ok"
+            }}
+        }}
+    }}
+}}
+"#).unwrap();
+
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    let json = rt.block_on(async {
+        let mut ev = Evaluator::new();
+        let val = ev.eval_source(
+            &std::fs::read_to_string(&child_path).unwrap(),
+            &child_path,
+        ).await.unwrap();
+        let val = ev.apply_converters(val).await.unwrap();
+        val.to_json()
+    });
+    eprintln!("JSON: {}", serde_json::to_string_pretty(&json).unwrap());
+    assert_eq!(json["hooks"]["check"]["steps"]["echo"]["_type"], "step");
+    assert_eq!(json["hooks"]["check"]["steps"]["echo"]["check"], "echo ok");
+}


### PR DESCRIPTION
## Summary

Fixes the `missing field '_type'` error in hk's CI ([PR #769](https://github.com/jdx/hk/pull/769)).

PR #49 added `output.renderer.converters` support, but only extracted converters from the *current* module's body entries. When a file `amends` or `extends` a base module that defines converters (like hk's `hk.pkl` amending `Config.pkl`), those converters were never extracted.

- Extract converters from the base module's AST during amends processing
- Extract converters from the base module's AST during extends processing
- Added `converter_inherited_from_amends_base` test with two files on disk

## Test plan

- [x] New test: `converter_inherited_from_amends_base` — creates Base.pkl with converters + child.pkl that amends it, verifies converters are applied
- [x] All 235 existing tests pass

*This comment was generated by Claude Code.*