### PR TITLE
chore: release v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0](https://github.com/jdx/pklr/compare/v0.3.0...v0.4.0) - 2026-03-25
+
+### Fixed
+
+- extract converters from amends/extends base modules ([#52](https://github.com/jdx/pklr/pull/52))
+
 ## [0.3.0](https://github.com/jdx/pklr/compare/v0.2.2...v0.3.0) - 2026-03-24
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -557,7 +557,7 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pklr"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "async-recursion",
  "indexmap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "pklr"
-version     = "0.3.0"
+version     = "0.4.0"
 edition      = "2024"
 rust-version = "1.88"
 description = "Pure Rust pkl configuration language parser and evaluator"


### PR DESCRIPTION



## 🤖 New release

* `pklr`: 0.3.0 -> 0.4.0 (⚠ API breaking changes)

### ⚠ `pklr` breaking changes

```text
--- failure enum_tuple_variant_field_added: pub enum tuple variant field added ---

Description:
An enum's exhaustive tuple variant has a new field, which has to be included when constructing or matching on this variant.
        ref: https://doc.rust-lang.org/reference/attributes/type_system.html#the-non_exhaustive-attribute
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_tuple_variant_field_added.ron

Failed in:
  field 2 of variant Expr::New in /tmp/.tmproz423/pklr/src/parser.rs:101
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.4.0](https://github.com/jdx/pklr/compare/v0.3.0...v0.4.0) - 2026-03-25

### Fixed

- extract converters from amends/extends base modules ([#52](https://github.com/jdx/pklr/pull/52))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).