### PR TITLE
chore: release v0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.1](https://github.com/jdx/pklr/compare/v0.4.0...v0.4.1) - 2026-04-07
+
+### Fixed
+
+- resolve nullable outer property access and semicolons ([#54](https://github.com/jdx/pklr/pull/54))
+
 ## [0.4.0](https://github.com/jdx/pklr/compare/v0.3.0...v0.4.0) - 2026-03-25
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -557,7 +557,7 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pklr"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "async-recursion",
  "indexmap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "pklr"
-version     = "0.4.0"
+version     = "0.4.1"
 edition      = "2024"
 rust-version = "1.88"
 description = "Pure Rust pkl configuration language parser and evaluator"


### PR DESCRIPTION



## 🤖 New release

* `pklr`: 0.4.0 -> 0.4.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.4.1](https://github.com/jdx/pklr/compare/v0.4.0...v0.4.1) - 2026-04-07

### Fixed

- resolve nullable outer property access and semicolons ([#54](https://github.com/jdx/pklr/pull/54))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk release bookkeeping only: version bumps and changelog update, with no code or dependency changes beyond the crate version metadata.
> 
> **Overview**
> Prepares the `v0.4.1` release by updating `Cargo.toml`/`Cargo.lock` from `0.4.0` to `0.4.1`.
> 
> Updates `CHANGELOG.md` with a new `0.4.1` entry noting the fix for nullable outer property access and semicolon handling (per #54).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f211a5c79a5bad2d8a159d58db7140ba8f1f4411. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->