### PR TITLE
chore: release v0.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0](https://github.com/jdx/pklr/compare/v0.4.1...v0.5.0) - 2026-04-26
+
+### Fixed
+
+- *(eval)* make @Deprecated lazy — only warn on access ([#58](https://github.com/jdx/pklr/pull/58))
+
 ## [0.4.1](https://github.com/jdx/pklr/compare/v0.4.0...v0.4.1) - 2026-04-07
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.5.0](https://github.com/jdx/pklr/compare/v0.4.1...v0.5.0) - 2026-04-26
+## [0.4.2](https://github.com/jdx/pklr/compare/v0.4.1...v0.4.2) - 2026-04-26
 
 ### Fixed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -557,7 +557,7 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pklr"
-version = "0.5.0"
+version = "0.4.2"
 dependencies = [
  "async-recursion",
  "indexmap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -557,7 +557,7 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pklr"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "async-recursion",
  "indexmap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "pklr"
-version     = "0.4.1"
+version     = "0.5.0"
 edition      = "2024"
 rust-version = "1.88"
 description = "Pure Rust pkl configuration language parser and evaluator"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "pklr"
-version     = "0.5.0"
+version     = "0.4.2"
 edition      = "2024"
 rust-version = "1.88"
 description = "Pure Rust pkl configuration language parser and evaluator"


### PR DESCRIPTION
## 🤖 Release

* `pklr`: 0.4.1 → 0.4.2

The `deprecated` field added in [#58](https://github.com/jdx/pklr/pull/58) is scoped to `pub(crate)` ([#61](https://github.com/jdx/pklr/pull/61)) so `ObjectSource` no longer exposes new public surface. cargo-semver-checks still flags the struct as no-longer-externally-constructible-via-literal, but in practice nothing downstream constructs `ObjectSource` literally — it's an internal-ish struct describing evaluator state — so this ships as a patch release. The release-plz auto-detected major bump is overridden here manually.

### Changelog

#### Fixed

- *(eval)* make @Deprecated lazy — only warn on access ([#58](https://github.com/jdx/pklr/pull/58))
- *(value)* scope `ObjectSource.deprecated` field to `pub(crate)` ([#61](https://github.com/jdx/pklr/pull/61))

---
This PR was originally opened by [release-plz](https://github.com/release-plz/release-plz/) as 0.5.0; manually retargeted to 0.4.2.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this PR only updates release metadata (version numbers and changelog) with no functional code changes.
> 
> **Overview**
> Publishes release `v0.4.2` by bumping the crate version from `0.4.1` to `0.4.2` in `Cargo.toml`/`Cargo.lock`.
> 
> Updates `CHANGELOG.md` with the `0.4.2` entry noting the fix to make `@Deprecated` warnings lazy (warn only on access).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5ebfa234d70d24397c35345bb3cf9d5a56d0e5bb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->