### PR TITLE
fix(eval): drop @Deprecated warnings to avoid SemVer break

### DIFF
--- a/src/eval.rs
+++ b/src/eval.rs
@@ -8,9 +8,7 @@ use std::path::{Path, PathBuf};
 
 use crate::error::{Error, Result};
 use crate::lexer;
-use crate::parser::{
-    self, BinOp, Entry, Expr, Modifier, Module, Property, StringInterpPart, UnOp,
-};
+use crate::parser::{self, BinOp, Entry, Expr, Modifier, Module, Property, StringInterpPart, UnOp};
 use crate::value::{ObjectSource, Value};
 
 /// Evaluates pkl source files to [`Value`].

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -8,7 +8,9 @@ use std::path::{Path, PathBuf};
 
 use crate::error::{Error, Result};
 use crate::lexer;
-use crate::parser::{self, BinOp, Entry, Expr, Modifier, Module, Property, StringInterpPart, UnOp};
+use crate::parser::{
+    self, BinOp, Entry, Expr, Modifier, Module, Property, StringInterpPart, UnOp,
+};
 use crate::value::{ObjectSource, Value};
 
 /// Evaluates pkl source files to [`Value`].
@@ -30,10 +32,6 @@ pub struct Evaluator {
     /// Converters extracted from `output.renderer.converters`.
     /// Each entry maps a class name to a converter lambda.
     converters: Vec<(String, Value)>,
-    /// Set of (property_name, message) pairs already warned about.
-    /// Used to deduplicate `@Deprecated` warnings so a deprecated property
-    /// referenced inside a loop or template doesn't flood stderr.
-    warned_deprecated: std::collections::HashSet<(String, Option<String>)>,
 }
 
 impl Default for Evaluator {
@@ -47,7 +45,6 @@ impl Default for Evaluator {
             package_dirs: HashMap::new(),
             http_rewrites: Vec::new(),
             converters: Vec::new(),
-            warned_deprecated: std::collections::HashSet::new(),
         }
     }
 }
@@ -85,28 +82,6 @@ impl Evaluator {
                 Some((src.to_string(), tgt.to_string()))
             })
             .collect();
-    }
-
-    /// If `field` is marked `@Deprecated` in `source`, emit the warning at
-    /// most once per (field, message) pair. Called from field-access
-    /// expressions so the warning fires when a deprecated property is *used*,
-    /// not when its containing module loads. Per-call dedup mirrors pkl-jvm,
-    /// which avoids flooding stderr when a deprecated property is referenced
-    /// inside a loop or template.
-    fn warn_if_deprecated_access(&mut self, source: &Option<Arc<ObjectSource>>, field: &str) {
-        let Some(src) = source else { return };
-        let Some(message) = src.deprecated.get(field) else {
-            return;
-        };
-        let key = (field.to_string(), message.clone());
-        if !self.warned_deprecated.insert(key) {
-            return;
-        }
-        if let Some(msg) = message {
-            eprintln!("[pklr] WARNING: property '{field}' is deprecated: {msg}");
-        } else {
-            eprintln!("[pklr] WARNING: property '{field}' is deprecated");
-        }
     }
 
     /// Apply rewrite rules to a URL. Returns the rewritten URL or the original.
@@ -772,23 +747,7 @@ impl Evaluator {
             }
             out.retain(|_, v| !matches!(v, Value::Lambda(..)));
         }
-        // If the module declares any `@Deprecated` properties, attach a
-        // minimal ObjectSource carrying just the deprecation map so field
-        // access can warn lazily. Modules without @Deprecated keep `None`
-        // source to avoid changing amend behavior in the common case.
-        let deprecated = collect_deprecated(&module.body);
-        let source = if deprecated.is_empty() {
-            None
-        } else {
-            Some(Arc::new(ObjectSource {
-                entries: Vec::new(),
-                scope: IndexMap::new(),
-                is_open: true,
-                type_name: None,
-                deprecated,
-            }))
-        };
-        Ok(Value::Object(Arc::new(out), source))
+        Ok(Value::Object(Arc::new(out), None))
     }
 
     #[async_recursion(?Send)]
@@ -957,7 +916,6 @@ impl Evaluator {
                                     scope: IndexMap::new(),
                                     is_open: true,
                                     type_name: Some(tn.clone()),
-                                    deprecated: merge_deprecated(&src.deprecated, body),
                                 },
                             };
                             *result_src = Some(std::sync::Arc::new(new_src));
@@ -1025,7 +983,6 @@ impl Evaluator {
             scope: child_scope.flatten(),
             is_open: true, // default: allow new properties
             type_name: None,
-            deprecated: collect_deprecated(entries),
         };
         Ok(Value::Object(Arc::new(map), Some(Arc::new(source))))
     }
@@ -1420,13 +1377,11 @@ impl Evaluator {
                         let mut source_scope = scope.flatten();
                         source_scope.shift_remove("outer");
                         source_scope.shift_remove("this");
-                        let deprecated = collect_deprecated(&src_entries);
                         let source = ObjectSource {
                             entries: src_entries,
                             scope: source_scope,
                             is_open: true,
                             type_name: None,
-                            deprecated,
                         };
                         Ok(Value::Object(Arc::new(map), Some(Arc::new(source))))
                     }
@@ -1512,36 +1467,25 @@ impl Evaluator {
                                         scope: IndexMap::new(),
                                         is_open,
                                         type_name: tn,
-                                        deprecated: merge_deprecated(&base_src.deprecated, entries),
                                     }
                                 };
                                 *src_slot = Some(Arc::new(new_src));
                             }
                             Ok(result)
-                        } else if let Some(Value::Object(base_map, base_src)) = base {
+                        } else if let Some(Value::Object(base_map, _)) = base {
                             // Fallback: eager merge
                             let overlay = self.eval_entries(entries, scope, depth + 1).await?;
                             let mut merged: IndexMap<String, Value> = (*base_map).clone();
-                            let mut deprecated = base_src
-                                .as_ref()
-                                .map(|s| s.deprecated.clone())
-                                .unwrap_or_default();
-                            if let Value::Object(overlay_map, overlay_src) = &overlay {
+                            if let Value::Object(overlay_map, _) = overlay {
                                 merged.extend(
                                     overlay_map.iter().map(|(k, v)| (k.clone(), v.clone())),
                                 );
-                                if let Some(os) = overlay_src.as_ref() {
-                                    for (k, v) in &os.deprecated {
-                                        deprecated.insert(k.clone(), v.clone());
-                                    }
-                                }
                             }
                             let src = ObjectSource {
                                 entries: Vec::new(),
                                 scope: IndexMap::new(),
                                 is_open: true,
                                 type_name: type_name.clone(),
-                                deprecated,
                             };
                             Ok(Value::Object(Arc::new(merged), Some(Arc::new(src))))
                         } else {
@@ -1594,14 +1538,10 @@ impl Evaluator {
                     _ => {}
                 }
                 match &obj {
-                    Value::Object(map, source) => {
-                        let val = map
-                            .get(field)
-                            .cloned()
-                            .ok_or_else(|| Error::Eval(format!("field not found: {field}")))?;
-                        self.warn_if_deprecated_access(source, field);
-                        Ok(val)
-                    }
+                    Value::Object(map, _) => map
+                        .get(field)
+                        .cloned()
+                        .ok_or_else(|| Error::Eval(format!("field not found: {field}"))),
                     _ => Err(Error::Eval(format!(
                         "cannot access field '{field}' on {}",
                         value_type_name(&obj)
@@ -1612,13 +1552,7 @@ impl Evaluator {
                 let obj = self.eval_expr(obj_expr, scope, depth + 1).await?;
                 match &obj {
                     Value::Null => Ok(Value::Null),
-                    Value::Object(map, source) => {
-                        let val = map.get(field).cloned().unwrap_or(Value::Null);
-                        if !matches!(val, Value::Null) {
-                            self.warn_if_deprecated_access(source, field);
-                        }
-                        Ok(val)
-                    }
+                    Value::Object(map, _) => Ok(map.get(field).cloned().unwrap_or(Value::Null)),
                     _ => Err(Error::Eval(format!(
                         "cannot access field '{field}' on {}",
                         value_type_name(&obj)
@@ -2268,7 +2202,6 @@ impl Evaluator {
                                     scope: IndexMap::new(),
                                     is_open: true,
                                     type_name: Some(tn.clone()),
-                                    deprecated: merge_deprecated(&src.deprecated, body),
                                 },
                             };
                             *result_src = Some(std::sync::Arc::new(new_src));
@@ -2535,49 +2468,6 @@ fn resolve_package_uri(uri: &str) -> Result<PackageSource> {
         return Ok(PackageSource::Zip(zip_url, file_path.to_string()));
     }
     Err(Error::Eval(format!("unsupported package URI: {uri}")))
-}
-
-/// Collect `@Deprecated` annotations from a list of entries into a map of
-/// property name → optional message. Used to populate `ObjectSource.deprecated`
-/// so field access can warn lazily, instead of warning eagerly when a module
-/// or object body is evaluated.
-fn collect_deprecated(entries: &[Entry]) -> IndexMap<String, Option<String>> {
-    let mut out: IndexMap<String, Option<String>> = IndexMap::new();
-    for entry in entries {
-        if let Entry::Property(prop) = entry {
-            for ann in &prop.annotations {
-                if ann.name != "Deprecated" {
-                    continue;
-                }
-                let mut message = None;
-                for e in &ann.body {
-                    if let Entry::Property(p) = e
-                        && p.name == "message"
-                        && let Some(Expr::String(s)) = &p.value
-                    {
-                        message = Some(s.clone());
-                    }
-                }
-                out.insert(prop.name.clone(), message);
-            }
-        }
-    }
-    out
-}
-
-/// Combine a base deprecation map with any `@Deprecated` annotations on a
-/// list of overlay entries, with overlay winning on conflict. Used by the
-/// amend/merge code paths so an amended object's `ObjectSource.deprecated`
-/// reflects deprecations from both the base and the overlay.
-fn merge_deprecated(
-    base: &IndexMap<String, Option<String>>,
-    overlay_entries: &[Entry],
-) -> IndexMap<String, Option<String>> {
-    let mut out = base.clone();
-    for (k, v) in collect_deprecated(overlay_entries) {
-        out.insert(k, v);
-    }
-    out
 }
 
 /// Resolve a potentially dotted name (e.g. "Foo.Bar") in scope.

--- a/src/value.rs
+++ b/src/value.rs
@@ -18,11 +18,6 @@ pub struct ObjectSource {
     /// The pkl class name this object was instantiated from (e.g., "Step", "Group").
     /// Used by `output.renderer.converters` to apply type-specific transforms.
     pub type_name: Option<String>,
-    /// Map of property name → optional deprecation message for properties
-    /// annotated with `@Deprecated`. Consulted on field access so the
-    /// warning fires when a deprecated property is *used*, not when the
-    /// containing module is loaded.
-    pub deprecated: IndexMap<String, Option<String>>,
 }
 
 /// A pkl runtime value.


### PR DESCRIPTION
## Summary

Closes the SemVer break that [#58](https://github.com/jdx/pklr/pull/58) introduced. release-plz auto-opened [#59](https://github.com/jdx/pklr/pull/59) to bump pklr to **0.5.0** because that PR added a new field (`deprecated`) to the public `ObjectSource` struct, making the struct externally non-constructible-via-struct-literal.

`@Deprecated` warning emission isn't a documented pklr feature, and the original eager implementation was the *source* of the user-facing noise that #58 set out to fix ([jdx/hk#878](https://github.com/jdx/hk/discussions/878)). Drop warning emission entirely: `@Deprecated` annotations still parse and evaluate normally — they're just not printed.

## Net effect for users

- Importing a module that defines `@Deprecated` properties is silent, whether or not the consumer references them. ✓ (the bug from jdx/hk#878 stays fixed)
- The eager-on-load warnings that hk users complained about: gone.
- The lazy-on-access warnings #58 added: also gone.
- All existing tests pass (none asserted on the warning text).

## API impact

`cargo semver-checks --baseline-version 0.4.1` now reports **"no semver update required"** — `ObjectSource` is back to its 0.4.1 shape, so this can ship as **0.4.2** instead of 0.5.0.

## Future work

If lazy `@Deprecated` warnings are desired later, they can be added without an API break — e.g. a side-channel on `Evaluator` keyed by `Arc::as_ptr` of the `Value::Object`'s inner map, or by introducing `#[non_exhaustive]` on `ObjectSource` in a deliberate future major release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: change only removes deprecation-warning plumbing and a public struct field, with no effect on evaluation semantics beyond no longer emitting warnings on deprecated property access.
> 
> **Overview**
> Stops tracking and emitting `@Deprecated` warnings by removing all deprecation collection/merge logic and the access-time warning hook in `eval.rs`.
> 
> Reverts the public API shape by deleting `ObjectSource.deprecated` from `value.rs` and updating all `ObjectSource` construction/merge paths to no longer populate or carry deprecation metadata.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1a346b080fe9ff63790912113a7f63bff5141b83. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->