### PR TITLE
chore(value): scope ObjectSource.deprecated field to pub(crate)

### DIFF
--- a/src/value.rs
+++ b/src/value.rs
@@ -21,8 +21,9 @@ pub struct ObjectSource {
     /// Map of property name → optional deprecation message for properties
     /// annotated with `@Deprecated`. Consulted on field access so the
     /// warning fires when a deprecated property is *used*, not when the
-    /// containing module is loaded.
-    pub deprecated: IndexMap<String, Option<String>>,
+    /// containing module is loaded. Crate-private: only the evaluator
+    /// reads/writes this; not part of the public API.
+    pub(crate) deprecated: IndexMap<String, Option<String>>,
 }
 
 /// A pkl runtime value.


### PR DESCRIPTION
## Summary

The `deprecated` map added in [#58](https://github.com/jdx/pklr/pull/58) is only read by the evaluator's private field-access helper. Marking the field `pub(crate)` keeps that working and removes it from pklr's public API.

cargo-semver-checks will still flag this as a break in the strict sense (`constructible_struct_adds_private_field` — `ObjectSource` is no longer externally constructible via a struct literal). In practice no one downstream constructs `ObjectSource` literally — it's an internal-ish struct describing evaluator state — so the plan is to override the release-plz auto-bump and ship 0.4.2 manually instead of 0.5.0 from [#59](https://github.com/jdx/pklr/pull/59).

## Test plan

- `cargo test`: 238 passed.
- `cargo clippy --all-targets -- -D warnings`: clean.
- The lazy-on-access warning behavior added in #58 is unchanged (the helper is in the same crate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk, single-field visibility change with no runtime behavior impact; only potential risk is breaking external code that constructed or accessed `ObjectSource` directly.
> 
> **Overview**
> Makes `ObjectSource.deprecated` `pub(crate)` so deprecation metadata remains usable by the evaluator but is no longer part of the public API (and can’t be read/constructed via struct literals outside the crate).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e96073730d1b2727315dca2d2e4c927f96fa8286. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->