### PR TITLE
chore: release v0.4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.3](https://github.com/jdx/pklr/compare/v0.4.2...v0.4.3) - 2026-05-18
+
+### Fixed
+
+- *(deps)* update rust crate reqwest to 0.13 ([#66](https://github.com/jdx/pklr/pull/66))
+- *(deps)* update rust crate zip to v8 ([#69](https://github.com/jdx/pklr/pull/69))
+
+### Other
+
+- *(deps)* lock file maintenance ([#76](https://github.com/jdx/pklr/pull/76))
+- *(deps)* lock file maintenance ([#73](https://github.com/jdx/pklr/pull/73))
+- *(deps)* lock file maintenance ([#72](https://github.com/jdx/pklr/pull/72))
+- set dev profile debug to 1 ([#71](https://github.com/jdx/pklr/pull/71))
+
 ## [0.4.2](https://github.com/jdx/pklr/compare/v0.4.1...v0.4.2) - 2026-04-26
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -651,7 +651,7 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pklr"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "async-recursion",
  "indexmap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "pklr"
-version     = "0.4.2"
+version     = "0.4.3"
 edition      = "2024"
 rust-version = "1.88"
 description = "Pure Rust pkl configuration language parser and evaluator"


### PR DESCRIPTION



## 🤖 New release

* `pklr`: 0.4.2 -> 0.4.3 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.4.3](https://github.com/jdx/pklr/compare/v0.4.2...v0.4.3) - 2026-05-18

### Fixed

- *(deps)* update rust crate reqwest to 0.13 ([#66](https://github.com/jdx/pklr/pull/66))
- *(deps)* update rust crate zip to v8 ([#69](https://github.com/jdx/pklr/pull/69))

### Other

- *(deps)* lock file maintenance ([#76](https://github.com/jdx/pklr/pull/76))
- *(deps)* lock file maintenance ([#73](https://github.com/jdx/pklr/pull/73))
- *(deps)* lock file maintenance ([#72](https://github.com/jdx/pklr/pull/72))
- set dev profile debug to 1 ([#71](https://github.com/jdx/pklr/pull/71))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk release metadata update: only bumps the crate version and updates changelog/lockfile, with no functional code changes in this PR diff.
> 
> **Overview**
> Bumps `pklr` from **0.4.2** to **0.4.3** in `Cargo.toml` and `Cargo.lock`.
> 
> Updates `CHANGELOG.md` with the `0.4.3` release notes (dependency updates for `reqwest`/`zip` plus lockfile maintenance and dev-profile debug tweak).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c8d4f1813c45c94f440809269ae0c5b52dbc2d67. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->