### PR TITLE
chore(ci): use !cancelled() instead of always() for final job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,9 @@ jobs:
     needs: [test, msrv]
     runs-on: ubuntu-latest
     timeout-minutes: 1
-    if: always()
+    # Run on success or upstream failure but skip when the workflow is cancelled
+    # — `always()` would override `cancel-in-progress` and waste a runner.
+    if: ${{ !cancelled() }}
     steps:
       - name: Check CI job results
         run: |


### PR DESCRIPTION
## Summary
- Combined with the workflow's `cancel-in-progress` group, `if: always()` overrides cancellation and runs the `final` aggregator even on superseded commits.
- `!cancelled()` still runs on upstream success or failure but skips when the workflow is cancelled — saves a runner and avoids confusing error annotations on already-superseded shas.
- Caught by Cursor Bugbot on a sibling repo (endevco/pitchfork#413). Same `final`-aggregator pattern + `cancel-in-progress: true` here, so the same fix applies.

## Test plan
- [ ] CI passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts a GitHub Actions `if` condition so the `final` aggregator job doesn’t run on cancelled/superseded workflows, reducing wasted runners and noisy failures.
> 
> **Overview**
> Updates the CI workflow so the `final` aggregator job runs for upstream success/failure but **skips when the workflow is cancelled** by replacing `if: always()` with `if: ${{ !cancelled() }}`.
> 
> This prevents `cancel-in-progress` superseded runs from still executing `final` and emitting misleading failure annotations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6b74546edd4c652aebdc2f1af1f06c166f3ecf99. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->