### PR TITLE
chore: set dev profile debug to 1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,3 +23,6 @@ zip             = { version = "8", default-features = false, features = ["deflat
 
 [dev-dependencies]
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
+
+[profile.dev]
+debug = 1


### PR DESCRIPTION
## Summary

Reduces `target/` disk usage by setting `[profile.dev] debug = 1`, while keeping backtrace file:line info intact.

The default `debug = 2` writes full DWARF — including variable/type info that's only needed when stepping through code in a debugger (lldb/gdb). With `debug = 1`, panics, `RUST_BACKTRACE=1`, and error chains still resolve to file:line; only debugger variable inspection is reduced.

In practice this typically shrinks `target/` by a meaningful percentage, which adds up across worktrees.

## Test plan

- [ ] `cargo build` still succeeds
- [ ] CI is green

---
*This PR was generated by an AI coding assistant.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk configuration-only change affecting local/dev build artifacts; it may slightly reduce debugger variable/type info but shouldn’t impact runtime behavior or release builds.
> 
> **Overview**
> Sets Cargo’s `[profile.dev]` `debug = 1` in `Cargo.toml` to reduce dev build `target/` size by emitting less debug info, without changing code or release configuration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f08b0a3bc0b954319934513a9681bc5713124d90. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->