### PR TITLE
chore(ci): align mise-action pin comments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
         with:
           persist-credentials: false
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
-      - uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4
+      - uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
       - run: cargo msrv verify
   final:
     needs: [test, msrv]

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -46,7 +46,7 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
-      - uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4
+      - uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
       - run: communique generate "$RELEASE_TAG" --github-release
         env:
           RELEASE_TAG: ${{ needs.release-plz-release.outputs.tag }}


### PR DESCRIPTION
## Summary
- update the `jdx/mise-action` hash pin comments from `# v4` to `# v4.1.0`
- match the concrete tag for pinned digest `dba19683ed58901619b14f395a24841710cb4925`
- fix the `ref-version-mismatch` findings reported by zizmor

## Verification
- `zizmor .github/workflows`

*This PR was generated by an AI coding assistant.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment-only workflow metadata; no change to action SHAs or runtime behavior.
> 
> **Overview**
> Updates the inline version comments on pinned **`jdx/mise-action`** steps in **`ci.yml`** (msrv job) and **`release-plz.yml`** (enhance-release job) from **`# v4`** to **`# v4.1.0`**, matching digest `dba19683ed58901619b14f395a24841710cb4925`. The action ref itself is unchanged—only the comment label is corrected for zizmor **`ref-version-mismatch`** compliance.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 646f7e5734eb27978ea831763c87b4154e6a5e79. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration and release automation workflows with the latest compatible tool versions for improved stability and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->