### PR TITLE
chore: release v0.4.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.4](https://github.com/jdx/pklr/compare/v0.4.3...v0.4.4) - 2026-06-08
+
+### Fixed
+
+- *(eval)* preserve union mapping defaults ([#86](https://github.com/jdx/pklr/pull/86))
+
 ## [0.4.3](https://github.com/jdx/pklr/compare/v0.4.2...v0.4.3) - 2026-05-18
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -651,7 +651,7 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pklr"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "async-recursion",
  "indexmap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "pklr"
-version     = "0.4.3"
+version     = "0.4.4"
 edition      = "2024"
 rust-version = "1.88"
 description = "Pure Rust pkl configuration language parser and evaluator"


### PR DESCRIPTION



## 🤖 New release

* `pklr`: 0.4.3 -> 0.4.4 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.4.4](https://github.com/jdx/pklr/compare/v0.4.3...v0.4.4) - 2026-06-08

### Fixed

- *(eval)* preserve union mapping defaults ([#86](https://github.com/jdx/pklr/pull/86))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version and changelog-only release with no code changes in this PR.
> 
> **Overview**
> **Release v0.4.4** bumps the `pklr` crate from **0.4.3** to **0.4.4** and records the release in **CHANGELOG.md** (dated 2026-06-08). **Cargo.lock** is updated to match the new package version.
> 
> The changelog entry documents the user-facing fix shipped in this release: evaluator behavior now **preserves union mapping defaults** ([#86](https://github.com/jdx/pklr/pull/86)). No source changes appear in this diff—only versioning and release notes (typical **release-plz** output).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fced01aa5f1d4bd332d171cdc51f8486852a2692. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->