### PR TITLE
fix(eval): preserve mapping locals

### DIFF
--- a/src/eval.rs
+++ b/src/eval.rs
@@ -36,6 +36,12 @@ pub struct Evaluator {
     warned_deprecated: std::collections::HashSet<(String, Option<String>)>,
 }
 
+#[derive(Clone, Default)]
+struct MappingInheritedDefault {
+    value: Option<Value>,
+    entries: Option<Vec<Entry>>,
+}
+
 impl Default for Evaluator {
     fn default() -> Self {
         Self {
@@ -839,7 +845,7 @@ impl Evaluator {
                         depth,
                         &mut amended,
                         &value_type_defaults,
-                        None,
+                        MappingInheritedDefault::default(),
                     )
                     .await?;
                     amended.extend(existing_map.iter().map(|(k, v)| (k.clone(), v.clone())));
@@ -849,7 +855,10 @@ impl Evaluator {
                         depth,
                         &mut amended,
                         &value_type_defaults,
-                        inherited_default,
+                        MappingInheritedDefault {
+                            value: inherited_default,
+                            entries: find_default_body_entries(&src.entries),
+                        },
                     )
                     .await?;
                     return Ok(Some(Value::Object(
@@ -1472,7 +1481,7 @@ impl Evaluator {
                             depth,
                             &mut map,
                             &value_type_defaults,
-                            None,
+                            MappingInheritedDefault::default(),
                         )
                         .await?;
                         // Build ObjectSource with a synthetic `default` entry so that
@@ -2318,17 +2327,66 @@ impl Evaluator {
         depth: usize,
         map: &mut IndexMap<String, Value>,
         type_defaults: &[(String, Value)],
-        inherited_default: Option<Value>,
+        inherited_default: MappingInheritedDefault,
     ) -> Result<()> {
+        let mut entry_scope = scope.child();
+        let mut deferred_lambdas: Vec<(String, &crate::parser::Expr)> = Vec::new();
+        for entry in entries {
+            match entry {
+                Entry::Property(prop)
+                    if has_modifier(&prop.modifiers, Modifier::Local) && prop.value.is_some() =>
+                {
+                    let expr = prop.value.as_ref().unwrap();
+                    if matches!(expr, crate::parser::Expr::Lambda(..)) {
+                        deferred_lambdas.push((prop.name.clone(), expr));
+                    } else {
+                        let val = self.eval_expr(expr, &entry_scope, depth).await?;
+                        entry_scope.set(prop.name.clone(), val);
+                    }
+                }
+                Entry::Property(prop)
+                    if has_modifier(&prop.modifiers, Modifier::Local) && prop.body.is_some() =>
+                {
+                    let val = self
+                        .eval_entries(prop.body.as_ref().unwrap(), &entry_scope, depth)
+                        .await?;
+                    entry_scope.set(prop.name.clone(), val);
+                }
+                Entry::ClassDef(name, class_mods, parent, body) => {
+                    let defaults = self
+                        .eval_class_def(
+                            name,
+                            class_mods,
+                            parent.as_deref(),
+                            body,
+                            &entry_scope,
+                            depth,
+                        )
+                        .await?;
+                    entry_scope.set(name.clone(), defaults);
+                }
+                Entry::TypeAlias(name, ty) => {
+                    self.eval_type_alias(name, ty, &mut entry_scope);
+                }
+                _ => {}
+            }
+        }
+        for (name, expr) in deferred_lambdas {
+            let val = self.eval_expr(expr, &entry_scope, depth).await?;
+            entry_scope.set(name, val);
+        }
+
         let explicit_default = self
-            .find_default_template(entries, scope, depth)
+            .find_default_template(entries, &entry_scope, depth)
             .await?
-            .or(inherited_default);
+            .or(inherited_default.value);
+        let explicit_default_entries =
+            find_default_body_entries(entries).or(inherited_default.entries);
 
         for entry in entries {
             match entry {
                 Entry::DynProperty(key_expr, val_expr) => {
-                    let key = self.eval_expr(key_expr, scope, depth + 1).await?;
+                    let key = self.eval_expr(key_expr, &entry_scope, depth + 1).await?;
                     let type_default = match val_expr {
                         Expr::ObjectBody(body) => select_mapping_type_default(type_defaults, body)
                             .map(|(name, value)| (Some(name.as_str()), value)),
@@ -2347,22 +2405,44 @@ impl Evaluator {
                         (None, Some(explicit_default)) => Some((None, explicit_default.clone())),
                         (None, None) => None,
                     };
-                    // If the default template has ObjectSource, amend the evaluated
-                    // template so inherited mapping defaults and nested amendments survive.
+                    // If the default template has ObjectSource, amend its source entries
+                    // so late-bound class properties are recomputed after overrides.
                     let val =
                         if let Some((default_type_name, Value::Object(template_map, Some(src)))) =
                             default_template.as_ref()
                             && let Expr::ObjectBody(body) = val_expr
                         {
-                            let mut result = self
-                                .eval_object_body_over_template(
-                                    template_map,
-                                    src,
-                                    body,
-                                    scope,
-                                    depth,
-                                )
-                                .await?;
+                            let mut result =
+                                if let Some(default_entries) = explicit_default_entries.as_ref() {
+                                    let mut overlay_entries = default_entries.clone();
+                                    overlay_entries.extend(body.iter().cloned());
+                                    self.eval_amended_object(
+                                        &src.entries,
+                                        &src.scope,
+                                        &overlay_entries,
+                                        &entry_scope,
+                                        depth,
+                                    )
+                                    .await?
+                                } else if explicit_default.is_some() && type_default.is_some() {
+                                    self.eval_object_body_over_template(
+                                        template_map,
+                                        src,
+                                        body,
+                                        &entry_scope,
+                                        depth,
+                                    )
+                                    .await?
+                                } else {
+                                    self.eval_amended_object(
+                                        &src.entries,
+                                        &src.scope,
+                                        body,
+                                        &entry_scope,
+                                        depth,
+                                    )
+                                    .await?
+                                };
                             let type_name = src.type_name.as_deref().or(*default_type_name);
                             if let Some(tn) = type_name
                                 && let Value::Object(_, ref mut result_src) = result
@@ -2386,7 +2466,7 @@ impl Evaluator {
                             }
                             result
                         } else {
-                            let mut val = self.eval_expr(val_expr, scope, depth + 1).await?;
+                            let mut val = self.eval_expr(val_expr, &entry_scope, depth + 1).await?;
                             if let Some((_, tpl)) = default_template {
                                 val = merge_values(tpl, val);
                             }
@@ -2399,15 +2479,17 @@ impl Evaluator {
                     if prop.name == "default"
                         && (explicit_default.is_some() || !type_defaults.is_empty()) => {}
                 Entry::Spread(e) => {
-                    let val = self.eval_expr(e, scope, depth + 1).await?;
+                    let val = self.eval_expr(e, &entry_scope, depth + 1).await?;
                     if let Value::Object(m, _) = val {
                         map.extend(m.iter().map(|(k, v)| (k.clone(), v.clone())));
                     }
                 }
                 Entry::ForGenerator(fgen) => {
-                    let collection = self.eval_expr(&fgen.collection, scope, depth + 1).await?;
+                    let collection = self
+                        .eval_expr(&fgen.collection, &entry_scope, depth + 1)
+                        .await?;
                     for (k, v) in collection_to_items(collection) {
-                        let mut iter_scope = scope.child();
+                        let mut iter_scope = entry_scope.child();
                         iter_scope.set(fgen.val_var.clone(), v);
                         if let Some(kv) = &fgen.key_var {
                             iter_scope.set(kv.clone(), k);
@@ -2418,7 +2500,10 @@ impl Evaluator {
                             depth + 1,
                             map,
                             type_defaults,
-                            explicit_default.clone(),
+                            MappingInheritedDefault {
+                                value: explicit_default.clone(),
+                                entries: explicit_default_entries.clone(),
+                            },
                         )
                         .await?;
                     }
@@ -2590,6 +2675,18 @@ fn select_mapping_type_default<'a>(
     // order. This mirrors Pkl's first assignable type behavior when there is no
     // stronger structural signal in the entry body.
     best.or_else(|| type_defaults.first())
+}
+
+fn find_default_body_entries(entries: &[Entry]) -> Option<Vec<Entry>> {
+    entries.iter().find_map(|entry| {
+        if let Entry::Property(prop) = entry
+            && prop.name == "default"
+            && !has_modifier(&prop.modifiers, Modifier::Local)
+        {
+            return prop.body.clone();
+        }
+        None
+    })
 }
 
 fn object_declares_field(value: &Value, field: &str) -> bool {

--- a/tests/pkl_features.rs
+++ b/tests/pkl_features.rs
@@ -3297,6 +3297,48 @@ hook = new Hook {
 }
 
 #[test]
+fn mapping_local_const_is_visible_to_dynamic_entries() {
+    let json = eval(
+        r#"
+values = new Mapping<String, String> {
+    local const prefix = "hello"
+    ["message"] = "\(prefix), world"
+}
+"#,
+    );
+    assert_eq!(json["values"]["message"], "hello, world");
+}
+
+#[test]
+fn mapping_local_function_is_visible_to_dynamic_entries() {
+    let json = eval(
+        r#"
+values = new Mapping<String, String> {
+    local const prefix = "value"
+    local function wrap(s: String): String = "[\(prefix):\(s)]"
+    ["message"] = wrap("ok")
+}
+"#,
+    );
+    assert_eq!(json["values"]["message"], "[value:ok]");
+}
+
+#[test]
+fn mapping_local_body_is_visible_to_dynamic_entries() {
+    let json = eval(
+        r#"
+values = new Mapping<String, Int> {
+    local options {
+        port = 3000
+    }
+    ["port"] = options.port
+}
+"#,
+    );
+    assert_eq!(json["values"]["port"], 3000);
+}
+
+#[test]
 fn single_type_mapping_amendment_preserves_default_template() {
     let json = eval_with_converters(
         r#"
@@ -3324,6 +3366,31 @@ hook = new Hook {
     );
     assert_eq!(json["hook"]["steps"]["echo"]["check"], "echo ok");
     assert_eq!(json["hook"]["steps"]["echo"]["enabled"], true);
+}
+
+#[test]
+fn mapping_entry_body_recomputes_late_bound_type_properties() {
+    let json = eval_with_converters(
+        r#"
+class Step {
+    check: String = ""
+    label: String = "Step: \(check)"
+    enabled: Boolean = false
+}
+
+steps = new Mapping<String, Step> {
+    default {
+        enabled = true
+    }
+    ["lint"] {
+        check = "eslint"
+    }
+}
+"#,
+    );
+    assert_eq!(json["steps"]["lint"]["check"], "eslint");
+    assert_eq!(json["steps"]["lint"]["label"], "Step: eslint");
+    assert_eq!(json["steps"]["lint"]["enabled"], true);
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- evaluate local properties, class definitions, and type aliases before processing typed mapping entries
- make mapping defaults and dynamic entries see mapping-local values such as hk builtin testMaker helpers
- add a regression for local const usage inside a Mapping

## Verification
- cargo fmt --check
- cargo test mapping_local_const_is_visible_to_dynamic_entries
- cargo test converter_union_mapping
- cargo test single_type_mapping_amendment_preserves_default_template
- cargo test

*This PR description was generated by AI.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core mapping evaluation and default merging in the evaluator; behavior is localized but affects all typed mappings and amendments.
> 
> **Overview**
> Fixes **typed `Mapping` evaluation** so mapping-local definitions are in scope before dynamic keys run, and so **default templates** can be re-evaluated with **late binding** when entries override fields.
> 
> `eval_mapping_entries_with_type_default` now builds an **`entry_scope`** first (locals, local bodies, class defs, type aliases, deferred lambdas)—matching ordinary object bodies—then evaluates `["key"]` entries against that scope instead of the outer scope only.
> 
> Inherited mapping defaults are modeled as **`MappingInheritedDefault`** (evaluated default **value** plus optional **`default { ... }` AST entries**). When a typed entry body amends a default object, the evaluator can **merge default body entries with the entry overlay** and run **`eval_amended_object`**, so properties like `label = "Step: \(check)"` update after `check` is set in the entry.
> 
> Regression tests cover **local const / function / body** inside mappings and **recomputed late-bound class fields** on mapping entries with a `default` block.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 60be82be073a63d8981e6553567a27c2cf3cf52d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected scope handling for typed mappings so local constants, functions, and local blocks are visible to dynamic mapping entries and loop bodies.
  * Ensured mapping entry defaults merge correctly and object-like defaults are applied reliably.
  * Fixed evaluation order so typed mapping properties are computed late-bound when passed through output rendering.

* **Tests**
  * Added regression tests covering these mapping and scope scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->