### PR TITLE
chore(deps): use cargo trusted publishing

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -14,6 +14,7 @@ jobs:
     if: ${{ github.repository_owner == 'jdx' }}
     permissions:
       contents: write
+      id-token: write
       pull-requests: write
     outputs:
       tag: ${{ steps.release-plz.outputs.releases && fromJSON(steps.release-plz.outputs.releases)[0].tag || '' }}
@@ -25,6 +26,9 @@ jobs:
           persist-credentials: false
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - name: Authenticate with crates.io
+        id: crates-io-auth
+        uses: rust-lang/crates-io-auth-action@bbd81622f20ce9e2dd9622e3218b975523e45bbe # v1.0.4
       - name: Run release-plz
         id: release-plz
         uses: release-plz/action@064f4d1e36c843611ddf013be726beaa4ad804db # v0.5.129
@@ -32,7 +36,7 @@ jobs:
           command: release
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ steps.crates-io-auth.outputs.token }}
 
   enhance-release:
     name: Enhance release notes


### PR DESCRIPTION
## Summary
- grant the release job `id-token: write` so GitHub can issue an OIDC token
- exchange that OIDC token with crates.io via `rust-lang/crates-io-auth-action@v1.0.4`
- pass the short-lived token to `release-plz` as `CARGO_REGISTRY_TOKEN` instead of using the long-lived `secrets.CARGO_REGISTRY_TOKEN`

## Setup note
Before the next release, crates.io needs a trusted publisher configured for `jdx/pklr` using `.github/workflows/release-plz.yml` and the `release-plz-release` job.

## Verification
- `python3` YAML parse check
- `mise x actionlint@1.7.12 shellcheck@0.11.0 -- actionlint .github/workflows/release-plz.yml`

References: crates.io trusted publishing uses OIDC and `rust-lang/crates-io-auth-action` to produce a temporary Cargo registry token.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how crates.io credentials are obtained for releases; misconfigured trusted publishing would block publishes until crates.io is set up correctly.
> 
> **Overview**
> The **release-plz-release** job now uses **crates.io trusted publishing** instead of a stored registry API token.
> 
> It adds **`id-token: write`** on that job, runs **`rust-lang/crates-io-auth-action`** to exchange the GitHub OIDC token for a short-lived Cargo token, and wires **`CARGO_REGISTRY_TOKEN`** from that step output rather than **`secrets.CARGO_REGISTRY_TOKEN`**. The release-pr job is unchanged.
> 
> **Setup:** crates.io must have a trusted publisher for this repo/workflow/job before the next publish will succeed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e5b1ad2fd644f201d4eb598690da93217f7a0c16. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->