### PR TITLE
chore: release v0.4.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.5](https://github.com/jdx/pklr/compare/v0.4.4...v0.4.5) - 2026-06-09
+
+### Fixed
+
+- *(eval)* preserve mapping locals ([#88](https://github.com/jdx/pklr/pull/88))
+
 ## [0.4.4](https://github.com/jdx/pklr/compare/v0.4.3...v0.4.4) - 2026-06-08
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -651,7 +651,7 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pklr"
-version = "0.4.4"
+version = "0.4.5"
 dependencies = [
  "async-recursion",
  "indexmap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "pklr"
-version     = "0.4.4"
+version     = "0.4.5"
 edition      = "2024"
 rust-version = "1.88"
 description = "Pure Rust pkl configuration language parser and evaluator"


### PR DESCRIPTION



## 🤖 New release

* `pklr`: 0.4.4 -> 0.4.5 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.4.5](https://github.com/jdx/pklr/compare/v0.4.4...v0.4.5) - 2026-06-09

### Fixed

- *(eval)* preserve mapping locals ([#88](https://github.com/jdx/pklr/pull/88))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version and changelog-only release with no code changes in the diff; API-compatible per release tooling.
> 
> **Overview**
> **Release v0.4.5** — bumps the `pklr` crate from **0.4.4** to **0.4.5** in `Cargo.toml` and `Cargo.lock`, and records the release in **CHANGELOG.md**.
> 
> The documented user-facing change for this version is a fix in **eval**: **mapping locals are preserved** ([#88](https://github.com/jdx/pklr/pull/88)). No application source changes appear in this diff; it is a **release-plz** packaging PR for publishing that fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 32b2634c219423e8ad5d655692f485761a7d15de. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->