### PR TITLE
fix(eval): skip unused imports

### DIFF
--- a/src/eval.rs
+++ b/src/eval.rs
@@ -2961,33 +2961,32 @@ fn referenced_roots(entries: &[Entry]) -> HashSet<String> {
     let mut refs = HashSet::new();
     let shadows = HashSet::new();
     collect_entry_refs(entries, &mut refs, &shadows);
-    for name in declared_entry_roots(entries) {
-        refs.remove(&name);
-    }
     refs
 }
 
 fn collect_entry_refs(entries: &[Entry], refs: &mut HashSet<String>, shadows: &HashSet<String>) {
+    let mut entry_shadows = shadows.clone();
+    entry_shadows.extend(declared_entry_roots(entries));
     for entry in entries {
         match entry {
             Entry::Property(prop) => {
                 if let Some(ty) = &prop.type_ann {
-                    collect_type_refs(ty, refs, shadows);
+                    collect_type_refs(ty, refs, &entry_shadows);
                 }
                 if let Some(expr) = &prop.value {
-                    collect_expr_refs(expr, refs, shadows);
+                    collect_expr_refs(expr, refs, &entry_shadows);
                 }
                 if let Some(body) = &prop.body {
-                    collect_entry_refs(body, refs, shadows);
+                    collect_entry_refs(body, refs, &entry_shadows);
                 }
             }
             Entry::DynProperty(key, value) => {
-                collect_expr_refs(key, refs, shadows);
-                collect_expr_refs(value, refs, shadows);
+                collect_expr_refs(key, refs, &entry_shadows);
+                collect_expr_refs(value, refs, &entry_shadows);
             }
             Entry::ForGenerator(fgen) => {
-                collect_expr_refs(&fgen.collection, refs, shadows);
-                let mut body_shadows = shadows.clone();
+                collect_expr_refs(&fgen.collection, refs, &entry_shadows);
+                let mut body_shadows = entry_shadows.clone();
                 body_shadows.insert(fgen.val_var.clone());
                 if let Some(key_var) = &fgen.key_var {
                     body_shadows.insert(key_var.clone());
@@ -2995,20 +2994,22 @@ fn collect_entry_refs(entries: &[Entry], refs: &mut HashSet<String>, shadows: &H
                 collect_entry_refs(&fgen.body, refs, &body_shadows);
             }
             Entry::WhenGenerator(wgen) => {
-                collect_expr_refs(&wgen.condition, refs, shadows);
-                collect_entry_refs(&wgen.body, refs, shadows);
+                collect_expr_refs(&wgen.condition, refs, &entry_shadows);
+                collect_entry_refs(&wgen.body, refs, &entry_shadows);
                 if let Some(else_body) = &wgen.else_body {
-                    collect_entry_refs(else_body, refs, shadows);
+                    collect_entry_refs(else_body, refs, &entry_shadows);
                 }
             }
-            Entry::Spread(expr) | Entry::Elem(expr) => collect_expr_refs(expr, refs, shadows),
+            Entry::Spread(expr) | Entry::Elem(expr) => {
+                collect_expr_refs(expr, refs, &entry_shadows)
+            }
             Entry::ClassDef(_, _, parent, body) => {
                 if let Some(parent) = parent {
-                    collect_name_root(parent, refs, shadows);
+                    collect_name_root(parent, refs, &entry_shadows);
                 }
-                collect_entry_refs(body, refs, shadows);
+                collect_entry_refs(body, refs, &entry_shadows);
             }
-            Entry::TypeAlias(_, ty) => collect_type_refs(ty, refs, shadows),
+            Entry::TypeAlias(_, ty) => collect_type_refs(ty, refs, &entry_shadows),
         }
     }
 }

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::rc::Rc;
 use std::sync::Arc;
 
@@ -299,6 +299,7 @@ impl Evaluator {
         }
         let mut scope = Scope::default();
         seed_builtins(&mut scope);
+        let referenced_imports = referenced_roots(&module.body);
 
         // Process imports
         for import in &module.imports {
@@ -310,6 +311,9 @@ impl Evaluator {
                     .alias
                     .clone()
                     .ok_or_else(|| Error::Eval("import* requires an alias".into()))?;
+                if !referenced_imports.contains(&alias) {
+                    continue;
+                }
 
                 // Non-local glob imports bind an empty mapping
                 if uri.contains("://") {
@@ -331,13 +335,6 @@ impl Evaluator {
 
             if uri.starts_with("https://") || uri.starts_with("http://") {
                 // HTTP import
-                let source = self.fetch_source(uri).await?;
-                let imported_val = {
-                    let tokens = lexer::lex_named(&source, uri)?;
-                    let imp_module = parser::parse_named(&tokens, &source, uri)?;
-                    self.eval_module(&imp_module, Path::new(uri), depth + 1)
-                        .await?
-                };
                 let alias = import.alias.clone().unwrap_or_else(|| {
                     uri.rsplit('/')
                         .next()
@@ -346,6 +343,16 @@ impl Evaluator {
                         .unwrap_or(uri)
                         .to_string()
                 });
+                if !referenced_imports.contains(&alias) {
+                    continue;
+                }
+                let source = self.fetch_source(uri).await?;
+                let imported_val = {
+                    let tokens = lexer::lex_named(&source, uri)?;
+                    let imp_module = parser::parse_named(&tokens, &source, uri)?;
+                    self.eval_module(&imp_module, Path::new(uri), depth + 1)
+                        .await?
+                };
                 scope.set(alias, imported_val);
                 continue;
             }
@@ -354,20 +361,23 @@ impl Evaluator {
                 let pkg = resolve_package_uri(uri)?;
                 let fragment = uri.split_once('#').map(|(_, f)| f).unwrap_or("");
                 let file_path = fragment.strip_prefix('/').unwrap_or(fragment);
+                let alias = import.alias.clone().unwrap_or_else(|| {
+                    file_path
+                        .rsplit('/')
+                        .next()
+                        .unwrap_or(file_path)
+                        .strip_suffix(".pkl")
+                        .unwrap_or(file_path)
+                        .to_string()
+                });
+                if !referenced_imports.contains(&alias) {
+                    continue;
+                }
                 // For zip packages, extract to temp dir and eval as local file
                 if let PackageSource::Zip(zip_url, _) = &pkg {
                     let pkg_dir = self.extract_package_zip(zip_url).await?;
                     let local_path = pkg_dir.join(file_path);
                     let imported_val = self.eval_file(&local_path, depth + 1).await?;
-                    let alias = import.alias.clone().unwrap_or_else(|| {
-                        file_path
-                            .rsplit('/')
-                            .next()
-                            .unwrap_or(file_path)
-                            .strip_suffix(".pkl")
-                            .unwrap_or(file_path)
-                            .to_string()
-                    });
                     scope.set(alias, imported_val);
                     continue;
                 }
@@ -382,15 +392,6 @@ impl Evaluator {
                     self.eval_module(&imp_module, Path::new(&url), depth + 1)
                         .await?
                 };
-                let alias = import.alias.clone().unwrap_or_else(|| {
-                    file_path
-                        .rsplit('/')
-                        .next()
-                        .unwrap_or(file_path)
-                        .strip_suffix(".pkl")
-                        .unwrap_or(file_path)
-                        .to_string()
-                });
                 scope.set(alias, imported_val);
                 continue;
             }
@@ -402,6 +403,9 @@ impl Evaluator {
                     .alias
                     .clone()
                     .unwrap_or_else(|| module_name.to_string());
+                if !referenced_imports.contains(&alias) {
+                    continue;
+                }
                 scope.set(alias, stdlib_val);
                 continue;
             }
@@ -417,19 +421,21 @@ impl Evaluator {
                 let base = path.parent().unwrap_or(Path::new("."));
                 base.join(uri)
             };
+            let alias = import.alias.clone().unwrap_or_else(|| {
+                import_path
+                    .file_stem()
+                    .unwrap_or_default()
+                    .to_string_lossy()
+                    .to_string()
+            });
+            if !referenced_imports.contains(&alias) {
+                continue;
+            }
             if !import_path.exists() {
                 return Err(Error::ImportNotFound(import_path.display().to_string()));
             }
             {
                 let imported_val = self.eval_file(&import_path, depth + 1).await?;
-                // Determine the binding name: alias or filename stem
-                let alias = import.alias.clone().unwrap_or_else(|| {
-                    import_path
-                        .file_stem()
-                        .unwrap_or_default()
-                        .to_string_lossy()
-                        .to_string()
-                });
                 scope.set(alias, imported_val);
             }
         }
@@ -2701,6 +2707,139 @@ fn object_declares_field(value: &Value, field: &str) -> bool {
                 _ => false,
             })
         })
+}
+
+fn referenced_roots(entries: &[Entry]) -> HashSet<String> {
+    let mut refs = HashSet::new();
+    collect_entry_refs(entries, &mut refs);
+    refs
+}
+
+fn collect_entry_refs(entries: &[Entry], refs: &mut HashSet<String>) {
+    for entry in entries {
+        match entry {
+            Entry::Property(prop) => {
+                if let Some(ty) = &prop.type_ann {
+                    collect_type_refs(ty, refs);
+                }
+                if let Some(expr) = &prop.value {
+                    collect_expr_refs(expr, refs);
+                }
+                if let Some(body) = &prop.body {
+                    collect_entry_refs(body, refs);
+                }
+            }
+            Entry::DynProperty(key, value) => {
+                collect_expr_refs(key, refs);
+                collect_expr_refs(value, refs);
+            }
+            Entry::ForGenerator(fgen) => {
+                collect_expr_refs(&fgen.collection, refs);
+                collect_entry_refs(&fgen.body, refs);
+            }
+            Entry::WhenGenerator(wgen) => {
+                collect_expr_refs(&wgen.condition, refs);
+                collect_entry_refs(&wgen.body, refs);
+                if let Some(else_body) = &wgen.else_body {
+                    collect_entry_refs(else_body, refs);
+                }
+            }
+            Entry::Spread(expr) | Entry::Elem(expr) => collect_expr_refs(expr, refs),
+            Entry::ClassDef(_, _, parent, body) => {
+                if let Some(parent) = parent {
+                    collect_name_root(parent, refs);
+                }
+                collect_entry_refs(body, refs);
+            }
+            Entry::TypeAlias(_, ty) => collect_type_refs(ty, refs),
+        }
+    }
+}
+
+fn collect_expr_refs(expr: &Expr, refs: &mut HashSet<String>) {
+    match expr {
+        Expr::Ident(name) => {
+            refs.insert(name.clone());
+        }
+        Expr::New(type_name, entries, generic_params) => {
+            if let Some(type_name) = type_name {
+                collect_name_root(type_name, refs);
+            }
+            for param in generic_params {
+                collect_name_root(param, refs);
+            }
+            collect_entry_refs(entries, refs);
+        }
+        Expr::Field(base, _) | Expr::NullSafeField(base, _) => collect_expr_refs(base, refs),
+        Expr::Index(base, index) | Expr::Binop(_, base, index) => {
+            collect_expr_refs(base, refs);
+            collect_expr_refs(index, refs);
+        }
+        Expr::Call(callee, args) => {
+            collect_expr_refs(callee, refs);
+            for arg in args {
+                collect_expr_refs(arg, refs);
+            }
+        }
+        Expr::If(cond, then_expr, else_expr) => {
+            collect_expr_refs(cond, refs);
+            collect_expr_refs(then_expr, refs);
+            collect_expr_refs(else_expr, refs);
+        }
+        Expr::Let(_, value, body) => {
+            collect_expr_refs(value, refs);
+            collect_expr_refs(body, refs);
+        }
+        Expr::Is(value, ty) | Expr::As(value, ty) => {
+            collect_expr_refs(value, refs);
+            collect_type_refs(ty, refs);
+        }
+        Expr::Unop(_, value)
+        | Expr::Lambda(_, value)
+        | Expr::Throw(value)
+        | Expr::Trace(value)
+        | Expr::Read(value)
+        | Expr::ReadOrNull(value) => collect_expr_refs(value, refs),
+        Expr::ObjectBody(entries) => collect_entry_refs(entries, refs),
+        Expr::StringInterpolation(parts) => {
+            for part in parts {
+                if let StringInterpPart::Expr(expr) = part {
+                    collect_expr_refs(expr, refs);
+                }
+            }
+        }
+        Expr::Null | Expr::Bool(_) | Expr::Int(_) | Expr::Float(_) | Expr::String(_) => {}
+    }
+}
+
+fn collect_type_refs(ty: &crate::parser::TypeExpr, refs: &mut HashSet<String>) {
+    match ty {
+        crate::parser::TypeExpr::Named(name) => collect_name_root(name, refs),
+        crate::parser::TypeExpr::Nullable(inner) => collect_type_refs(inner, refs),
+        crate::parser::TypeExpr::Union(types) => {
+            for ty in types {
+                collect_type_refs(ty, refs);
+            }
+        }
+        crate::parser::TypeExpr::Generic(name, params) => {
+            collect_name_root(name, refs);
+            for param in params {
+                collect_type_refs(param, refs);
+            }
+        }
+        crate::parser::TypeExpr::Constrained(name, expr) => {
+            collect_name_root(name, refs);
+            collect_expr_refs(expr, refs);
+        }
+    }
+}
+
+fn collect_name_root(name: &str, refs: &mut HashSet<String>) {
+    if let Some(root) = name.split('.').next()
+        && !root.is_empty()
+    {
+        refs.insert(root.to_string());
+    }
 }
 
 // --- Scope ---

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -191,6 +191,81 @@ impl Evaluator {
         Ok(body)
     }
 
+    #[async_recursion(?Send)]
+    async fn inherited_reference_roots(
+        &mut self,
+        module: &Module,
+        path: &Path,
+        depth: usize,
+    ) -> Result<HashSet<String>> {
+        let mut refs = HashSet::new();
+        if depth > self.max_depth {
+            return Ok(refs);
+        }
+        for uri in [module.amends.as_deref(), module.extends.as_deref()]
+            .into_iter()
+            .flatten()
+        {
+            if let Some((source, source_path)) = self.load_module_source(uri, path).await?
+                && let Ok(tokens) = lexer::lex_named(&source, &source_path)
+                && let Ok(base_module) = parser::parse_named(&tokens, &source, &source_path)
+            {
+                refs.extend(referenced_roots(&base_module.body));
+                refs.extend(
+                    self.inherited_reference_roots(
+                        &base_module,
+                        Path::new(&source_path),
+                        depth + 1,
+                    )
+                    .await?,
+                );
+            }
+        }
+        Ok(refs)
+    }
+
+    async fn load_module_source(
+        &mut self,
+        uri: &str,
+        path: &Path,
+    ) -> Result<Option<(String, String)>> {
+        if uri.starts_with("https://") || uri.starts_with("http://") {
+            let source = self.fetch_source(uri).await?;
+            return Ok(Some((source, uri.to_string())));
+        }
+        if uri.starts_with("package://") {
+            let pkg = resolve_package_uri(uri)?;
+            match &pkg {
+                PackageSource::Direct(url) => {
+                    let source = self.fetch_source(url).await?;
+                    return Ok(Some((source, url.clone())));
+                }
+                PackageSource::Zip(zip_url, entry) => {
+                    let pkg_dir = self.extract_package_zip(zip_url).await?;
+                    let local_path = pkg_dir.join(entry);
+                    let source = std::fs::read_to_string(&local_path)
+                        .map_err(|e| Error::Io(local_path.clone(), e))?;
+                    return Ok(Some((source, local_path.display().to_string())));
+                }
+            }
+        }
+        if uri.starts_with("pkl:") || (uri.contains("://") && !uri.starts_with("file://")) {
+            return Ok(None);
+        }
+        let import_path = if let Some(rel) = uri.strip_prefix("file://") {
+            PathBuf::from(rel)
+        } else {
+            let base = path.parent().unwrap_or(Path::new("."));
+            base.join(uri)
+        };
+        if !import_path.exists() {
+            return Ok(None);
+        }
+        let source =
+            std::fs::read_to_string(&import_path).map_err(|e| Error::Io(import_path.clone(), e))?;
+        Ok(Some((source, import_path.display().to_string())))
+    }
+
     /// Download a package zip and extract it to a temp directory.
     /// Returns the path to the extracted directory. Caches by zip URL.
     async fn extract_package_zip(&mut self, zip_url: &str) -> Result<PathBuf> {
@@ -289,8 +364,18 @@ impl Evaluator {
         Ok(val)
     }
 
-    #[async_recursion(?Send)]
     async fn eval_module(&mut self, module: &Module, path: &Path, depth: usize) -> Result<Value> {
+        self.eval_module_with_scope(module, path, depth, None).await
+    }
+
+    #[async_recursion(?Send)]
+    async fn eval_module_with_scope(
+        &mut self,
+        module: &Module,
+        path: &Path,
+        depth: usize,
+        inherited_scope: Option<Scope>,
+    ) -> Result<Value> {
         if depth > self.max_depth {
             return Err(Error::Eval(format!(
                 "max import depth {} exceeded",
@@ -306,7 +391,19 @@ impl Evaluator {
         }
         let mut scope = Scope::default();
         seed_builtins(&mut scope);
-        let referenced_imports = referenced_roots(&module.body);
+        if let Some(inherited_scope) = inherited_scope {
+            for (key, value) in inherited_scope.flatten() {
+                scope.set(key, value);
+            }
+            for (key, ty) in inherited_scope.flatten_type_aliases() {
+                scope.set_type_alias(key, ty);
+            }
+        }
+        let mut referenced_imports = referenced_roots(&module.body);
+        referenced_imports.extend(
+            self.inherited_reference_roots(module, path, depth + 1)
+                .await?,
+        );
 
         // Process imports
         for import in &module.imports {
@@ -456,7 +553,12 @@ impl Evaluator {
                 let tokens = lexer::lex_named(&source, uri)?;
                 let base_module = parser::parse_named(&tokens, &source, uri)?;
                 let base_val = self
-                    .eval_module(&base_module, Path::new(uri), depth + 1)
+                    .eval_module_with_scope(
+                        &base_module,
+                        Path::new(uri),
+                        depth + 1,
+                        Some(scope.clone()),
+                    )
                     .await?;
                 if let Value::Object(m, _) = base_val {
                     base_obj = (*m).clone();
@@ -466,7 +568,19 @@ impl Evaluator {
                 if let PackageSource::Zip(zip_url, entry) = &pkg {
                     let pkg_dir = self.extract_package_zip(zip_url).await?;
                     let local_path = pkg_dir.join(entry);
-                    let base_val = self.eval_file(&local_path, depth + 1).await?;
+                    let source = std::fs::read_to_string(&local_path)
+                        .map_err(|e| Error::Io(local_path.clone(), e))?;
+                    let name = local_path.display().to_string();
+                    let tokens = lexer::lex_named(&source, &name)?;
+                    let base_module = parser::parse_named(&tokens, &source, &name)?;
+                    let base_val = self
+                        .eval_module_with_scope(
+                            &base_module,
+                            &local_path,
+                            depth + 1,
+                            Some(scope.clone()),
+                        )
+                        .await?;
                     if let Value::Object(m, _) = base_val {
                         base_obj = (*m).clone();
                     }
@@ -475,7 +589,12 @@ impl Evaluator {
                     let tokens = lexer::lex_named(&source, url)?;
                     let base_module = parser::parse_named(&tokens, &source, url)?;
                     let base_val = self
-                        .eval_module(&base_module, Path::new(url.as_str()), depth + 1)
+                        .eval_module_with_scope(
+                            &base_module,
+                            Path::new(url.as_str()),
+                            depth + 1,
+                            Some(scope.clone()),
+                        )
                         .await?;
                     if let Value::Object(m, _) = base_val {
                         base_obj = (*m).clone();
@@ -491,7 +610,19 @@ impl Evaluator {
                     base.join(uri)
                 };
                 if amends_path.exists() {
-                    let base_val = self.eval_file(&amends_path, depth + 1).await?;
+                    let source = std::fs::read_to_string(&amends_path)
+                        .map_err(|e| Error::Io(amends_path.clone(), e))?;
+                    let name = amends_path.display().to_string();
+                    let tokens = lexer::lex_named(&source, &name)?;
+                    let base_module = parser::parse_named(&tokens, &source, &name)?;
+                    let base_val = self
+                        .eval_module_with_scope(
+                            &base_module,
+                            &amends_path,
+                            depth + 1,
+                            Some(scope.clone()),
+                        )
+                        .await?;
                     if let Value::Object(m, _) = base_val {
                         base_obj = (*m).clone();
                     }
@@ -591,7 +722,12 @@ impl Evaluator {
                     let ext_module = parser::parse_named(&tokens, &source, &name)?;
                     // Evaluate the base module to get its properties
                     let ext_val = self
-                        .eval_module(&ext_module, &extends_path, depth + 1)
+                        .eval_module_with_scope(
+                            &ext_module,
+                            &extends_path,
+                            depth + 1,
+                            Some(scope.clone()),
+                        )
                         .await?;
                     if let Value::Object(m, _) = ext_val {
                         base_obj = (*m).clone();
@@ -629,7 +765,12 @@ impl Evaluator {
                 let tokens = lexer::lex_named(&source, uri)?;
                 let ext_module = parser::parse_named(&tokens, &source, uri)?;
                 let ext_val = self
-                    .eval_module(&ext_module, Path::new(uri), depth + 1)
+                    .eval_module_with_scope(
+                        &ext_module,
+                        Path::new(uri),
+                        depth + 1,
+                        Some(scope.clone()),
+                    )
                     .await?;
                 if let Value::Object(m, _) = ext_val {
                     base_obj = (*m).clone();

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -533,6 +533,8 @@ impl Evaluator {
                     .to_string()
             });
             if !referenced_imports.contains(&alias) {
+                // Unused imports are intentionally lazy: missing local paths are
+                // reported only if the imported binding is actually referenced.
                 continue;
             }
             if !import_path.exists() {

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -20,6 +20,8 @@ pub struct Evaluator {
     http_cache: HashMap<String, String>,
     /// Cache for evaluated local imports (canonical path → Value)
     import_cache: HashMap<PathBuf, Value>,
+    /// Local files currently being evaluated with inherited scope.
+    scoped_imports_in_flight: HashSet<PathBuf>,
     /// Reusable HTTP client for connection pooling
     http_client: reqwest::Client,
     /// Extracted package zip directories (zip URL → temp dir path)
@@ -49,6 +51,7 @@ impl Default for Evaluator {
             max_depth: 32,
             http_cache: HashMap::new(),
             import_cache: HashMap::new(),
+            scoped_imports_in_flight: HashSet::new(),
             http_client: reqwest::Client::new(),
             package_dirs: HashMap::new(),
             http_rewrites: Vec::new(),
@@ -354,8 +357,10 @@ impl Evaluator {
         canonical: &Path,
         depth: usize,
     ) -> Result<Value> {
-        self.eval_file_inner_with_scope(path, canonical, depth, None)
-            .await
+        let val = self.eval_file_inner_with_scope(path, depth, None).await?;
+        self.import_cache
+            .insert(canonical.to_path_buf(), val.clone());
+        Ok(val)
     }
 
     async fn eval_file_with_scope(
@@ -370,23 +375,19 @@ impl Evaluator {
         let canonical = path
             .canonicalize()
             .map_err(|e| Error::Io(path.to_path_buf(), e))?;
-        self.import_cache.insert(
-            canonical.clone(),
-            Value::Object(Arc::new(IndexMap::new()), None),
-        );
-        let result = self
-            .eval_file_inner_with_scope(path, &canonical, depth, inherited_scope)
-            .await;
-        if result.is_err() {
-            self.import_cache.remove(&canonical);
+        if !self.scoped_imports_in_flight.insert(canonical.clone()) {
+            return Ok(Value::Object(Arc::new(IndexMap::new()), None));
         }
+        let result = self
+            .eval_file_inner_with_scope(path, depth, inherited_scope)
+            .await;
+        self.scoped_imports_in_flight.remove(&canonical);
         result
     }
 
     async fn eval_file_inner_with_scope(
         &mut self,
         path: &Path,
-        canonical: &Path,
         depth: usize,
         inherited_scope: Option<Scope>,
     ) -> Result<Value> {
@@ -397,8 +398,6 @@ impl Evaluator {
         let val = self
             .eval_module_with_scope(&module, path, depth, inherited_scope)
             .await?;
-        self.import_cache
-            .insert(canonical.to_path_buf(), val.clone());
         Ok(val)
     }
 

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -1317,14 +1317,38 @@ impl Evaluator {
             // Set is_open flag and class_name on the result's ObjectSource
             let is_open = has_modifier(class_mods, Modifier::Open);
             if let Value::Object(map, Some(src)) = val {
+                let data_property_names = body
+                    .iter()
+                    .filter_map(|entry| match entry {
+                        Entry::Property(prop)
+                            if !has_modifier(&prop.modifiers, Modifier::Local) =>
+                        {
+                            Some(prop.name.as_str())
+                        }
+                        _ => None,
+                    })
+                    .collect::<HashSet<_>>();
+                let schema_member_names = body
+                    .iter()
+                    .filter_map(|entry| match entry {
+                        Entry::ClassDef(name, ..)
+                            if !data_property_names.contains(name.as_str()) =>
+                        {
+                            Some(name.as_str())
+                        }
+                        Entry::Property(prop)
+                            if matches!(prop.value, Some(Expr::Lambda(..)))
+                                && has_modifier(&prop.modifiers, Modifier::Local)
+                                && !data_property_names.contains(prop.name.as_str()) =>
+                        {
+                            Some(prop.name.as_str())
+                        }
+                        _ => None,
+                    })
+                    .collect::<HashSet<_>>();
                 let mut map = map;
-                Arc::make_mut(&mut map).retain(|key, value| {
-                    !matches!(
-                        value,
-                        Value::Object(_, Some(value_src))
-                            if value_src.type_name.as_deref() == Some(key.as_str())
-                    ) && !matches!(value, Value::Lambda(..))
-                });
+                Arc::make_mut(&mut map)
+                    .retain(|key, _| !schema_member_names.contains(key.as_str()));
                 let mut new_src = (*src).clone();
                 new_src.is_open = is_open;
                 new_src.type_name = Some(class_name.to_string());

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -297,6 +297,13 @@ impl Evaluator {
                 self.max_depth
             )));
         }
+        if module
+            .body
+            .iter()
+            .any(|entry| matches!(entry, Entry::Elem(_)))
+        {
+            return Err(Error::Eval("Invalid property definition".into()));
+        }
         let mut scope = Scope::default();
         seed_builtins(&mut scope);
         let referenced_imports = referenced_roots(&module.body);
@@ -1169,6 +1176,14 @@ impl Evaluator {
             // Set is_open flag and class_name on the result's ObjectSource
             let is_open = has_modifier(class_mods, Modifier::Open);
             if let Value::Object(map, Some(src)) = val {
+                let mut map = map;
+                Arc::make_mut(&mut map).retain(|key, value| {
+                    !matches!(
+                        value,
+                        Value::Object(_, Some(value_src))
+                            if value_src.type_name.as_deref() == Some(key.as_str())
+                    ) && !matches!(value, Value::Lambda(..))
+                });
                 let mut new_src = (*src).clone();
                 new_src.is_open = is_open;
                 new_src.type_name = Some(class_name.to_string());
@@ -2117,7 +2132,9 @@ impl Evaluator {
                 let key = args.first().and_then(|v| v.as_str()).unwrap_or("");
                 Ok(Some(Value::Bool(map.contains_key(key))))
             }
-            (Value::Object(map, _), "toMap") => Ok(Some(Value::Object(map.clone(), None))),
+            (Value::Object(map, _), "toMap" | "toMapping") => {
+                Ok(Some(Value::Object(map.clone(), None)))
+            }
             (Value::Object(map, _), "mapValues") => {
                 let lambda = args
                     .first()
@@ -2195,6 +2212,54 @@ impl Evaluator {
             // merge entry lists and re-evaluate so dependent properties pick up
             // overridden values.
             if let Value::Object(_, Some(base_src)) = &base {
+                if !base_src.mapping_value_types.is_empty() {
+                    let mut type_scope = Scope::default();
+                    for (key, value) in &base_src.scope {
+                        type_scope.set(key.clone(), value.clone());
+                    }
+                    for (key, value) in scope.flatten() {
+                        type_scope.set(key, value);
+                    }
+                    for (key, ty) in scope.flatten_type_aliases() {
+                        type_scope.set_type_alias(key, ty);
+                    }
+                    let value_type_defaults = base_src
+                        .mapping_value_types
+                        .iter()
+                        .filter_map(|name| {
+                            resolve_dotted(&type_scope, name).map(|value| (name.clone(), value))
+                        })
+                        .collect::<Vec<_>>();
+                    let inherited_default = self
+                        .find_default_template(&base_src.entries, &type_scope, depth)
+                        .await?;
+                    let mut amended = IndexMap::new();
+                    self.eval_mapping_entries_with_type_default(
+                        &base_src.entries,
+                        &type_scope,
+                        depth,
+                        &mut amended,
+                        &value_type_defaults,
+                        MappingInheritedDefault::default(),
+                    )
+                    .await?;
+                    if let Value::Object(existing_map, _) = &base {
+                        amended.extend(existing_map.iter().map(|(k, v)| (k.clone(), v.clone())));
+                    }
+                    self.eval_mapping_entries_with_type_default(
+                        overlay_entries,
+                        &type_scope,
+                        depth,
+                        &mut amended,
+                        &value_type_defaults,
+                        MappingInheritedDefault {
+                            value: inherited_default,
+                            entries: find_default_body_entries(&base_src.entries),
+                        },
+                    )
+                    .await?;
+                    return Ok(Value::Object(Arc::new(amended), Some(Arc::clone(base_src))));
+                }
                 return self
                     .eval_amended_object(
                         &base_src.entries.clone(),
@@ -2393,6 +2458,22 @@ impl Evaluator {
             match entry {
                 Entry::DynProperty(key_expr, val_expr) => {
                     let key = self.eval_expr(key_expr, &entry_scope, depth + 1).await?;
+                    let key_str = value_to_key(&key)?;
+                    if let Some(Value::Object(existing_map, Some(existing_src))) = map.get(&key_str)
+                        && let Expr::ObjectBody(body) = val_expr
+                    {
+                        let val = self
+                            .eval_object_body_over_template(
+                                existing_map,
+                                existing_src,
+                                body,
+                                &entry_scope,
+                                depth,
+                            )
+                            .await?;
+                        map.insert(key_str, val);
+                        continue;
+                    }
                     let type_default = match val_expr {
                         Expr::ObjectBody(body) => select_mapping_type_default(type_defaults, body)
                             .map(|(name, value)| (Some(name.as_str()), value)),
@@ -2478,7 +2559,7 @@ impl Evaluator {
                             }
                             val
                         };
-                    map.insert(value_to_key(&key)?, val);
+                    map.insert(key_str, val);
                 }
                 Entry::Property(prop) if has_modifier(&prop.modifiers, Modifier::Local) => {}
                 Entry::Property(prop)

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -354,11 +354,49 @@ impl Evaluator {
         canonical: &Path,
         depth: usize,
     ) -> Result<Value> {
+        self.eval_file_inner_with_scope(path, canonical, depth, None)
+            .await
+    }
+
+    async fn eval_file_with_scope(
+        &mut self,
+        path: &Path,
+        depth: usize,
+        inherited_scope: Option<Scope>,
+    ) -> Result<Value> {
+        if inherited_scope.is_none() {
+            return self.eval_file(path, depth).await;
+        }
+        let canonical = path
+            .canonicalize()
+            .map_err(|e| Error::Io(path.to_path_buf(), e))?;
+        self.import_cache.insert(
+            canonical.clone(),
+            Value::Object(Arc::new(IndexMap::new()), None),
+        );
+        let result = self
+            .eval_file_inner_with_scope(path, &canonical, depth, inherited_scope)
+            .await;
+        if result.is_err() {
+            self.import_cache.remove(&canonical);
+        }
+        result
+    }
+
+    async fn eval_file_inner_with_scope(
+        &mut self,
+        path: &Path,
+        canonical: &Path,
+        depth: usize,
+        inherited_scope: Option<Scope>,
+    ) -> Result<Value> {
         let source = std::fs::read_to_string(path).map_err(|e| Error::Io(path.to_path_buf(), e))?;
         let name = path.display().to_string();
         let tokens = lexer::lex_named(&source, &name)?;
         let module = parser::parse_named(&tokens, &source, &name)?;
-        let val = self.eval_module(&module, path, depth).await?;
+        let val = self
+            .eval_module_with_scope(&module, path, depth, inherited_scope)
+            .await?;
         self.import_cache
             .insert(canonical.to_path_buf(), val.clone());
         Ok(val)
@@ -404,6 +442,13 @@ impl Evaluator {
             self.inherited_reference_roots(module, path, depth + 1)
                 .await?,
         );
+
+        let inherited_local_path = module
+            .amends
+            .as_deref()
+            .or(module.extends.as_deref())
+            .and_then(|uri| local_module_path(path, uri));
+        let mut deferred_inherited_imports = Vec::new();
 
         // Process imports
         for import in &module.imports {
@@ -540,6 +585,13 @@ impl Evaluator {
             if !import_path.exists() {
                 return Err(Error::ImportNotFound(import_path.display().to_string()));
             }
+            if inherited_local_path
+                .as_ref()
+                .is_some_and(|inherited_path| same_local_path(inherited_path, &import_path))
+            {
+                deferred_inherited_imports.push(alias);
+                continue;
+            }
             {
                 let imported_val = self.eval_file(&import_path, depth + 1).await?;
                 scope.set(alias, imported_val);
@@ -548,6 +600,7 @@ impl Evaluator {
 
         // Process amends: load base module as starting values
         let mut base_obj = IndexMap::new();
+        let mut inherited_base_val = None;
         if let Some(uri) = &module.amends {
             if uri.starts_with("https://") || uri.starts_with("http://") {
                 // HTTP amends
@@ -612,21 +665,12 @@ impl Evaluator {
                     base.join(uri)
                 };
                 if amends_path.exists() {
-                    let source = std::fs::read_to_string(&amends_path)
-                        .map_err(|e| Error::Io(amends_path.clone(), e))?;
-                    let name = amends_path.display().to_string();
-                    let tokens = lexer::lex_named(&source, &name)?;
-                    let base_module = parser::parse_named(&tokens, &source, &name)?;
                     let base_val = self
-                        .eval_module_with_scope(
-                            &base_module,
-                            &amends_path,
-                            depth + 1,
-                            Some(scope.clone()),
-                        )
+                        .eval_file_with_scope(&amends_path, depth + 1, Some(scope.clone()))
                         .await?;
-                    if let Value::Object(m, _) = base_val {
-                        base_obj = (*m).clone();
+                    if let Value::Object(m, _) = &base_val {
+                        inherited_base_val = Some(base_val.clone());
+                        base_obj = (**m).clone();
                     }
                 }
             }
@@ -717,22 +761,17 @@ impl Evaluator {
                     base.join(uri)
                 };
                 if extends_path.exists() {
+                    let ext_val = self
+                        .eval_file_with_scope(&extends_path, depth + 1, Some(scope.clone()))
+                        .await?;
+                    let name = extends_path.display().to_string();
                     let source = std::fs::read_to_string(&extends_path)
                         .map_err(|e| Error::Io(extends_path.clone(), e))?;
-                    let name = extends_path.display().to_string();
                     let tokens = lexer::lex_named(&source, &name)?;
                     let ext_module = parser::parse_named(&tokens, &source, &name)?;
-                    // Evaluate the base module to get its properties
-                    let ext_val = self
-                        .eval_module_with_scope(
-                            &ext_module,
-                            &extends_path,
-                            depth + 1,
-                            Some(scope.clone()),
-                        )
-                        .await?;
-                    if let Value::Object(m, _) = ext_val {
-                        base_obj = (*m).clone();
+                    if let Value::Object(m, _) = &ext_val {
+                        inherited_base_val = Some(ext_val.clone());
+                        base_obj = (**m).clone();
                     }
                     // Also evaluate the base module's scope (classes, locals) into our scope
                     // by re-processing its body entries
@@ -794,6 +833,12 @@ impl Evaluator {
                         base_obj.shift_remove(cls_name);
                     }
                 }
+            }
+        }
+
+        if let Some(inherited_base_val) = inherited_base_val {
+            for alias in deferred_inherited_imports {
+                scope.set(alias, inherited_base_val.clone());
             }
         }
 
@@ -3555,6 +3600,23 @@ fn pathdiff_or_full(path: &Path, base: &Path) -> String {
         .unwrap_or(path)
         .to_string_lossy()
         .to_string()
+}
+
+fn local_module_path(current_path: &Path, uri: &str) -> Option<PathBuf> {
+    if uri.contains("://") && !uri.starts_with("file://") {
+        return None;
+    }
+    Some(if let Some(rel) = uri.strip_prefix("file://") {
+        PathBuf::from(rel)
+    } else {
+        current_path.parent().unwrap_or(Path::new(".")).join(uri)
+    })
+}
+
+fn same_local_path(left: &Path, right: &Path) -> bool {
+    let left_key = left.canonicalize().unwrap_or_else(|_| left.to_path_buf());
+    let right_key = right.canonicalize().unwrap_or_else(|_| right.to_path_buf());
+    left_key == right_key
 }
 
 fn stdlib_module(name: &str) -> Value {

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -443,11 +443,12 @@ impl Evaluator {
                 .await?,
         );
 
-        let inherited_local_path = module
+        let inherited_local_paths: Vec<_> = module
             .amends
-            .as_deref()
-            .or(module.extends.as_deref())
-            .and_then(|uri| local_module_path(path, uri));
+            .iter()
+            .chain(module.extends.iter())
+            .filter_map(|uri| local_module_path(path, uri))
+            .collect();
         let mut deferred_inherited_imports = Vec::new();
 
         // Process imports
@@ -585,11 +586,11 @@ impl Evaluator {
             if !import_path.exists() {
                 return Err(Error::ImportNotFound(import_path.display().to_string()));
             }
-            if inherited_local_path
-                .as_ref()
-                .is_some_and(|inherited_path| same_local_path(inherited_path, &import_path))
+            if let Some(inherited_path) = inherited_local_paths
+                .iter()
+                .find(|inherited_path| same_local_path(inherited_path, &import_path))
             {
-                deferred_inherited_imports.push(alias);
+                deferred_inherited_imports.push((alias, inherited_path.clone()));
                 continue;
             }
             {
@@ -600,7 +601,6 @@ impl Evaluator {
 
         // Process amends: load base module as starting values
         let mut base_obj = IndexMap::new();
-        let mut inherited_base_val = None;
         if let Some(uri) = &module.amends {
             if uri.starts_with("https://") || uri.starts_with("http://") {
                 // HTTP amends
@@ -669,7 +669,12 @@ impl Evaluator {
                         .eval_file_with_scope(&amends_path, depth + 1, Some(scope.clone()))
                         .await?;
                     if let Value::Object(m, _) = &base_val {
-                        inherited_base_val = Some(base_val.clone());
+                        bind_deferred_inherited_imports(
+                            &deferred_inherited_imports,
+                            &amends_path,
+                            &base_val,
+                            &mut scope,
+                        );
                         base_obj = (**m).clone();
                     }
                 }
@@ -770,7 +775,12 @@ impl Evaluator {
                     let tokens = lexer::lex_named(&source, &name)?;
                     let ext_module = parser::parse_named(&tokens, &source, &name)?;
                     if let Value::Object(m, _) = &ext_val {
-                        inherited_base_val = Some(ext_val.clone());
+                        bind_deferred_inherited_imports(
+                            &deferred_inherited_imports,
+                            &extends_path,
+                            &ext_val,
+                            &mut scope,
+                        );
                         base_obj = (**m).clone();
                     }
                     // Also evaluate the base module's scope (classes, locals) into our scope
@@ -833,12 +843,6 @@ impl Evaluator {
                         base_obj.shift_remove(cls_name);
                     }
                 }
-            }
-        }
-
-        if let Some(inherited_base_val) = inherited_base_val {
-            for alias in deferred_inherited_imports {
-                scope.set(alias, inherited_base_val.clone());
             }
         }
 
@@ -3617,6 +3621,19 @@ fn same_local_path(left: &Path, right: &Path) -> bool {
     let left_key = left.canonicalize().unwrap_or_else(|_| left.to_path_buf());
     let right_key = right.canonicalize().unwrap_or_else(|_| right.to_path_buf());
     left_key == right_key
+}
+
+fn bind_deferred_inherited_imports(
+    deferred: &[(String, PathBuf)],
+    inherited_path: &Path,
+    inherited_val: &Value,
+    scope: &mut Scope,
+) {
+    for (alias, alias_path) in deferred {
+        if same_local_path(alias_path, inherited_path) {
+            scope.set(alias.clone(), inherited_val.clone());
+        }
+    }
 }
 
 fn stdlib_module(name: &str) -> Value {

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -2959,100 +2959,119 @@ fn object_declares_field(value: &Value, field: &str) -> bool {
 
 fn referenced_roots(entries: &[Entry]) -> HashSet<String> {
     let mut refs = HashSet::new();
-    collect_entry_refs(entries, &mut refs);
+    let shadows = HashSet::new();
+    collect_entry_refs(entries, &mut refs, &shadows);
+    for name in declared_entry_roots(entries) {
+        refs.remove(&name);
+    }
     refs
 }
 
-fn collect_entry_refs(entries: &[Entry], refs: &mut HashSet<String>) {
+fn collect_entry_refs(entries: &[Entry], refs: &mut HashSet<String>, shadows: &HashSet<String>) {
     for entry in entries {
         match entry {
             Entry::Property(prop) => {
                 if let Some(ty) = &prop.type_ann {
-                    collect_type_refs(ty, refs);
+                    collect_type_refs(ty, refs, shadows);
                 }
                 if let Some(expr) = &prop.value {
-                    collect_expr_refs(expr, refs);
+                    collect_expr_refs(expr, refs, shadows);
                 }
                 if let Some(body) = &prop.body {
-                    collect_entry_refs(body, refs);
+                    collect_entry_refs(body, refs, shadows);
                 }
             }
             Entry::DynProperty(key, value) => {
-                collect_expr_refs(key, refs);
-                collect_expr_refs(value, refs);
+                collect_expr_refs(key, refs, shadows);
+                collect_expr_refs(value, refs, shadows);
             }
             Entry::ForGenerator(fgen) => {
-                collect_expr_refs(&fgen.collection, refs);
-                collect_entry_refs(&fgen.body, refs);
+                collect_expr_refs(&fgen.collection, refs, shadows);
+                let mut body_shadows = shadows.clone();
+                body_shadows.insert(fgen.val_var.clone());
+                if let Some(key_var) = &fgen.key_var {
+                    body_shadows.insert(key_var.clone());
+                }
+                collect_entry_refs(&fgen.body, refs, &body_shadows);
             }
             Entry::WhenGenerator(wgen) => {
-                collect_expr_refs(&wgen.condition, refs);
-                collect_entry_refs(&wgen.body, refs);
+                collect_expr_refs(&wgen.condition, refs, shadows);
+                collect_entry_refs(&wgen.body, refs, shadows);
                 if let Some(else_body) = &wgen.else_body {
-                    collect_entry_refs(else_body, refs);
+                    collect_entry_refs(else_body, refs, shadows);
                 }
             }
-            Entry::Spread(expr) | Entry::Elem(expr) => collect_expr_refs(expr, refs),
+            Entry::Spread(expr) | Entry::Elem(expr) => collect_expr_refs(expr, refs, shadows),
             Entry::ClassDef(_, _, parent, body) => {
                 if let Some(parent) = parent {
-                    collect_name_root(parent, refs);
+                    collect_name_root(parent, refs, shadows);
                 }
-                collect_entry_refs(body, refs);
+                collect_entry_refs(body, refs, shadows);
             }
-            Entry::TypeAlias(_, ty) => collect_type_refs(ty, refs),
+            Entry::TypeAlias(_, ty) => collect_type_refs(ty, refs, shadows),
         }
     }
 }
 
-fn collect_expr_refs(expr: &Expr, refs: &mut HashSet<String>) {
+fn collect_expr_refs(expr: &Expr, refs: &mut HashSet<String>, shadows: &HashSet<String>) {
     match expr {
         Expr::Ident(name) => {
-            refs.insert(name.clone());
+            if !shadows.contains(name) {
+                refs.insert(name.clone());
+            }
         }
         Expr::New(type_name, entries, generic_params) => {
             if let Some(type_name) = type_name {
-                collect_name_root(type_name, refs);
+                collect_name_root(type_name, refs, shadows);
             }
             for param in generic_params {
-                collect_name_root(param, refs);
+                collect_name_root(param, refs, shadows);
             }
-            collect_entry_refs(entries, refs);
+            collect_entry_refs(entries, refs, shadows);
         }
-        Expr::Field(base, _) | Expr::NullSafeField(base, _) => collect_expr_refs(base, refs),
+        Expr::Field(base, _) | Expr::NullSafeField(base, _) => {
+            collect_expr_refs(base, refs, shadows);
+        }
         Expr::Index(base, index) | Expr::Binop(_, base, index) => {
-            collect_expr_refs(base, refs);
-            collect_expr_refs(index, refs);
+            collect_expr_refs(base, refs, shadows);
+            collect_expr_refs(index, refs, shadows);
         }
         Expr::Call(callee, args) => {
-            collect_expr_refs(callee, refs);
+            collect_expr_refs(callee, refs, shadows);
             for arg in args {
-                collect_expr_refs(arg, refs);
+                collect_expr_refs(arg, refs, shadows);
             }
         }
         Expr::If(cond, then_expr, else_expr) => {
-            collect_expr_refs(cond, refs);
-            collect_expr_refs(then_expr, refs);
-            collect_expr_refs(else_expr, refs);
+            collect_expr_refs(cond, refs, shadows);
+            collect_expr_refs(then_expr, refs, shadows);
+            collect_expr_refs(else_expr, refs, shadows);
         }
-        Expr::Let(_, value, body) => {
-            collect_expr_refs(value, refs);
-            collect_expr_refs(body, refs);
+        Expr::Let(name, value, body) => {
+            collect_expr_refs(value, refs, shadows);
+            let mut body_shadows = shadows.clone();
+            body_shadows.insert(name.clone());
+            collect_expr_refs(body, refs, &body_shadows);
         }
         Expr::Is(value, ty) | Expr::As(value, ty) => {
-            collect_expr_refs(value, refs);
-            collect_type_refs(ty, refs);
+            collect_expr_refs(value, refs, shadows);
+            collect_type_refs(ty, refs, shadows);
+        }
+        Expr::Lambda(params, value) => {
+            let mut body_shadows = shadows.clone();
+            body_shadows.extend(params.iter().cloned());
+            collect_expr_refs(value, refs, &body_shadows);
         }
         Expr::Unop(_, value)
-        | Expr::Lambda(_, value)
         | Expr::Throw(value)
         | Expr::Trace(value)
         | Expr::Read(value)
-        | Expr::ReadOrNull(value) => collect_expr_refs(value, refs),
-        Expr::ObjectBody(entries) => collect_entry_refs(entries, refs),
+        | Expr::ReadOrNull(value) => collect_expr_refs(value, refs, shadows),
+        Expr::ObjectBody(entries) => collect_entry_refs(entries, refs, shadows),
         Expr::StringInterpolation(parts) => {
             for part in parts {
                 if let StringInterpPart::Expr(expr) = part {
-                    collect_expr_refs(expr, refs);
+                    collect_expr_refs(expr, refs, shadows);
                 }
             }
         }
@@ -3060,34 +3079,55 @@ fn collect_expr_refs(expr: &Expr, refs: &mut HashSet<String>) {
     }
 }
 
-fn collect_type_refs(ty: &crate::parser::TypeExpr, refs: &mut HashSet<String>) {
+fn collect_type_refs(
+    ty: &crate::parser::TypeExpr,
+    refs: &mut HashSet<String>,
+    shadows: &HashSet<String>,
+) {
     match ty {
-        crate::parser::TypeExpr::Named(name) => collect_name_root(name, refs),
-        crate::parser::TypeExpr::Nullable(inner) => collect_type_refs(inner, refs),
+        crate::parser::TypeExpr::Named(name) => collect_name_root(name, refs, shadows),
+        crate::parser::TypeExpr::Nullable(inner) => collect_type_refs(inner, refs, shadows),
         crate::parser::TypeExpr::Union(types) => {
             for ty in types {
-                collect_type_refs(ty, refs);
+                collect_type_refs(ty, refs, shadows);
             }
         }
         crate::parser::TypeExpr::Generic(name, params) => {
-            collect_name_root(name, refs);
+            collect_name_root(name, refs, shadows);
             for param in params {
-                collect_type_refs(param, refs);
+                collect_type_refs(param, refs, shadows);
             }
         }
         crate::parser::TypeExpr::Constrained(name, expr) => {
-            collect_name_root(name, refs);
-            collect_expr_refs(expr, refs);
+            collect_name_root(name, refs, shadows);
+            collect_expr_refs(expr, refs, shadows);
         }
     }
 }
 
-fn collect_name_root(name: &str, refs: &mut HashSet<String>) {
+fn collect_name_root(name: &str, refs: &mut HashSet<String>, shadows: &HashSet<String>) {
     if let Some(root) = name.split('.').next()
         && !root.is_empty()
+        && !shadows.contains(root)
     {
         refs.insert(root.to_string());
     }
+}
+
+fn declared_entry_roots(entries: &[Entry]) -> HashSet<String> {
+    entries
+        .iter()
+        .filter_map(|entry| match entry {
+            Entry::ClassDef(name, ..) | Entry::TypeAlias(name, _) => Some(name.clone()),
+            Entry::Property(prop)
+                if has_modifier(&prop.modifiers, Modifier::Local)
+                    || matches!(prop.value, Some(Expr::Lambda(..))) =>
+            {
+                Some(prop.name.clone())
+            }
+            _ => None,
+        })
+        .collect()
 }
 
 // --- Scope ---

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -27,6 +27,7 @@ pub enum TokenKind {
     LBracket,         // [
     RBracket,         // ]
     Comma,            // ,
+    Semicolon,        // ;
     Dot,              // .
     DotDotDot,        // ...
     Equals,           // =
@@ -163,10 +164,10 @@ impl<'a> Lexer<'a> {
 
     fn skip_whitespace_and_comments(&mut self) {
         loop {
-            // Skip whitespace and semicolons (Pkl allows `;` as a property separator)
+            // Skip whitespace
             while self
                 .peek()
-                .map(|c| c.is_ascii_whitespace() || c == ';')
+                .map(|c| c.is_ascii_whitespace())
                 .unwrap_or(false)
             {
                 self.advance();
@@ -520,6 +521,10 @@ impl<'a> Lexer<'a> {
             ',' => {
                 self.advance();
                 TokenKind::Comma
+            }
+            ';' => {
+                self.advance();
+                TokenKind::Semicolon
             }
             '.' => {
                 self.advance();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -101,15 +101,16 @@ fn analyze_imports_inner(
             }
         }
         for import_path in local_imports {
+            if !import_path.exists() {
+                continue;
+            }
             let result_key = import_path
                 .canonicalize()
                 .unwrap_or_else(|_| import_path.clone());
             if seen_results.insert(result_key) {
                 results.push(import_path.clone());
             }
-            if import_path.exists() {
-                analyze_imports_inner(&import_path, visited, seen_results, results)?;
-            }
+            analyze_imports_inner(&import_path, visited, seen_results, results)?;
         }
     }
     Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,24 +65,45 @@ pub async fn eval_to_json_with_options(
 
 /// Analyze imports of a pkl file, returning all transitive local file dependencies.
 pub fn analyze_imports(path: &Path) -> Result<Vec<std::path::PathBuf>> {
+    let mut results = Vec::new();
+    let mut visited = std::collections::HashSet::new();
+    analyze_imports_inner(path, &mut visited, &mut results)?;
+    Ok(results)
+}
+
+fn analyze_imports_inner(
+    path: &Path,
+    visited: &mut std::collections::HashSet<std::path::PathBuf>,
+    results: &mut Vec<std::path::PathBuf>,
+) -> Result<()> {
+    let canonical = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
+    if !visited.insert(canonical) {
+        return Ok(());
+    }
     let source = std::fs::read_to_string(path).map_err(|e| Error::Io(path.to_path_buf(), e))?;
     let tokens = lexer::lex_named(&source, &path.display().to_string())?;
     let imports = parser::collect_imports(&tokens);
     let base = path.parent().unwrap_or(Path::new("."));
-    let mut results = Vec::new();
     for uri in imports {
+        let mut local_imports = Vec::new();
         if let Some(rel) = uri.strip_prefix("file://") {
-            results.push(std::path::PathBuf::from(rel));
+            local_imports.push(std::path::PathBuf::from(rel));
         } else if !uri.contains("://") {
             if uri.contains('*') {
                 // Expand glob patterns to actual files
                 if let Ok(expanded) = eval::expand_glob(base, &uri) {
-                    results.extend(expanded);
+                    local_imports.extend(expanded);
                 }
             } else {
-                results.push(base.join(&uri));
+                local_imports.push(base.join(&uri));
+            }
+        }
+        for import_path in local_imports {
+            results.push(import_path.clone());
+            if import_path.exists() {
+                analyze_imports_inner(&import_path, visited, results)?;
             }
         }
     }
-    Ok(results)
+    Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,13 +67,15 @@ pub async fn eval_to_json_with_options(
 pub fn analyze_imports(path: &Path) -> Result<Vec<std::path::PathBuf>> {
     let mut results = Vec::new();
     let mut visited = std::collections::HashSet::new();
-    analyze_imports_inner(path, &mut visited, &mut results)?;
+    let mut seen_results = std::collections::HashSet::new();
+    analyze_imports_inner(path, &mut visited, &mut seen_results, &mut results)?;
     Ok(results)
 }
 
 fn analyze_imports_inner(
     path: &Path,
     visited: &mut std::collections::HashSet<std::path::PathBuf>,
+    seen_results: &mut std::collections::HashSet<std::path::PathBuf>,
     results: &mut Vec<std::path::PathBuf>,
 ) -> Result<()> {
     let canonical = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
@@ -99,9 +101,14 @@ fn analyze_imports_inner(
             }
         }
         for import_path in local_imports {
-            results.push(import_path.clone());
+            let result_key = import_path
+                .canonicalize()
+                .unwrap_or_else(|_| import_path.clone());
+            if seen_results.insert(result_key) {
+                results.push(import_path.clone());
+            }
             if import_path.exists() {
-                analyze_imports_inner(&import_path, visited, results)?;
+                analyze_imports_inner(&import_path, visited, seen_results, results)?;
             }
         }
     }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -333,6 +333,9 @@ impl<'a> Parser<'a> {
 
         loop {
             match self.peek().clone() {
+                TokenKind::Comma | TokenKind::Semicolon => {
+                    self.advance();
+                }
                 TokenKind::KwAmends => {
                     self.advance();
                     let uri = self.expect_string()?;

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -376,6 +376,10 @@ impl<'a> Parser<'a> {
     fn parse_entries(&mut self) -> Result<Vec<Entry>> {
         let mut entries = Vec::new();
         while !self.at_eof() && !matches!(self.peek(), TokenKind::RBrace) {
+            if matches!(self.peek(), TokenKind::Comma | TokenKind::Semicolon) {
+                self.advance();
+                continue;
+            }
             let entry_annotations = self.parse_annotations()?;
             // Parse class definitions (with optional modifiers); skip typealias/function declarations
             let class_modifiers =
@@ -460,6 +464,9 @@ impl<'a> Parser<'a> {
                 prop.annotations = entry_annotations;
             }
             entries.push(entry);
+            while matches!(self.peek(), TokenKind::Comma | TokenKind::Semicolon) {
+                self.advance();
+            }
         }
         Ok(entries)
     }
@@ -486,8 +493,15 @@ impl<'a> Parser<'a> {
                     self.advance();
                 }
                 TokenKind::Ident(name) if depth == 1 => {
-                    params.push(name.clone());
+                    let mut name = name.clone();
                     self.advance();
+                    while depth == 1 && matches!(self.peek(), TokenKind::Dot) {
+                        self.advance();
+                        let part = self.expect_ident()?;
+                        name.push('.');
+                        name.push_str(&part);
+                    }
+                    params.push(name);
                 }
                 TokenKind::Eof => {
                     return Err(self.parse_error("unclosed generic type parameters"));

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -56,6 +56,35 @@ import "pkl/Builtins.pkl"
     assert!(imports.contains(&"pkl/Builtins.pkl".to_string()));
 }
 
+#[test]
+fn analyze_imports_deduplicates_diamond_graph() {
+    let dir = std::env::temp_dir().join(format!(
+        "pklr_test_analyze_imports_diamond_{}",
+        std::process::id()
+    ));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    std::fs::write(
+        dir.join("main.pkl"),
+        r#"
+import "left.pkl"
+import "right.pkl"
+"#,
+    )
+    .unwrap();
+    std::fs::write(dir.join("left.pkl"), r#"import "shared.pkl""#).unwrap();
+    std::fs::write(dir.join("right.pkl"), r#"import "shared.pkl""#).unwrap();
+    std::fs::write(dir.join("shared.pkl"), "x = 1").unwrap();
+
+    let imports = pklr::analyze_imports(&dir.join("main.pkl")).unwrap();
+    let shared = dir.join("shared.pkl");
+    assert_eq!(
+        imports.iter().filter(|path| **path == shared).count(),
+        1,
+        "{imports:?}"
+    );
+}
+
 // --- Evaluator tests ---
 
 fn eval_src(src: &str) -> serde_json::Value {

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -57,6 +57,18 @@ import "pkl/Builtins.pkl"
 }
 
 #[test]
+fn parser_allows_semicolons_between_header_directives() {
+    let src = r#"
+amends "base.pkl"; import "helper.pkl"; x = helper.value
+"#;
+    let tokens = lex(src).unwrap();
+    let module = parse(&tokens).unwrap();
+    assert_eq!(module.amends.as_deref(), Some("base.pkl"));
+    assert_eq!(module.imports.len(), 1);
+    assert_eq!(module.imports[0].uri, "helper.pkl");
+}
+
+#[test]
 fn analyze_imports_deduplicates_diamond_graph() {
     let dir = std::env::temp_dir().join(format!(
         "pklr_test_analyze_imports_diamond_{}",
@@ -83,6 +95,29 @@ import "right.pkl"
         1,
         "{imports:?}"
     );
+}
+
+#[test]
+fn analyze_imports_excludes_missing_files() {
+    let dir = std::env::temp_dir().join(format!(
+        "pklr_test_analyze_imports_missing_{}",
+        std::process::id()
+    ));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    std::fs::write(
+        dir.join("main.pkl"),
+        r#"
+import "missing.pkl"
+import "existing.pkl"
+"#,
+    )
+    .unwrap();
+    std::fs::write(dir.join("existing.pkl"), "x = 1").unwrap();
+
+    let imports = pklr::analyze_imports(&dir.join("main.pkl")).unwrap();
+    assert_eq!(imports, vec![dir.join("existing.pkl")]);
+    let _ = std::fs::remove_dir_all(&dir);
 }
 
 // --- Evaluator tests ---

--- a/tests/pkl_features.rs
+++ b/tests/pkl_features.rs
@@ -3074,6 +3074,39 @@ result = g.greet("Hello")
 }
 
 #[test]
+fn class_lambda_valued_property_is_preserved() {
+    let json = eval(
+        r#"
+class Transformer {
+    transform = (x) -> x + 1
+}
+t = new Transformer {}
+result = t.transform.apply(2)
+"#,
+    );
+    assert_eq!(json["result"], 3);
+    assert_eq!(json["t"]["transform"], "<lambda>");
+}
+
+#[test]
+fn class_same_named_typed_property_is_preserved() {
+    let json = eval(
+        r#"
+class Script {
+    linux: String = "echo ok"
+}
+
+class Holder {
+    Script = new Script {}
+}
+
+h = new Holder {}
+"#,
+    );
+    assert_eq!(json["h"]["Script"]["linux"], "echo ok");
+}
+
+#[test]
 fn class_function_testmaker_pattern() {
     // First check: does the class itself have checkFail?
     let json1 = eval(

--- a/tests/pkl_features.rs
+++ b/tests/pkl_features.rs
@@ -1115,6 +1115,21 @@ result = new Foo {}
 }
 
 #[test]
+fn nested_shadowed_unused_import_is_not_evaluated() {
+    let json = eval(
+        r#"
+import "does-not-exist.pkl" as Foo
+class Outer {
+    class Foo {}
+    x = new Foo {}
+}
+result = new Outer {}
+"#,
+    );
+    assert!(json["result"]["x"].is_object());
+}
+
+#[test]
 fn unused_import_glob_without_alias_is_still_invalid() {
     let err = eval_fails(r#"import* "items/*.pkl""#);
     assert!(err.contains("import* requires an alias"), "{err}");

--- a/tests/pkl_features.rs
+++ b/tests/pkl_features.rs
@@ -1062,6 +1062,55 @@ result = "ok"
     assert_eq!(val["result"], "ok");
 }
 
+#[test]
+fn missing_unused_import_is_not_evaluated() {
+    // Unused imports are intentionally lazy, so missing paths only fail once
+    // the imported binding is referenced.
+    let json = eval(
+        r#"
+import "does-not-exist.pkl"
+result = "ok"
+"#,
+    );
+    assert_eq!(json["result"], "ok");
+}
+
+#[test]
+fn unused_import_glob_without_alias_is_still_invalid() {
+    let err = eval_fails(r#"import* "items/*.pkl""#);
+    assert!(err.contains("import* requires an alias"), "{err}");
+}
+
+#[tokio::test]
+async fn import_used_by_inherited_class_default_is_loaded() {
+    let dir = std::env::temp_dir().join(format!(
+        "pklr_test_inherited_import_ref_{}",
+        std::process::id()
+    ));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    std::fs::write(
+        dir.join("Base.pkl"),
+        r#"
+class Project {
+    name = meta.name
+}
+"#,
+    )
+    .unwrap();
+    std::fs::write(dir.join("meta.pkl"), r#"name = "hk""#).unwrap();
+    let src = r#"
+amends "Base.pkl"
+import "meta.pkl"
+result = new Project {}
+"#;
+
+    let mut ev = Evaluator::new();
+    let val = ev.eval_source(src, &dir.join("child.pkl")).await.unwrap();
+    let json = val.to_json();
+    assert_eq!(json["result"]["name"], "hk");
+}
+
 #[tokio::test]
 async fn import_used_only_by_annotation_does_not_create_builtin_cycle() {
     let dir = std::path::Path::new("/tmp/pklr_test_annotation_import_cycle");

--- a/tests/pkl_features.rs
+++ b/tests/pkl_features.rs
@@ -1102,6 +1102,129 @@ result = prettier.prettier
     assert_eq!(val["result"], "ok");
 }
 
+#[test]
+fn object_entries_can_be_separated_by_semicolons() {
+    let json = eval(
+        r#"
+x {
+  ["FOO"] = "foo"; ["BAR"] = "bar"
+}
+"#,
+    );
+    assert_eq!(json["x"]["FOO"], "foo");
+    assert_eq!(json["x"]["BAR"], "bar");
+}
+
+#[test]
+fn object_to_mapping_returns_mapping_like_object() {
+    let json = eval(
+        r#"
+local Builtins = new Mapping {
+  ["one"] = "1"
+}
+x = Builtins.toMap().toMapping()
+"#,
+    );
+    assert_eq!(json["x"]["one"], "1");
+}
+
+#[test]
+fn top_level_bare_elements_are_invalid() {
+    let err = eval_fails("BROKEN SYNTAX");
+    assert!(err.contains("Invalid property definition"), "{err}");
+}
+
+#[tokio::test]
+async fn imported_typed_mapping_does_not_leak_schema_classes() {
+    let dir = std::path::Path::new("/tmp/pklr_test_imported_typed_mapping");
+    std::fs::create_dir_all(dir).unwrap();
+    std::fs::write(
+        dir.join("Config.pkl"),
+        r#"
+class Script {
+  linux: String?
+}
+
+class Step {
+  check: (String | Script)?
+}
+"#,
+    )
+    .unwrap();
+    std::fs::write(
+        dir.join("other.pkl"),
+        r#"
+import "./Config.pkl"
+STEPS = new Mapping<String, Config.Step> {
+  ["original"] { check = "echo original" }
+}
+"#,
+    )
+    .unwrap();
+    std::fs::write(
+        dir.join("main.pkl"),
+        r#"
+import "./Config.pkl"
+import "./other.pkl"
+steps = other.STEPS
+"#,
+    )
+    .unwrap();
+
+    let val = pklr::eval_to_json(&dir.join("main.pkl")).await.unwrap();
+    assert_eq!(val["steps"]["original"]["check"], "echo original");
+    assert!(val["steps"]["original"].get("Script").is_none(), "{val}");
+}
+
+#[test]
+fn typed_mapping_amendment_preserves_existing_keyed_entries() {
+    let json = eval(
+        r#"
+class Step {
+  check: String?
+  env: Mapping<String, String> = new Mapping<String, String> {}
+}
+
+class Hook {
+  steps: Mapping<String, Step> = new Mapping<String, Step> {}
+}
+
+local hooks = new Mapping<String, Hook> {
+  ["check"] {
+    steps {
+      ["echo"] { check = "env" }
+    }
+  }
+}
+
+result = (hooks) {
+  ["check"] {
+    steps {
+      ["echo"] {
+        env {
+          ["STEP_VAR"] = "step_value"
+        }
+      }
+      ["new step"] {
+        check = "echo hello"
+      }
+    }
+  }
+}
+"#,
+    );
+
+    assert_eq!(json["result"]["check"]["steps"]["echo"]["check"], "env");
+    assert_eq!(
+        json["result"]["check"]["steps"]["echo"]["env"]["STEP_VAR"],
+        "step_value"
+    );
+    assert_eq!(
+        json["result"]["check"]["steps"]["new step"]["check"],
+        "echo hello"
+    );
+}
+
 // ============================================================
 // Class instantiation (future)
 // ============================================================

--- a/tests/pkl_features.rs
+++ b/tests/pkl_features.rs
@@ -1190,6 +1190,39 @@ baseName = Base.name
 }
 
 #[tokio::test]
+async fn scoped_inherited_base_does_not_pollute_import_cache() {
+    let temp = TestTempDir::new("pklr_test_scoped_base_cache");
+    let dir = temp.path();
+    std::fs::write(
+        dir.join("Base.pkl"),
+        r#"
+name = meta.name
+"#,
+    )
+    .unwrap();
+    std::fs::write(dir.join("meta.pkl"), r#"name = "hk""#).unwrap();
+    std::fs::write(
+        dir.join("child.pkl"),
+        r#"
+amends "Base.pkl"
+import "meta.pkl"
+result = name
+"#,
+    )
+    .unwrap();
+
+    let mut ev = Evaluator::new();
+    let child_val = ev.eval_file_pub(&dir.join("child.pkl")).await.unwrap();
+    assert_eq!(child_val.to_json()["result"], "hk");
+
+    let err = ev.eval_file_pub(&dir.join("Base.pkl")).await.unwrap_err();
+    assert!(
+        err.to_string().contains("undefined variable: meta"),
+        "{err}"
+    );
+}
+
+#[tokio::test]
 async fn imported_amends_and_extends_bases_keep_separate_values() {
     let temp = TestTempDir::new("pklr_test_imported_dual_inherited_bases");
     let dir = temp.path();

--- a/tests/pkl_features.rs
+++ b/tests/pkl_features.rs
@@ -39,6 +39,33 @@ fn eval_fails(src: &str) -> String {
     })
 }
 
+struct TestTempDir {
+    path: std::path::PathBuf,
+}
+
+impl TestTempDir {
+    fn new(name: &str) -> Self {
+        let unique = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let path = std::env::temp_dir().join(format!("{name}_{}_{}", std::process::id(), unique));
+        let _ = std::fs::remove_dir_all(&path);
+        std::fs::create_dir_all(&path).unwrap();
+        Self { path }
+    }
+
+    fn path(&self) -> &std::path::Path {
+        &self.path
+    }
+}
+
+impl Drop for TestTempDir {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.path);
+    }
+}
+
 // ============================================================
 // Primitives
 // ============================================================
@@ -1039,8 +1066,8 @@ beta_val = Items["items/beta.pkl"].value
 
 #[tokio::test]
 async fn unused_import_is_not_evaluated() {
-    let dir = std::path::Path::new("/tmp/pklr_test_unused_import");
-    std::fs::create_dir_all(dir).unwrap();
+    let temp = TestTempDir::new("pklr_test_unused_import");
+    let dir = temp.path();
     std::fs::write(
         dir.join("broken.pkl"),
         r#"
@@ -1076,6 +1103,18 @@ result = "ok"
 }
 
 #[test]
+fn shadowed_unused_import_is_not_evaluated() {
+    let json = eval(
+        r#"
+import "does-not-exist.pkl" as Foo
+class Foo {}
+result = new Foo {}
+"#,
+    );
+    assert!(json["result"].is_object());
+}
+
+#[test]
 fn unused_import_glob_without_alias_is_still_invalid() {
     let err = eval_fails(r#"import* "items/*.pkl""#);
     assert!(err.contains("import* requires an alias"), "{err}");
@@ -1083,12 +1122,8 @@ fn unused_import_glob_without_alias_is_still_invalid() {
 
 #[tokio::test]
 async fn import_used_by_inherited_class_default_is_loaded() {
-    let dir = std::env::temp_dir().join(format!(
-        "pklr_test_inherited_import_ref_{}",
-        std::process::id()
-    ));
-    let _ = std::fs::remove_dir_all(&dir);
-    std::fs::create_dir_all(&dir).unwrap();
+    let temp = TestTempDir::new("pklr_test_inherited_import_ref");
+    let dir = temp.path();
     std::fs::write(
         dir.join("Base.pkl"),
         r#"
@@ -1113,7 +1148,8 @@ result = new Project {}
 
 #[tokio::test]
 async fn import_used_only_by_annotation_does_not_create_builtin_cycle() {
-    let dir = std::path::Path::new("/tmp/pklr_test_annotation_import_cycle");
+    let temp = TestTempDir::new("pklr_test_annotation_import_cycle");
+    let dir = temp.path();
     std::fs::create_dir_all(dir.join("builtins")).unwrap();
     std::fs::write(
         dir.join("Builtins.pkl"),
@@ -1185,8 +1221,8 @@ fn top_level_bare_elements_are_invalid() {
 
 #[tokio::test]
 async fn imported_typed_mapping_does_not_leak_schema_classes() {
-    let dir = std::path::Path::new("/tmp/pklr_test_imported_typed_mapping");
-    std::fs::create_dir_all(dir).unwrap();
+    let temp = TestTempDir::new("pklr_test_imported_typed_mapping");
+    let dir = temp.path();
     std::fs::write(
         dir.join("Config.pkl"),
         r#"
@@ -3158,8 +3194,8 @@ result = c.compute(5)
 #[tokio::test]
 async fn eval_amends_perf() {
     // Minimal amends test to check performance
-    let dir = std::path::Path::new("/tmp/pklr_test_perf");
-    std::fs::create_dir_all(dir).unwrap();
+    let temp = TestTempDir::new("pklr_test_perf");
+    let dir = temp.path();
     std::fs::write(
         dir.join("Base.pkl"),
         r#"
@@ -3209,8 +3245,8 @@ hooks = new {
 #[tokio::test]
 async fn class_function_nested_in_new() {
     // Matches the hk builtin pattern: testMaker.checkFail() inside new Config.Step { tests { ... } }
-    let dir = std::path::Path::new("/tmp/pklr_test_nested");
-    std::fs::create_dir_all(dir).unwrap();
+    let temp = TestTempDir::new("pklr_test_nested");
+    let dir = temp.path();
     std::fs::write(
         dir.join("helpers.pkl"),
         r#"
@@ -3242,8 +3278,8 @@ x {
 
 #[tokio::test]
 async fn class_function_cross_module() {
-    let dir = std::path::Path::new("/tmp/pklr_test_cross_module");
-    std::fs::create_dir_all(dir).unwrap();
+    let temp = TestTempDir::new("pklr_test_cross_module");
+    let dir = temp.path();
     std::fs::write(
         dir.join("helpers.pkl"),
         r#"

--- a/tests/pkl_features.rs
+++ b/tests/pkl_features.rs
@@ -1162,6 +1162,34 @@ result = new Project {}
 }
 
 #[tokio::test]
+async fn imported_amends_base_uses_inherited_scope() {
+    let temp = TestTempDir::new("pklr_test_imported_amends_base_scope");
+    let dir = temp.path();
+    std::fs::write(
+        dir.join("Base.pkl"),
+        r#"
+name = meta.name
+"#,
+    )
+    .unwrap();
+    std::fs::write(dir.join("meta.pkl"), r#"name = "hk""#).unwrap();
+    std::fs::write(
+        dir.join("child.pkl"),
+        r#"
+amends "Base.pkl"
+import "meta.pkl"
+import "Base.pkl" as Base
+baseName = Base.name
+"#,
+    )
+    .unwrap();
+
+    let val = pklr::eval_to_json(&dir.join("child.pkl")).await.unwrap();
+    assert_eq!(val["name"], "hk");
+    assert_eq!(val["baseName"], "hk");
+}
+
+#[tokio::test]
 async fn import_used_only_by_annotation_does_not_create_builtin_cycle() {
     let temp = TestTempDir::new("pklr_test_annotation_import_cycle");
     let dir = temp.path();

--- a/tests/pkl_features.rs
+++ b/tests/pkl_features.rs
@@ -1190,6 +1190,33 @@ baseName = Base.name
 }
 
 #[tokio::test]
+async fn imported_amends_and_extends_bases_keep_separate_values() {
+    let temp = TestTempDir::new("pklr_test_imported_dual_inherited_bases");
+    let dir = temp.path();
+    std::fs::write(dir.join("AmendsBase.pkl"), r#"amendsName = meta.name"#).unwrap();
+    std::fs::write(dir.join("ExtendsBase.pkl"), r#"extendsName = meta.name"#).unwrap();
+    std::fs::write(dir.join("meta.pkl"), r#"name = "hk""#).unwrap();
+    std::fs::write(
+        dir.join("child.pkl"),
+        r#"
+amends "AmendsBase.pkl"
+extends "ExtendsBase.pkl"
+import "meta.pkl"
+import "AmendsBase.pkl" as AmendsBase
+import "ExtendsBase.pkl" as ExtendsBase
+amended = AmendsBase.amendsName
+extended = ExtendsBase.extendsName
+"#,
+    )
+    .unwrap();
+
+    let val = pklr::eval_to_json(&dir.join("child.pkl")).await.unwrap();
+    assert_eq!(val["extendsName"], "hk");
+    assert_eq!(val["amended"], "hk");
+    assert_eq!(val["extended"], "hk");
+}
+
+#[tokio::test]
 async fn import_used_only_by_annotation_does_not_create_builtin_cycle() {
     let temp = TestTempDir::new("pklr_test_annotation_import_cycle");
     let dir = temp.path();

--- a/tests/pkl_features.rs
+++ b/tests/pkl_features.rs
@@ -1037,6 +1037,71 @@ beta_val = Items["items/beta.pkl"].value
     assert_eq!(json["beta_val"], "beta");
 }
 
+#[tokio::test]
+async fn unused_import_is_not_evaluated() {
+    let dir = std::path::Path::new("/tmp/pklr_test_unused_import");
+    std::fs::create_dir_all(dir).unwrap();
+    std::fs::write(
+        dir.join("broken.pkl"),
+        r#"
+value = missing.field
+"#,
+    )
+    .unwrap();
+    std::fs::write(
+        dir.join("main.pkl"),
+        r#"
+import "broken.pkl"
+result = "ok"
+"#,
+    )
+    .unwrap();
+
+    let path = dir.join("main.pkl");
+    let val = pklr::eval_to_json(&path).await.unwrap();
+    assert_eq!(val["result"], "ok");
+}
+
+#[tokio::test]
+async fn import_used_only_by_annotation_does_not_create_builtin_cycle() {
+    let dir = std::path::Path::new("/tmp/pklr_test_annotation_import_cycle");
+    std::fs::create_dir_all(dir.join("builtins")).unwrap();
+    std::fs::write(
+        dir.join("Builtins.pkl"),
+        r#"
+class meta extends Annotation {
+    description: String?
+}
+
+import* "builtins/*.pkl" as Builtins
+prettier = Builtins["builtins/prettier.pkl"].prettier
+"#,
+    )
+    .unwrap();
+    std::fs::write(
+        dir.join("builtins").join("prettier.pkl"),
+        r#"
+import "../Builtins.pkl"
+
+@Builtins.meta { description = "formatter" }
+prettier = "ok"
+"#,
+    )
+    .unwrap();
+    std::fs::write(
+        dir.join("main.pkl"),
+        r#"
+import "builtins/prettier.pkl"
+result = prettier.prettier
+"#,
+    )
+    .unwrap();
+
+    let path = dir.join("main.pkl");
+    let val = pklr::eval_to_json(&path).await.unwrap();
+    assert_eq!(val["result"], "ok");
+}
+
 // ============================================================
 // Class instantiation (future)
 // ============================================================


### PR DESCRIPTION
## Summary
- skip evaluating imports whose module binding is not referenced by executable expressions
- keep annotation-only imports from forcing builtin metadata cycles
- add regressions for unused broken imports and hk-style builtin annotation cycles

## Why
After pklr 0.4.5, hk can evaluate `testMaker`, but the full hk Bats suite still fails when a config imports an individual builtin such as `builtins/prettier.pkl`. That builtin imports `Builtins.pkl` for annotations, while `Builtins.pkl` glob-imports the builtin back, causing the in-progress builtin placeholder to be read as if it were complete.

## Verification
- `cargo fmt --check`
- `cargo test unused_import_is_not_evaluated`
- `cargo test import_used_only_by_annotation_does_not_create_builtin_cycle`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`

*This PR was generated by AI.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Core module loading, import caching, and inheritance semantics changed in the evaluator; regressions could affect any multi-file Pkl config, though coverage is broad.
> 
> **Overview**
> **Lazy imports** are the headline fix: the evaluator walks module bodies (and inherited `amends`/`extends` trees) to collect referenced import roots, then **skips loading/evaluating** any import whose alias is not referenced—including broken or missing files, and shadowed names. That avoids cycles such as annotation-only builtin imports that glob back into the same module.
> 
> **`amends` / `extends`** now evaluate base modules with the child’s scope passed in (`eval_module_with_scope` / `eval_file_with_scope`), with a separate in-flight set so scoped base evaluation does not overwrite the normal import cache. Imports of the same local file as the inherited base are deferred and bound from the evaluated base value.
> 
> **Parser/lexer** treat `;` as an explicit separator (no longer swallowed as whitespace) in headers and object bodies. **`analyze_imports`** recursively walks the graph, deduplicates paths, and skips missing files.
> 
> Additional evaluator behavior: typed **mapping** `+` / property amendments preserve keys and merge nested entries; class instances drop schema-only members (nested classes / local lambdas) from data; **`toMapping`** aliases **`toMap`**; dotted generic type params parse correctly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1015069e9378e3a9440538be76c24e74ec6e9e4a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Semicolon (`;`) is accepted as an entry separator and preserved by the parser/lexer.
  * Import analysis now computes transitive, deduplicated local dependencies.
  * `toMap` and `toMapping` are treated equivalently for object mapping round-trips.

* **Bug Fixes**
  * Unused imports (including shadowed or missing cases) are not evaluated; missing-local errors only raised for referenced imports.
  * Typed mapping amendments preserve existing keyed entries and correctly merge/override nested values.
  * Dotted generic parameter names supported; lambda-valued class properties remain callable after instantiation.

* **Tests**
  * Expanded coverage for import analysis, separators, mapping/class semantics, and temp-dir helpers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->