### PR TITLE
chore: release v1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0](https://github.com/jdx/pklr/compare/v0.4.5...v1.0.0) - 2026-06-09
+
+### Fixed
+
+- *(eval)* skip unused imports ([#91](https://github.com/jdx/pklr/pull/91))
+
 ## [0.4.5](https://github.com/jdx/pklr/compare/v0.4.4...v0.4.5) - 2026-06-09
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -651,7 +651,7 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pklr"
-version = "0.4.5"
+version = "1.0.0"
 dependencies = [
  "async-recursion",
  "indexmap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "pklr"
-version     = "0.4.5"
+version     = "1.0.0"
 edition      = "2024"
 rust-version = "1.88"
 description = "Pure Rust pkl configuration language parser and evaluator"


### PR DESCRIPTION



## 🤖 New release

* `pklr`: 0.4.5 -> 0.5.0 (⚠ API breaking changes)

### ⚠ `pklr` breaking changes

```text
--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.47.0/src/lints/enum_variant_added.ron

Failed in:
  variant TokenKind:Semicolon in /tmp/.tmpVhENYh/pklr/src/lexer.rs:30
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.5.0](https://github.com/jdx/pklr/compare/v0.4.5...v0.5.0) - 2026-06-09

### Fixed

- *(eval)* skip unused imports ([#91](https://github.com/jdx/pklr/pull/91))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Diff is version and changelog only; any API impact (e.g. new `TokenKind::Semicolon`) comes from code already merged in prior PRs, not from files changed here.
> 
> **Overview**
> **Release bump** for the `pklr` crate from `0.4.5` to **`1.0.0`**, with matching updates in `Cargo.lock`.
> 
> **CHANGELOG** adds a `[1.0.0]` entry (2026-06-09) under **Fixed**: *(eval)* skip unused imports ([#91](https://github.com/jdx/pklr/pull/91)). No library source changes appear in this diff—only version and changelog metadata for the release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 24e6cb19b95fcf20d5c24d30f16905850248b031. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->