### PR TITLE
fix: preserve regex output compatibility

### DIFF
--- a/src/eval.rs
+++ b/src/eval.rs
@@ -44,6 +44,13 @@ struct MappingInheritedDefault {
     entries: Option<Vec<Entry>>,
 }
 
+fn regex_value(pattern: Value) -> Value {
+    let mut map = IndexMap::new();
+    map.insert("_type".to_string(), Value::String("regex".to_string()));
+    map.insert("pattern".to_string(), pattern);
+    Value::Object(Arc::new(map), None)
+}
+
 impl Default for Evaluator {
     fn default() -> Self {
         Self {
@@ -2112,9 +2119,7 @@ impl Evaluator {
                 "Regex" => {
                     if let Some(arg) = args.first() {
                         let val = self.eval_expr(arg, scope, depth + 1).await?;
-                        let mut map = IndexMap::new();
-                        map.insert("pattern".to_string(), val);
-                        return Ok(Value::Object(Arc::new(map), None));
+                        return Ok(regex_value(val));
                     }
                     return Err(Error::Eval("Regex() requires a pattern argument".into()));
                 }
@@ -2170,9 +2175,7 @@ impl Evaluator {
             && let Some(arg) = args.first()
         {
             let val = self.eval_expr(arg, scope, depth + 1).await?;
-            let mut map = IndexMap::new();
-            map.insert("pattern".to_string(), val);
-            return Ok(Value::Object(Arc::new(map), None));
+            return Ok(regex_value(val));
         }
 
         // Plain call with no args on an object — return the object

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -343,10 +343,29 @@ impl<'a> Lexer<'a> {
                 Some(c) => s.push(c),
             }
         }
-        // Strip leading/trailing newlines per pkl convention
-        let s = s.trim_start_matches('\n');
-        // Dedent by removing common leading whitespace
-        dedent(s)
+        normalize_multiline_string(&s)
+    }
+
+    fn read_raw_multiline_string(&mut self) -> Result<String> {
+        // Already consumed `#"""`
+        // Read until closing `"""#`
+        let mut s = String::new();
+        loop {
+            if self.source[self.pos..].starts_with("\"\"\"#") {
+                self.advance();
+                self.advance();
+                self.advance();
+                self.advance();
+                break;
+            }
+            match self.advance() {
+                None => {
+                    return Err(self.lex_error("unterminated raw multiline string"));
+                }
+                Some(c) => s.push(c),
+            }
+        }
+        normalize_multiline_string(&s)
     }
 
     fn read_number(&mut self, first: char) -> Result<TokenKind> {
@@ -668,7 +687,13 @@ impl<'a> Lexer<'a> {
             '#' => {
                 // #"..."# raw strings
                 self.advance();
-                if self.peek() == Some('"') {
+                if self.source[self.pos..].starts_with("\"\"\"") {
+                    self.advance();
+                    self.advance();
+                    self.advance();
+                    let s = self.read_raw_multiline_string()?;
+                    TokenKind::StringLit(s)
+                } else if self.peek() == Some('"') {
                     self.advance();
                     let s = self.read_raw_string('#')?;
                     TokenKind::StringLit(s)
@@ -740,6 +765,11 @@ impl<'a> Lexer<'a> {
         }
         Ok(s)
     }
+}
+
+fn normalize_multiline_string(s: &str) -> Result<String> {
+    let s = s.trim_start_matches('\n');
+    dedent(s)
 }
 
 fn keyword_or_ident(s: &str) -> TokenKind {

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -346,16 +346,16 @@ impl<'a> Lexer<'a> {
         normalize_multiline_string(&s)
     }
 
-    fn read_raw_multiline_string(&mut self) -> Result<String> {
-        // Already consumed `#"""`
-        // Read until closing `"""#`
+    fn read_raw_multiline_string(&mut self, hash_count: usize) -> Result<String> {
+        // Already consumed the opening hashes and `"""`
+        // Read until the matching closing `"""` plus the same number of hashes.
+        let closing = format!("\"\"\"{}", "#".repeat(hash_count));
         let mut s = String::new();
         loop {
-            if self.source[self.pos..].starts_with("\"\"\"#") {
-                self.advance();
-                self.advance();
-                self.advance();
-                self.advance();
+            if self.source[self.pos..].starts_with(&closing) {
+                for _ in 0..closing.chars().count() {
+                    self.advance();
+                }
                 break;
             }
             match self.advance() {
@@ -685,17 +685,21 @@ impl<'a> Lexer<'a> {
                 }
             }
             '#' => {
-                // #"..."# raw strings
-                self.advance();
+                // #"..."# and #"""..."""# raw strings. Pkl allows multiple hashes.
+                let mut hash_count = 0;
+                while self.peek() == Some('#') {
+                    self.advance();
+                    hash_count += 1;
+                }
                 if self.source[self.pos..].starts_with("\"\"\"") {
                     self.advance();
                     self.advance();
                     self.advance();
-                    let s = self.read_raw_multiline_string()?;
+                    let s = self.read_raw_multiline_string(hash_count)?;
                     TokenKind::StringLit(s)
                 } else if self.peek() == Some('"') {
                     self.advance();
-                    let s = self.read_raw_string('#')?;
+                    let s = self.read_raw_string(hash_count)?;
                     TokenKind::StringLit(s)
                 } else {
                     // Could be a shebang line or annotation — skip line
@@ -747,13 +751,15 @@ impl<'a> Lexer<'a> {
         Ok(kind)
     }
 
-    fn read_raw_string(&mut self, _delimiter: char) -> Result<String> {
-        // Read until `"#`
+    fn read_raw_string(&mut self, hash_count: usize) -> Result<String> {
+        // Read until the closing quote plus the same number of hashes.
+        let closing = format!("\"{}", "#".repeat(hash_count));
         let mut s = String::new();
         loop {
-            if self.source[self.pos..].starts_with("\"#") {
-                self.advance();
-                self.advance();
+            if self.source[self.pos..].starts_with(&closing) {
+                for _ in 0..closing.chars().count() {
+                    self.advance();
+                }
                 break;
             }
             match self.advance() {
@@ -768,7 +774,7 @@ impl<'a> Lexer<'a> {
 }
 
 fn normalize_multiline_string(s: &str) -> Result<String> {
-    let s = s.trim_start_matches('\n');
+    let s = s.strip_prefix('\n').unwrap_or(s);
     dedent(s)
 }
 

--- a/tests/pkl_features.rs
+++ b/tests/pkl_features.rs
@@ -196,6 +196,13 @@ fn string_multiline() {
 }
 
 #[test]
+fn string_raw_multiline() {
+    let src = "x = #\"\"\"\n  hello\\n\n  world\n  \"\"\"#";
+    let json = eval(src);
+    assert_eq!(json["x"], "hello\\n\nworld\n");
+}
+
+#[test]
 fn string_unicode_escape() {
     let json = eval(r#"x = "\u{26} \u{E9} \u{1F600}""#);
     assert_eq!(json["x"], "& \u{E9} \u{1F600}");
@@ -3293,6 +3300,116 @@ result = c.compute(5)
 // ============================================================
 // hk.pkl compatibility
 // ============================================================
+
+#[test]
+fn regex_constructor_emits_type_tag() {
+    let json = eval(
+        r##"
+glob = Regex(#"^.*\.json$"#)
+"##,
+    );
+    assert_eq!(json["glob"]["_type"], "regex");
+    assert_eq!(json["glob"]["pattern"], r"^.*\.json$");
+}
+
+#[tokio::test]
+async fn imported_regex_constructor_emits_type_tag() {
+    let temp = TestTempDir::new("pklr_test_imported_regex_type_tag");
+    let dir = temp.path();
+    std::fs::write(
+        dir.join("Types.pkl"),
+        r#"
+import "pkl:base"
+function Regex(pattern: String) = base.Regex(pattern)
+"#,
+    )
+    .unwrap();
+    std::fs::write(
+        dir.join("test.pkl"),
+        r##"
+import "Types.pkl"
+glob = Types.Regex(#"^.*\.yaml$"#)
+"##,
+    )
+    .unwrap();
+
+    let mut ev = Evaluator::new();
+    let path = dir.join("test.pkl");
+    let val = ev
+        .eval_source(&std::fs::read_to_string(&path).unwrap(), &path)
+        .await
+        .unwrap();
+    let json = val.to_json();
+    assert_eq!(json["glob"]["_type"], "regex");
+    assert_eq!(json["glob"]["pattern"], r"^.*\.yaml$");
+}
+
+#[tokio::test]
+async fn hk_step_regex_glob_emits_type_tag() {
+    let temp = TestTempDir::new("pklr_test_hk_step_regex_glob");
+    let dir = temp.path();
+    std::fs::write(
+        dir.join("Config.pkl"),
+        r#"
+function Regex(pattern: String) = base.Regex(pattern)
+class Step {
+    glob: (String | List<String> | Regex)?
+    check: String?
+}
+class Hook {
+    steps: Mapping<String, Step> = new Mapping<String, Step> {}
+}
+hooks: Mapping<String, Hook> = new Mapping<String, Hook> {}
+"#,
+    )
+    .unwrap();
+    std::fs::write(
+        dir.join("hk.pkl"),
+        r##"
+amends "Config.pkl"
+hooks {
+    ["check"] {
+        steps {
+            ["regex-test"] {
+                glob = Regex(#"^.*\.json$"#)
+                check = "echo {{files}}"
+            }
+        }
+    }
+}
+"##,
+    )
+    .unwrap();
+
+    let mut ev = Evaluator::new();
+    let path = dir.join("hk.pkl");
+    let val = ev
+        .eval_source(&std::fs::read_to_string(&path).unwrap(), &path)
+        .await
+        .unwrap();
+    let json = val.to_json();
+    let glob = &json["hooks"]["check"]["steps"]["regex-test"]["glob"];
+    assert_eq!(glob["_type"], "regex");
+    assert_eq!(glob["pattern"], r"^.*\.json$");
+}
+
+#[test]
+fn hk_multiline_regex_pattern_is_normalized() {
+    let json = eval(
+        r####"
+glob = Regex(#"""
+    (?x)
+    ^.*airflow\.template\.yaml$|
+    ^chart/(?:templates|files)/.*\.yaml$
+    """#)
+"####,
+    );
+    assert_eq!(json["glob"]["_type"], "regex");
+    assert_eq!(
+        json["glob"]["pattern"],
+        "(?x)\n^.*airflow\\.template\\.yaml$|\n^chart/(?:templates|files)/.*\\.yaml$\n"
+    );
+}
 
 #[tokio::test]
 async fn eval_amends_perf() {

--- a/tests/pkl_features.rs
+++ b/tests/pkl_features.rs
@@ -203,6 +203,26 @@ fn string_raw_multiline() {
 }
 
 #[test]
+fn string_multiline_strips_only_one_opening_newline() {
+    let src = "x = \"\"\"\n\n  hello\n  \"\"\"";
+    let json = eval(src);
+    assert_eq!(json["x"], "\nhello\n");
+}
+
+#[test]
+fn string_multi_hash_raw() {
+    let json = eval(r####"x = ##"hello "# world"##"####);
+    assert_eq!(json["x"], "hello \"# world");
+}
+
+#[test]
+fn string_multi_hash_raw_multiline() {
+    let src = "x = ##\"\"\"\n  hello \"\"\"#\n  world\n  \"\"\"##";
+    let json = eval(src);
+    assert_eq!(json["x"], "hello \"\"\"#\nworld\n");
+}
+
+#[test]
 fn string_unicode_escape() {
     let json = eval(r#"x = "\u{26} \u{E9} \u{1F600}""#);
     assert_eq!(json["x"], "& \u{E9} \u{1F600}");
@@ -3351,6 +3371,7 @@ async fn hk_step_regex_glob_emits_type_tag() {
     std::fs::write(
         dir.join("Config.pkl"),
         r#"
+import "pkl:base" as base
 function Regex(pattern: String) = base.Regex(pattern)
 class Step {
     glob: (String | List<String> | Regex)?


### PR DESCRIPTION
## Summary
- emit `_type = "regex"` for pklr `Regex(...)` values so downstream deserializers can distinguish regex objects from ordinary objects
- parse raw multiline strings (`#"""..."""#`) as multiline strings, including leading newline stripping and dedent
- add regression coverage for bare `Regex`, imported `base.Regex`, hk-style step regex globs, and multiline regex patterns

## Verification
- `cargo test`
- in `jdx/hk` with `pklr` temporarily pointed at this local checkout: `cargo check --locked`
- in `jdx/hk` with `pklr` temporarily pointed at this local checkout: `mise run test:bats test/regex_patterns.bats`
- in `jdx/hk` with `pklr` temporarily pointed at this local checkout: `mise run test:bats test/pklr_backend.bats`

This should cover the failures seen while trying to consume pklr 1.0.0 from the hk default-pklr-backend PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes serialized Regex shape and lexer behavior for multiline/raw strings; downstream deserializers depend on the new `_type` field, and string edge cases could affect existing configs.
> 
> **Overview**
> Restores **downstream-compatible** `Regex(...)` output and expands **string literal** parsing to match Pkl/hk expectations.
> 
> **Regex values** now go through a shared `regex_value` helper so both `Regex(...)` and scoped calls like `base.Regex(...)` emit `_type = "regex"` plus `pattern`, letting consumers tell regex objects apart from plain maps.
> 
> **Lexer string changes:** multiline `"""..."""` normalization strips only the first leading newline (not all leading newlines) before dedent. Raw strings support **multiple `#` delimiters** and **raw multiline** `#"""..."""#` (with the same newline/dedent rules as ordinary multiline strings).
> 
> Regression tests cover multi-hash raw strings, imported/hk-style regex globs, and multiline regex patterns.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cefb25d602622ba07d1f9a8638111f0b1fbe9e22. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for raw multiline string literals using hash-delimited syntax, including multi-hash variants and consistent newline/dedent normalization
  * More consistent regex value output that preserves a type tag and pattern, including normalized multiline regex patterns

* **Tests**
  * Added comprehensive tests covering raw multiline strings and regex behavior, including multi-hash and multiline cases
<!-- end of auto-generated comment: release notes by coderabbit.ai -->