### PR TITLE
chore: release v1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.1](https://github.com/jdx/pklr/compare/v1.0.0...v1.0.1) - 2026-06-09
+
+### Fixed
+
+- preserve regex output compatibility ([#93](https://github.com/jdx/pklr/pull/93))
+
 ## [1.0.0](https://github.com/jdx/pklr/compare/v0.4.5...v1.0.0) - 2026-06-09
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -651,7 +651,7 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pklr"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "async-recursion",
  "indexmap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "pklr"
-version     = "1.0.0"
+version     = "1.0.1"
 edition      = "2024"
 rust-version = "1.88"
 description = "Pure Rust pkl configuration language parser and evaluator"


### PR DESCRIPTION



## 🤖 New release

* `pklr`: 1.0.0 -> 1.0.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [1.0.1](https://github.com/jdx/pklr/compare/v1.0.0...v1.0.1) - 2026-06-09

### Fixed

- preserve regex output compatibility ([#93](https://github.com/jdx/pklr/pull/93))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version and changelog-only release with no code changes in this diff.
> 
> **Overview**
> **Release v1.0.1** — bumps the crate from `1.0.0` to `1.0.1` in `Cargo.toml` and `Cargo.lock`, and adds the **1.0.1** section to `CHANGELOG.md`.
> 
> The changelog entry records the patch fix from [#93](https://github.com/jdx/pklr/pull/93): **preserve regex output compatibility**. This PR does not include evaluator/source changes; it only packages and documents that already-merged fix for publish.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f567b94743ff7b3ac070a2a6048f3f7ecb37b30b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue to preserve regex output compatibility and ensure consistent behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->