### PR TITLE
fix(eval): preserve explicit union mapping types

### DIFF
--- a/src/eval.rs
+++ b/src/eval.rs
@@ -2695,6 +2695,11 @@ impl Evaluator {
                     let type_default = match val_expr {
                         Expr::ObjectBody(body) => select_mapping_type_default(type_defaults, body)
                             .map(|(name, value)| (Some(name.as_str()), value)),
+                        Expr::New(Some(type_name), _, _) => {
+                            select_mapping_type_default_for_new(type_defaults, type_name)
+                                .map(|(name, value)| (Some(name.as_str()), value))
+                        }
+                        Expr::New(None, _, _) => None,
                         _ => type_defaults
                             .first()
                             .map(|(name, value)| (Some(name.as_str()), value)),
@@ -2715,8 +2720,11 @@ impl Evaluator {
                     let val =
                         if let Some((default_type_name, Value::Object(template_map, Some(src)))) =
                             default_template.as_ref()
-                            && let Expr::ObjectBody(body) = val_expr
+                            && let Some(body) = mapping_entry_body(val_expr)
                         {
+                            if let Expr::New(Some(type_name), _, _) = val_expr {
+                                validate_new_object_body(type_name, body, src)?;
+                            }
                             let mut result =
                                 if let Some(default_entries) = explicit_default_entries.as_ref() {
                                     let mut overlay_entries = default_entries.clone();
@@ -2980,6 +2988,90 @@ fn select_mapping_type_default<'a>(
     // order. This mirrors Pkl's first assignable type behavior when there is no
     // stronger structural signal in the entry body.
     best.or_else(|| type_defaults.first())
+}
+
+fn select_mapping_type_default_for_new<'a>(
+    type_defaults: &'a [(String, Value)],
+    type_name: &str,
+) -> Option<&'a (String, Value)> {
+    type_defaults
+        .iter()
+        .find(|(name, _)| name == type_name)
+        .or_else(|| {
+            type_defaults
+                .iter()
+                .find(|(name, _)| type_names_match(name, type_name))
+        })
+        .or_else(|| {
+            type_defaults.iter().find(|(_, value)| {
+                matches!(
+                    value,
+                    Value::Object(_, Some(src))
+                        if src
+                            .type_name
+                            .as_deref()
+                            .is_some_and(|tn| type_names_match(tn, type_name))
+                )
+            })
+        })
+}
+
+fn type_names_match(a: &str, b: &str) -> bool {
+    a == b
+        || (a.len() > b.len() && a.ends_with(b) && a.as_bytes()[a.len() - b.len() - 1] == b'.')
+        || (b.len() > a.len() && b.ends_with(a) && b.as_bytes()[b.len() - a.len() - 1] == b'.')
+}
+
+fn mapping_entry_body(expr: &Expr) -> Option<&[Entry]> {
+    match expr {
+        Expr::ObjectBody(body) => Some(body),
+        Expr::New(Some(_), body, _) => Some(body),
+        _ => None,
+    }
+}
+
+fn validate_new_object_body(
+    type_name: &str,
+    entries: &[Entry],
+    base_src: &ObjectSource,
+) -> Result<()> {
+    if base_src.is_open {
+        return Ok(());
+    }
+
+    let base_names: HashSet<String> = base_src
+        .entries
+        .iter()
+        .filter_map(|entry| {
+            if let Entry::Property(prop) = entry {
+                Some(prop.name.clone())
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    for entry in entries {
+        match entry {
+            Entry::Property(prop)
+                if !has_modifier(&prop.modifiers, Modifier::Local)
+                    && !base_names.contains(&prop.name) =>
+            {
+                return Err(Error::Eval(format!(
+                    "cannot add property '{}' to non-open class {type_name}",
+                    prop.name
+                )));
+            }
+            Entry::DynProperty(Expr::String(key), _) if !base_names.contains(key) => {
+                return Err(Error::Eval(format!(
+                    "cannot add property '{key}' to non-open class {type_name}"
+                )));
+            }
+            _ => {}
+        }
+    }
+
+    Ok(())
 }
 
 fn find_default_body_entries(entries: &[Entry]) -> Option<Vec<Entry>> {

--- a/tests/pkl_features.rs
+++ b/tests/pkl_features.rs
@@ -3818,6 +3818,199 @@ steps = new Mapping<String, Step | Group> {
 }
 
 #[test]
+fn converter_union_mapping_preserves_explicit_new_type() {
+    let json = eval_with_converters(
+        r#"
+class Group {
+    steps: Mapping<String, Step> = new Mapping<String, Step> {}
+    shared: Boolean = false
+}
+
+class Step {
+    check: String = ""
+    shared: Boolean = false
+}
+
+output {
+    renderer {
+        converters {
+            [Group] = (g) -> new Dynamic {
+                _type = "group"
+                ...g.toDynamic()
+            }
+            [Step] = (s) -> new Dynamic {
+                _type = "step"
+                ...s.toDynamic()
+            }
+        }
+    }
+}
+
+steps = new Mapping<String, Step | Group> {
+    default {
+        shared = true
+    }
+    ["group"] = new Group {
+        steps {
+            ["lint"] {
+                check = "eslint"
+            }
+        }
+    }
+    ["echo"] {
+        check = "echo ok"
+    }
+}
+"#,
+    );
+    assert_eq!(json["steps"]["group"]["_type"], "group");
+    assert_eq!(json["steps"]["group"]["shared"], true);
+    assert_eq!(json["steps"]["group"]["steps"]["lint"]["_type"], "step");
+    assert_eq!(json["steps"]["echo"]["_type"], "step");
+    assert_eq!(json["steps"]["echo"]["shared"], true);
+}
+
+#[test]
+fn converter_union_mapping_explicit_new_validates_class_body() {
+    let msg = eval_fails(
+        r#"
+class Group {
+    steps: Mapping<String, Step> = new Mapping<String, Step> {}
+}
+
+class Step {
+    check: String = ""
+}
+
+steps = new Mapping<String, Step | Group> {
+    ["group"] = new Group {
+        unknown = true
+    }
+}
+"#,
+    );
+    assert!(msg.contains("non-open"));
+    assert!(msg.contains("unknown"));
+}
+
+#[test]
+fn converter_union_mapping_explicit_default_does_not_open_new_body() {
+    let msg = eval_fails(
+        r#"
+class Group {
+    steps: Mapping<String, Step> = new Mapping<String, Step> {}
+}
+
+class Step {
+    check: String = ""
+}
+
+steps = new Mapping<String, Step | Group> {
+    default {
+        extra = false
+    }
+    ["group"] = new Group {
+        extra = true
+    }
+}
+"#,
+    );
+    assert!(msg.contains("non-open"));
+    assert!(msg.contains("extra"));
+}
+
+#[test]
+fn converter_union_mapping_untyped_new_stays_untyped() {
+    let json = eval_with_converters(
+        r#"
+class Group {
+    steps: Mapping<String, Step> = new Mapping<String, Step> {}
+}
+
+class Step {
+    check: String = ""
+}
+
+output {
+    renderer {
+        converters {
+            [Group] = (g) -> new Dynamic {
+                _type = "group"
+                ...g.toDynamic()
+            }
+            [Step] = (s) -> new Dynamic {
+                _type = "step"
+                ...s.toDynamic()
+            }
+        }
+    }
+}
+
+steps = new Mapping<String, Step | Group> {
+    ["plain"] = new {
+        steps {
+            ["lint"] {
+                check = "eslint"
+            }
+        }
+    }
+}
+"#,
+    );
+    assert_eq!(json["steps"]["plain"]["_type"], serde_json::Value::Null);
+    assert_eq!(json["steps"]["plain"]["steps"]["lint"]["check"], "eslint");
+}
+
+#[test]
+fn converter_union_mapping_explicit_new_without_type_default_uses_constructor() {
+    let json = eval_with_converters(
+        r#"
+class Group {
+    steps: Mapping<String, Step> = new Mapping<String, Step> {}
+    shared: Boolean = false
+}
+
+class Step {
+    check: String = ""
+}
+
+typealias GroupAlias = Group
+
+output {
+    renderer {
+        converters {
+            [Group] = (g) -> new Dynamic {
+                _type = "group"
+                ...g.toDynamic()
+            }
+            [Step] = (s) -> new Dynamic {
+                _type = "step"
+                ...s.toDynamic()
+            }
+        }
+    }
+}
+
+steps = new Mapping<String, GroupAlias | Step> {
+    default {
+        shared = true
+    }
+    ["group"] = new Group {
+        steps {
+            ["lint"] {
+                check = "eslint"
+            }
+        }
+    }
+}
+"#,
+    );
+    assert_eq!(json["steps"]["group"]["_type"], "group");
+    assert_eq!(json["steps"]["group"]["shared"], true);
+    assert_eq!(json["steps"]["group"]["steps"]["lint"]["_type"], "step");
+}
+
+#[test]
 fn mapping_amendment_preserves_type_aliases() {
     let json = eval_with_converters(
         r#"


### PR DESCRIPTION
## Summary
- preserve explicit `new Type` metadata when evaluating typed union mapping entries
- apply mapping defaults through the selected template for explicit `new Type { ... }` entries
- add regression coverage for explicit `new Group` in `Mapping<String, Step | Group>`

## Validation
- `cargo fmt --check`
- `cargo test --locked`

This PR was generated with AI assistance.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core mapping evaluation and type/default merging for union value types, which can affect serialized output and converter tagging beyond the new tests.
> 
> **Overview**
> **Union-typed mapping entries** now treat explicit `new Type { ... }` like object bodies when picking defaults and applying templates, so converter `_type` metadata and mapping `default` merging stay aligned with the chosen union member.
> 
> Type selection for `new Type` uses **`select_mapping_type_default_for_new`** (exact name, dotted suffix, or template `ObjectSource.type_name`) instead of always falling back to the first union variant. **`new { ... }`** without a type name deliberately skips typed defaults so entries remain untyped. Template application runs through **`mapping_entry_body`** for both object bodies and `new` bodies, with **`validate_new_object_body`** rejecting extra properties on **non-open** classes—mapping `default { }` does not relax that rule.
> 
> Regression tests cover converter output, validation errors, untyped `new`, and typealias-based default resolution.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 83870c0d431c01097019dea2ecf257ace7f975e1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserve explicit type metadata and converter tags for entries constructed with explicit types in union-type mappings.
  * Ensure explicit anonymous constructions remain untyped while still converting nested fields.
  * Improve selection of type-specific defaults using exact and dotted-suffix matching and avoid inappropriate fallbacks.
  * Validate explicit object constructions and applied defaults against non-open class constraints and report clear errors for unknown properties.

* **Tests**
  * Added tests covering type-preservation, untyped entries, default-selection behavior, amendment-body handling, and rejection of invalid explicit object bodies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->