### PR TITLE
chore: release v1.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.2](https://github.com/jdx/pklr/compare/v1.0.1...v1.0.2) - 2026-06-09
+
+### Fixed
+
+- *(eval)* preserve explicit union mapping types ([#95](https://github.com/jdx/pklr/pull/95))
+
 ## [1.0.1](https://github.com/jdx/pklr/compare/v1.0.0...v1.0.1) - 2026-06-09
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -651,7 +651,7 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pklr"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
  "async-recursion",
  "indexmap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "pklr"
-version     = "1.0.1"
+version     = "1.0.2"
 edition      = "2024"
 rust-version = "1.88"
 description = "Pure Rust pkl configuration language parser and evaluator"


### PR DESCRIPTION



## 🤖 New release

* `pklr`: 1.0.1 -> 1.0.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [1.0.2](https://github.com/jdx/pklr/compare/v1.0.1...v1.0.2) - 2026-06-09

### Fixed

- *(eval)* preserve explicit union mapping types ([#95](https://github.com/jdx/pklr/pull/95))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version and changelog-only release with no code changes in this PR; API-compatible patch per release tooling.
> 
> **Overview**
> **Release v1.0.2** — bumps the `pklr` crate from **1.0.1** to **1.0.2** in `Cargo.toml` and `Cargo.lock`, and records the release in `CHANGELOG.md`.
> 
> The changelog entry documents the user-facing fix from [#95](https://github.com/jdx/pklr/pull/95): the evaluator now **preserves explicit union mapping types** when amending or evaluating mapping bodies (so converter/type metadata for union mappings is not lost). No other source changes appear in this diff; it is a **release-plz** packaging PR for that already-merged fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3e2cfab28c477f93202fa54bd648f6c204b328c7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where `(eval)` was not properly preserving explicit union mapping types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->