### PR TITLE
fix(eval): support string boolean conversion

### DIFF
--- a/src/eval.rs
+++ b/src/eval.rs
@@ -2095,6 +2095,23 @@ impl Evaluator {
                 return self.eval_expr(body, &call_scope, depth + 1).await;
             }
         }
+        // Handle null-safe method calls: obj?.method(args)
+        if let Expr::NullSafeField(obj_expr, method) = func_expr {
+            let obj = self.eval_expr(obj_expr, scope, depth + 1).await?;
+            if matches!(obj, Value::Null) {
+                return Ok(Value::Null);
+            }
+            let mut evaled_args = Vec::new();
+            for a in args {
+                evaled_args.push(self.eval_expr(a, scope, depth + 1).await?);
+            }
+            if let Some(result) = self
+                .eval_method_call(&obj, method, &evaled_args, depth)
+                .await?
+            {
+                return Ok(result);
+            }
+        }
 
         // Handle built-in functions: List(), Listing(), Map()
         if let Expr::Ident(name) = func_expr {
@@ -2227,6 +2244,10 @@ impl Evaluator {
                 .parse::<i64>()
                 .map(|n| Some(Value::Int(n)))
                 .map_err(|_| Error::Eval(format!("cannot convert '{s}' to Int"))),
+            (Value::String(s), "toBoolean") => s
+                .parse::<bool>()
+                .map(|b| Some(Value::Bool(b)))
+                .map_err(|_| Error::Eval(format!("cannot convert '{s}' to Boolean"))),
 
             // List methods
             (Value::List(items), "contains") => {

--- a/tests/pkl_features.rs
+++ b/tests/pkl_features.rs
@@ -972,6 +972,22 @@ x = List().isEmpty
     assert_eq!(json["x"], true);
 }
 
+#[test]
+fn string_to_boolean() {
+    let json = eval(
+        r#"
+truthy = "true".toBoolean()
+falsy = "false".toBoolean()
+nullish = null?.toBoolean()
+null_safe = "false"?.toBoolean()
+"#,
+    );
+    assert_eq!(json["truthy"], true);
+    assert_eq!(json["falsy"], false);
+    assert_eq!(json["nullish"], serde_json::Value::Null);
+    assert_eq!(json["null_safe"], false);
+}
+
 // ============================================================
 // Import resolution (future)
 // ============================================================


### PR DESCRIPTION
## Summary
- add String.toBoolean() support
- dispatch null-safe method calls like value?.toBoolean()
- cover string and null-safe boolean conversion in evaluator tests

## Verification
- cargo test
- verified hk stage_setting.bats passes locally when hk is built against this pklr checkout

*This PR was generated by Claude Code.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized evaluator changes for one string method and call-site handling; covered by new tests with no auth or I/O impact.
> 
> **Overview**
> Adds **`String.toBoolean()`** in the evaluator (parses `"true"` / `"false"` via Rust’s bool parser, with eval errors on invalid strings).
> 
> **Null-safe calls** like `null?.toBoolean()` and `"false"?.toBoolean()` now work: when the callee is `Expr::NullSafeField`, a null receiver short-circuits to `Null`; otherwise args are evaluated and **`eval_method_call`** runs (property-only `?.` behavior was already there).
> 
> Tests in `tests/pkl_features.rs` cover truthy/falsy strings and null-safe boolean conversion.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3634a9be29fbbf346bc2116152d8822c01beef40. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added null-safe method calls for safer object manipulation, enabling method invocation on potentially null objects with automatic null propagation.
  * Introduced string `.toBoolean()` method to parse string values into boolean results, with robust error handling for invalid input formats.

* **Tests**
  * Added comprehensive test coverage for the new `.toBoolean()` functionality and null-safe behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->