### PR TITLE
chore: release v1.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.3](https://github.com/jdx/pklr/compare/v1.0.2...v1.0.3) - 2026-06-09
+
+### Fixed
+
+- *(eval)* support string boolean conversion
+
 ## [1.0.2](https://github.com/jdx/pklr/compare/v1.0.1...v1.0.2) - 2026-06-09
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -651,7 +651,7 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pklr"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "async-recursion",
  "indexmap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "pklr"
-version     = "1.0.2"
+version     = "1.0.3"
 edition      = "2024"
 rust-version = "1.88"
 description = "Pure Rust pkl configuration language parser and evaluator"


### PR DESCRIPTION



## 🤖 New release

* `pklr`: 1.0.2 -> 1.0.3 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [1.0.3](https://github.com/jdx/pklr/compare/v1.0.2...v1.0.3) - 2026-06-09

### Fixed

- *(eval)* support string boolean conversion
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version and changelog-only release with no source changes in this PR; API marked compatible by release-plz.
> 
> **Overview**
> **Release v1.0.3** bumps the crate from `1.0.2` to `1.0.3` via release-plz: `Cargo.toml`, `Cargo.lock`, and a new **1.0.3** section in `CHANGELOG.md`.
> 
> The documented user-facing change for this version is an **eval** fix: **string boolean conversion** (e.g. `"true"` / `"false"` via `toBoolean()`), which shipped in the prior fix and is only recorded here—not modified in this diff beyond the changelog line.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c67e37323c567c3c6186e095cc4da3ee7dba1f39. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes - Version 1.0.3

* **Bug Fixes**
  * Fixed support for converting strings to boolean values with `*(eval)*`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->