### PR TITLE
fix(eval): handle null-safe object method calls

### DIFF
--- a/src/eval.rs
+++ b/src/eval.rs
@@ -2076,6 +2076,13 @@ impl Evaluator {
             {
                 return Ok(result);
             }
+            if let Some(result) = self.eval_object_field_call(&obj, method, &evaled_args)? {
+                return Ok(result);
+            }
+            return Err(Error::Eval(format!(
+                "unknown method '{method}' on {}",
+                value_type_name(&obj)
+            )));
         }
         // Handle null-safe method calls: obj?.method(args)
         if let Expr::NullSafeField(obj_expr, method) = func_expr {
@@ -2097,6 +2104,9 @@ impl Evaluator {
                 .eval_object_method_call(&obj, method, &evaled_args, depth)
                 .await?
             {
+                return Ok(result);
+            }
+            if let Some(result) = self.eval_object_field_call(&obj, method, &evaled_args)? {
                 return Ok(result);
             }
             return Err(Error::Eval(format!(
@@ -2192,6 +2202,30 @@ impl Evaluator {
             return Ok(func_val);
         }
         Err(Error::Eval("cannot call non-function".into()))
+    }
+
+    fn eval_object_field_call(
+        &mut self,
+        obj: &Value,
+        method: &str,
+        evaled_args: &[Value],
+    ) -> Result<Option<Value>> {
+        if let Value::Object(map, source) = obj
+            && let Some(func_val) = map.get(method).cloned()
+        {
+            self.warn_if_deprecated_access(source, method);
+            if let Value::String(ref name) = func_val
+                && name == "Regex"
+                && let Some(arg) = evaled_args.first()
+            {
+                return Ok(Some(regex_value(arg.clone())));
+            }
+            if evaled_args.is_empty() {
+                return Ok(Some(func_val));
+            }
+            return Err(Error::Eval("cannot call non-function".into()));
+        }
+        Ok(None)
     }
 
     #[async_recursion(?Send)]

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -2070,29 +2070,11 @@ impl Evaluator {
             {
                 return Ok(result);
             }
-            // If the field is a Lambda on an Object (class method), invoke it
-            // with the object's properties layered into the call scope so that
-            // overridden properties are visible to the function body and any
-            // local functions it calls.
-            if let Value::Object(ref map, _) = obj
-                && let Some(Value::Lambda(params, body, captured)) = map.get(method)
+            if let Some(result) = self
+                .eval_object_method_call(&obj, method, &evaled_args, depth)
+                .await?
             {
-                let mut call_scope = Scope::default();
-                for (k, v) in captured.iter() {
-                    call_scope.set(k.clone(), v.clone());
-                }
-                // Layer in ALL of the instance's properties including lambdas,
-                // so local functions called by this method also see overrides
-                for (k, v) in map.iter() {
-                    call_scope.set(k.clone(), v.clone());
-                }
-                call_scope.set("this".into(), obj.clone());
-                for (i, param) in params.iter().enumerate() {
-                    if let Some(arg) = evaled_args.get(i) {
-                        call_scope.set(param.clone(), arg.clone());
-                    }
-                }
-                return self.eval_expr(body, &call_scope, depth + 1).await;
+                return Ok(result);
             }
         }
         // Handle null-safe method calls: obj?.method(args)
@@ -2111,6 +2093,16 @@ impl Evaluator {
             {
                 return Ok(result);
             }
+            if let Some(result) = self
+                .eval_object_method_call(&obj, method, &evaled_args, depth)
+                .await?
+            {
+                return Ok(result);
+            }
+            return Err(Error::Eval(format!(
+                "unknown method '{method}' on {}",
+                value_type_name(&obj)
+            )));
         }
 
         // Handle built-in functions: List(), Listing(), Map()
@@ -2203,6 +2195,37 @@ impl Evaluator {
     }
 
     #[async_recursion(?Send)]
+    async fn eval_object_method_call(
+        &mut self,
+        obj: &Value,
+        method: &str,
+        evaled_args: &[Value],
+        depth: usize,
+    ) -> Result<Option<Value>> {
+        if let Value::Object(map, _) = obj
+            && let Some(Value::Lambda(params, body, captured)) = map.get(method)
+        {
+            let mut call_scope = Scope::default();
+            for (k, v) in captured.iter() {
+                call_scope.set(k.clone(), v.clone());
+            }
+            // Layer in all instance properties, including lambdas, so local
+            // functions called by this method see overrides.
+            for (k, v) in map.iter() {
+                call_scope.set(k.clone(), v.clone());
+            }
+            call_scope.set("this".into(), obj.clone());
+            for (i, param) in params.iter().enumerate() {
+                if let Some(arg) = evaled_args.get(i) {
+                    call_scope.set(param.clone(), arg.clone());
+                }
+            }
+            return Ok(Some(self.eval_expr(body, &call_scope, depth + 1).await?));
+        }
+        Ok(None)
+    }
+
+    #[async_recursion(?Send)]
     async fn eval_method_call(
         &mut self,
         obj: &Value,
@@ -2244,10 +2267,11 @@ impl Evaluator {
                 .parse::<i64>()
                 .map(|n| Some(Value::Int(n)))
                 .map_err(|_| Error::Eval(format!("cannot convert '{s}' to Int"))),
-            (Value::String(s), "toBoolean") => s
-                .parse::<bool>()
-                .map(|b| Some(Value::Bool(b)))
-                .map_err(|_| Error::Eval(format!("cannot convert '{s}' to Boolean"))),
+            (Value::String(s), "toBoolean") => match s.to_ascii_lowercase().as_str() {
+                "true" => Ok(Some(Value::Bool(true))),
+                "false" => Ok(Some(Value::Bool(false))),
+                _ => Err(Error::Eval(format!("cannot convert '{s}' to Boolean"))),
+            },
 
             // List methods
             (Value::List(items), "contains") => {

--- a/tests/pkl_features.rs
+++ b/tests/pkl_features.rs
@@ -3291,6 +3291,62 @@ result = g?.missing("Hello")
 }
 
 #[test]
+fn null_safe_regex_constructor_emits_type_tag() {
+    let json = eval(
+        r##"
+import "pkl:base" as base
+glob = base?.Regex(#"^.*\.json$"#)
+"##,
+    );
+    assert_eq!(json["glob"]["_type"], "regex");
+    assert_eq!(json["glob"]["pattern"], r"^.*\.json$");
+}
+
+#[test]
+fn null_safe_non_function_field_errors_like_regular_call() {
+    let error = eval_fails(
+        r#"
+class Greeter {
+    name: String = "World"
+}
+g = new Greeter {}
+result = g?.name("Hello")
+"#,
+    );
+    assert!(error.contains("cannot call non-function"));
+}
+
+#[test]
+fn zero_arg_field_call_returns_field_value() {
+    let json = eval(
+        r#"
+class Greeter {
+    name: String = "World"
+}
+g = new Greeter {}
+a = g.name()
+b = g?.name()
+"#,
+    );
+    assert_eq!(json["a"], "World");
+    assert_eq!(json["b"], "World");
+}
+
+#[test]
+fn regular_unknown_method_errors_without_falling_through() {
+    let error = eval_fails(
+        r#"
+class Greeter {
+    name: String = "World"
+}
+g = new Greeter {}
+result = g.missing("Hello")
+"#,
+    );
+    assert!(error.contains("unknown method 'missing' on Object"));
+}
+
+#[test]
 fn class_lambda_valued_property_is_preserved() {
     let json = eval(
         r#"

--- a/tests/pkl_features.rs
+++ b/tests/pkl_features.rs
@@ -978,12 +978,16 @@ fn string_to_boolean() {
         r#"
 truthy = "true".toBoolean()
 falsy = "false".toBoolean()
+uppercase_truthy = "TRUE".toBoolean()
+mixed_falsy = "False".toBoolean()
 nullish = null?.toBoolean()
 null_safe = "false"?.toBoolean()
 "#,
     );
     assert_eq!(json["truthy"], true);
     assert_eq!(json["falsy"], false);
+    assert_eq!(json["uppercase_truthy"], true);
+    assert_eq!(json["mixed_falsy"], false);
     assert_eq!(json["nullish"], serde_json::Value::Null);
     assert_eq!(json["null_safe"], false);
 }
@@ -3253,6 +3257,37 @@ result = g.greet("Hello")
 "#,
     );
     assert_eq!(json["result"], "Hello World");
+}
+
+#[test]
+fn null_safe_class_function_call() {
+    let json = eval(
+        r#"
+class Greeter {
+    name: String = "World"
+    function greet(prefix: String): String = prefix + " " + name
+}
+g = new Greeter {}
+a = g?.greet("Hello")
+b = null?.greet("Hello")
+"#,
+    );
+    assert_eq!(json["a"], "Hello World");
+    assert_eq!(json["b"], serde_json::Value::Null);
+}
+
+#[test]
+fn null_safe_unknown_method_errors_without_falling_through() {
+    let error = eval_fails(
+        r#"
+class Greeter {
+    name: String = "World"
+}
+g = new Greeter {}
+result = g?.missing("Hello")
+"#,
+    );
+    assert!(error.contains("unknown method 'missing' on Object"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- mirror regular object/lambda method dispatch for null-safe calls
- stop null-safe method calls from falling through and re-evaluating receivers/arguments
- make String.toBoolean() case-insensitive to match Pkl

## Review feedback addressed
- addresses Cursor Bugbot and Greptile feedback from jdx/pklr#97 about null-safe method fallthrough/double evaluation
- addresses Greptile feedback from jdx/pklr#97 about uppercase/lowercase boolean conversion

## Verification
- cargo test null_safe
- cargo test string_to_boolean
- cargo test

*This PR was generated by Claude Code.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core call evaluation for objects and null-safe chains; behavior is narrower (no fallthrough) but covered by new tests.
> 
> **Overview**
> **Unifies object method dispatch** for `obj.method(...)` and `obj?.method(...)` by routing both through built-in `eval_method_call`, then new `eval_object_method_call` (class lambdas with `this` / instance overrides) and `eval_object_field_call` (field values, `Regex` patterns, zero-arg property access). Missing methods now fail with **`unknown method … on Object`** instead of falling through and re-evaluating the call expression.
> 
> **`String.toBoolean()`** now treats `"true"` / `"false"` case-insensitively (e.g. `"TRUE"`, `"False"`) to align with Pkl.
> 
> Tests cover null-safe class calls, unknown methods, regex via null-safe import, non-function calls, and boolean parsing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 60b9de4949354b8fac7ac843a894684c38e3054b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Null-safe method calls (`?.`) now consistently return “unknown method '…' on Object” when missing and do not fall through.
  * Calling a non-function on an object now reliably yields “cannot call non-function”.
  * Deprecated warnings for field calls are deduplicated.

* **New Features**
  * toBoolean() accepts case-insensitive "TRUE"/"False".
  * Calling a built-in regex constructor as a method produces a regex value; zero-arg field calls return the stored value.

* **Tests**
  * Added tests for null-safe calls, unknown-method errors, regex constructor, non-function call errors, and boolean parsing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->