### PR TITLE
chore: release v1.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.4](https://github.com/jdx/pklr/compare/v1.0.3...v1.0.4) - 2026-06-09
+
+### Fixed
+
+- *(eval)* support rewritten package amends ([#101](https://github.com/jdx/pklr/pull/101))
+
 ## [1.0.3](https://github.com/jdx/pklr/compare/v1.0.2...v1.0.3) - 2026-06-09
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -651,7 +651,7 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pklr"
-version = "1.0.3"
+version = "1.0.4"
 dependencies = [
  "async-recursion",
  "indexmap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "pklr"
-version     = "1.0.3"
+version     = "1.0.4"
 edition      = "2024"
 rust-version = "1.88"
 description = "Pure Rust pkl configuration language parser and evaluator"


### PR DESCRIPTION



## 🤖 New release

* `pklr`: 1.0.3 -> 1.0.4 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [1.0.4](https://github.com/jdx/pklr/compare/v1.0.3...v1.0.4) - 2026-06-09

### Fixed

- *(eval)* support rewritten package amends ([#101](https://github.com/jdx/pklr/pull/101))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version and changelog-only release metadata with no runtime code changes in this PR.
> 
> **Overview**
> **Release v1.0.4** — bumps the `pklr` crate from **1.0.3** to **1.0.4** in `Cargo.toml` and `Cargo.lock`, and records the release in `CHANGELOG.md`.
> 
> The changelog entry documents the user-facing fix shipped in this version: evaluator support for **rewritten package amends** ([#101](https://github.com/jdx/pklr/pull/101)). No library source changes appear in this diff; it is a **release-plz** packaging PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 16be55f9644c0bbf837f3d5e8bbbb77a4011e25d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Released version 1.0.4
  * Updated changelog with bug fix entry

<!-- end of auto-generated comment: release notes by coderabbit.ai -->