### PR TITLE
fix(eval): support import glob wildcards

### DIFF
--- a/src/eval.rs
+++ b/src/eval.rs
@@ -481,6 +481,9 @@ impl Evaluator {
                 let matched = expand_glob(base_dir, uri)?;
                 let mut mapping = IndexMap::new();
                 for matched_path in matched {
+                    if matched_path == path {
+                        continue;
+                    }
                     let rel_key = pathdiff_or_full(&matched_path, base_dir);
                     let val = self.eval_file(&matched_path, depth + 1).await?;
                     mapping.insert(rel_key, val);
@@ -3725,50 +3728,73 @@ fn make_unit_object(value: Value, unit: &str) -> Value {
     Value::Object(Arc::new(map), None)
 }
 
-/// Expand a simple glob pattern relative to a base directory.
-/// Supports `dir/*.ext` and `*.ext` patterns (single `*` only).
-/// Expand a simple glob pattern relative to a base directory.
-/// Supports `dir/*.ext` and `*.ext` patterns (single `*` only).
+/// Expand a Pkl glob pattern relative to a base directory.
 pub fn expand_glob(base: &Path, pattern: &str) -> Result<Vec<PathBuf>> {
-    let full = base.join(pattern);
-    let dir = full.parent().unwrap_or(base).to_path_buf();
-    let file_pattern = full
-        .file_name()
-        .map(|f| f.to_string_lossy().to_string())
-        .unwrap_or_default();
-
-    if !dir.is_dir() {
+    if !base.is_dir() {
         return Ok(vec![]);
     }
 
-    // Convert simple glob to prefix/suffix matching
-    let (prefix, suffix) = if let Some(star_pos) = file_pattern.find('*') {
-        (
-            file_pattern[..star_pos].to_string(),
-            file_pattern[star_pos + 1..].to_string(),
-        )
-    } else {
-        // No wildcard — exact match
-        let p = dir.join(&file_pattern);
-        return if p.exists() { Ok(vec![p]) } else { Ok(vec![]) };
-    };
-
-    let min_len = prefix.len() + suffix.len();
-    let mut results = Vec::new();
-    let entries = std::fs::read_dir(&dir).map_err(|e| Error::Io(dir.to_path_buf(), e))?;
-    for entry in entries {
-        let entry = entry.map_err(|e| Error::Io(dir.to_path_buf(), e))?;
-        let name = entry.file_name().to_string_lossy().to_string();
-        if name.len() >= min_len
-            && name.starts_with(&prefix)
-            && name.ends_with(&suffix)
-            && entry.path().is_file()
-        {
-            results.push(entry.path());
-        }
+    if !pattern.contains('*') {
+        let path = base.join(pattern);
+        return if path.is_file() {
+            Ok(vec![path])
+        } else {
+            Ok(vec![])
+        };
     }
+
+    let mut results = Vec::new();
+    collect_glob_matches(base, base, pattern, &mut results)?;
     results.sort();
     Ok(results)
+}
+
+fn collect_glob_matches(
+    base: &Path,
+    dir: &Path,
+    pattern: &str,
+    results: &mut Vec<PathBuf>,
+) -> Result<()> {
+    let entries = std::fs::read_dir(dir).map_err(|e| Error::Io(dir.to_path_buf(), e))?;
+    for entry in entries {
+        let entry = entry.map_err(|e| Error::Io(dir.to_path_buf(), e))?;
+        let path = entry.path();
+        let file_type = entry.file_type().map_err(|e| Error::Io(entry.path(), e))?;
+        if file_type.is_dir() {
+            collect_glob_matches(base, &path, pattern, results)?;
+        } else if file_type.is_file() {
+            let relative = pathdiff_or_full(&path, base);
+            if glob_matches(pattern, &relative) {
+                results.push(path);
+            }
+        }
+    }
+    Ok(())
+}
+
+fn glob_matches(pattern: &str, path: &str) -> bool {
+    glob_matches_chars(
+        &pattern.chars().collect::<Vec<_>>(),
+        &path.chars().collect::<Vec<_>>(),
+    )
+}
+
+fn glob_matches_chars(pattern: &[char], path: &[char]) -> bool {
+    if pattern.is_empty() {
+        return path.is_empty();
+    }
+
+    if pattern.starts_with(&['*', '*']) {
+        return glob_matches_chars(&pattern[2..], path)
+            || (!path.is_empty() && glob_matches_chars(pattern, &path[1..]));
+    }
+
+    if pattern[0] == '*' {
+        return glob_matches_chars(&pattern[1..], path)
+            || (!path.is_empty() && path[0] != '/' && glob_matches_chars(pattern, &path[1..]));
+    }
+
+    !path.is_empty() && pattern[0] == path[0] && glob_matches_chars(&pattern[1..], &path[1..])
 }
 
 /// Get a relative path string from `path` relative to `base`, or the full path if not a prefix.

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -3759,10 +3759,10 @@ fn collect_glob_matches(
     for entry in entries {
         let entry = entry.map_err(|e| Error::Io(dir.to_path_buf(), e))?;
         let path = entry.path();
-        let file_type = entry.file_type().map_err(|e| Error::Io(entry.path(), e))?;
+        let file_type = entry.file_type().map_err(|e| Error::Io(path.clone(), e))?;
         if file_type.is_dir() {
             collect_glob_matches(base, &path, pattern, results)?;
-        } else if file_type.is_file() {
+        } else if path.is_file() {
             let relative = pathdiff_or_full(&path, base);
             if glob_matches(pattern, &relative) {
                 results.push(path);

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -481,7 +481,7 @@ impl Evaluator {
                 let matched = expand_glob(base_dir, uri)?;
                 let mut mapping = IndexMap::new();
                 for matched_path in matched {
-                    if matched_path == path {
+                    if same_local_path(&matched_path, path) {
                         continue;
                     }
                     let rel_key = pathdiff_or_full(&matched_path, base_dir);
@@ -3799,10 +3799,22 @@ fn glob_matches_chars(pattern: &[char], path: &[char]) -> bool {
 
 /// Get a relative path string from `path` relative to `base`, or the full path if not a prefix.
 fn pathdiff_or_full(path: &Path, base: &Path) -> String {
-    path.strip_prefix(base)
+    let path = path
+        .strip_prefix(base)
         .unwrap_or(path)
         .to_string_lossy()
-        .to_string()
+        .to_string();
+    normalize_pkl_path(path)
+}
+
+#[cfg(windows)]
+fn normalize_pkl_path(path: String) -> String {
+    path.replace(std::path::MAIN_SEPARATOR, "/")
+}
+
+#[cfg(not(windows))]
+fn normalize_pkl_path(path: String) -> String {
+    path
 }
 
 fn local_module_path(current_path: &Path, uri: &str) -> Option<PathBuf> {

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -3773,6 +3773,8 @@ fn collect_glob_matches(
 }
 
 fn glob_matches(pattern: &str, path: &str) -> bool {
+    let pattern = normalize_pkl_path(pattern);
+    let path = normalize_pkl_path(path);
     glob_matches_chars(
         &pattern.chars().collect::<Vec<_>>(),
         &path.chars().collect::<Vec<_>>(),
@@ -3804,17 +3806,11 @@ fn pathdiff_or_full(path: &Path, base: &Path) -> String {
         .unwrap_or(path)
         .to_string_lossy()
         .to_string();
-    normalize_pkl_path(path)
+    normalize_pkl_path(&path)
 }
 
-#[cfg(windows)]
-fn normalize_pkl_path(path: String) -> String {
-    path.replace(std::path::MAIN_SEPARATOR, "/")
-}
-
-#[cfg(not(windows))]
-fn normalize_pkl_path(path: String) -> String {
-    path
+fn normalize_pkl_path(path: &str) -> String {
+    path.replace('\\', "/")
 }
 
 fn local_module_path(current_path: &Path, uri: &str) -> Option<PathBuf> {

--- a/tests/pkl_features.rs
+++ b/tests/pkl_features.rs
@@ -1112,6 +1112,48 @@ beta_val = Items["items/beta.pkl"].value
 }
 
 #[tokio::test]
+async fn import_glob_double_star_crosses_directories() {
+    let temp = TestTempDir::new("pklr_test_import_glob_double_star");
+    let dir = temp.path();
+    std::fs::create_dir_all(dir.join("config")).unwrap();
+    std::fs::write(dir.join("config/foo.pkl"), r#"value = "foo""#).unwrap();
+    std::fs::write(
+        dir.join("hk.pkl"),
+        r#"
+import* "**.pkl" as Index
+value = Index["config/foo.pkl"].value
+"#,
+    )
+    .unwrap();
+
+    let val = pklr::eval_to_json(&dir.join("hk.pkl")).await.unwrap();
+    assert_eq!(val["value"], "foo");
+}
+
+#[tokio::test]
+async fn import_glob_star_matches_one_directory_segment() {
+    let temp = TestTempDir::new("pklr_test_import_glob_star_directory_segment");
+    let dir = temp.path();
+    std::fs::create_dir_all(dir.join("config")).unwrap();
+    std::fs::create_dir_all(dir.join("nested/config")).unwrap();
+    std::fs::write(dir.join("config/foo.pkl"), r#"value = "foo""#).unwrap();
+    std::fs::write(dir.join("nested/config/bar.pkl"), r#"value = "bar""#).unwrap();
+    std::fs::write(
+        dir.join("hk.pkl"),
+        r#"
+import* "*/*.pkl" as Index
+value = Index["config/foo.pkl"].value
+has_nested = Index.containsKey("nested/config/bar.pkl")
+"#,
+    )
+    .unwrap();
+
+    let val = pklr::eval_to_json(&dir.join("hk.pkl")).await.unwrap();
+    assert_eq!(val["value"], "foo");
+    assert_eq!(val["has_nested"], false);
+}
+
+#[tokio::test]
 async fn unused_import_is_not_evaluated() {
     let temp = TestTempDir::new("pklr_test_unused_import");
     let dir = temp.path();

--- a/tests/pkl_features.rs
+++ b/tests/pkl_features.rs
@@ -1155,6 +1155,27 @@ has_nested = Index.containsKey("nested/config/bar.pkl")
     assert_eq!(val["has_nested"], false);
 }
 
+#[cfg(unix)]
+#[tokio::test]
+async fn import_glob_matches_symlinked_files() {
+    let temp = TestTempDir::new("pklr_test_import_glob_symlinked_files");
+    let dir = temp.path();
+    std::fs::create_dir_all(dir.join("real")).unwrap();
+    std::fs::write(dir.join("real/foo.pkl"), r#"value = "foo""#).unwrap();
+    std::os::unix::fs::symlink(dir.join("real/foo.pkl"), dir.join("linked.pkl")).unwrap();
+    std::fs::write(
+        dir.join("main.pkl"),
+        r#"
+import* "*.pkl" as Index
+value = Index["linked.pkl"].value
+"#,
+    )
+    .unwrap();
+
+    let val = pklr::eval_to_json(&dir.join("main.pkl")).await.unwrap();
+    assert_eq!(val["value"], "foo");
+}
+
 #[tokio::test]
 async fn unused_import_is_not_evaluated() {
     let temp = TestTempDir::new("pklr_test_unused_import");

--- a/tests/pkl_features.rs
+++ b/tests/pkl_features.rs
@@ -1122,12 +1122,14 @@ async fn import_glob_double_star_crosses_directories() {
         r#"
 import* "**.pkl" as Index
 value = Index["config/foo.pkl"].value
+has_self = Index.containsKey("hk.pkl")
 "#,
     )
     .unwrap();
 
     let val = pklr::eval_to_json(&dir.join("hk.pkl")).await.unwrap();
     assert_eq!(val["value"], "foo");
+    assert_eq!(val["has_self"], false);
 }
 
 #[tokio::test]


### PR DESCRIPTION
Closes #102

## Summary
- support `import*` glob patterns with `**` across directories
- support `*` in directory path segments
- add regressions for `**.pkl` and `*/*.pkl` patterns

## Tests
- `cargo test`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how local `import*` resolves files (recursive walk and new wildcard semantics), which can alter which modules load for existing glob patterns; scope is limited to local glob imports in the evaluator.
> 
> **Overview**
> **`import*` glob expansion** now walks the import base directory recursively and matches paths with Pkl-style rules: `**` crosses directory boundaries, `*` matches within a single segment (not `/`). Non-wildcard patterns resolve as a single file under the base; results are sorted and keys use normalized `/` paths.
> 
> Glob import binding **skips the current module** when a pattern would otherwise include it (canonical path compare), so patterns like `**.pkl` do not index the importing file itself.
> 
> Adds async regressions for `**.pkl`, `*/*.pkl`, and (on Unix) symlinked `.pkl` files matched by `*.pkl`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 184b6deff7f65ca3b6c81f8040878c9565f4ecb5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented glob imports from including the current module itself when expanding patterns.

* **New Features**
  * Enhanced glob matching: `**` now spans recursive directory boundaries; `*` is limited to a single directory segment. Matches are normalized and deterministically sorted; non-directory bases return no matches.

* **Tests**
  * Added async tests validating `*` vs `**` behavior and symlinked file resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->