### PR TITLE
chore: release v1.0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.5](https://github.com/jdx/pklr/compare/v1.0.4...v1.0.5) - 2026-06-11
+
+### Fixed
+
+- *(eval)* harden import glob matching ([#105](https://github.com/jdx/pklr/pull/105))
+- *(eval)* support import glob wildcards ([#103](https://github.com/jdx/pklr/pull/103))
+
 ## [1.0.4](https://github.com/jdx/pklr/compare/v1.0.3...v1.0.4) - 2026-06-09
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -651,7 +651,7 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pklr"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "async-recursion",
  "indexmap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "pklr"
-version     = "1.0.4"
+version     = "1.0.5"
 edition      = "2024"
 rust-version = "1.88"
 description = "Pure Rust pkl configuration language parser and evaluator"


### PR DESCRIPTION



## 🤖 New release

* `pklr`: 1.0.4 -> 1.0.5 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [1.0.5](https://github.com/jdx/pklr/compare/v1.0.4...v1.0.5) - 2026-06-11

### Fixed

- *(eval)* harden import glob matching ([#105](https://github.com/jdx/pklr/pull/105))
- *(eval)* support import glob wildcards ([#103](https://github.com/jdx/pklr/pull/103))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version and changelog updates only; no runtime code changes in this diff.
> 
> **Overview**
> **Release v1.0.5** bumps the `pklr` crate from **1.0.4** to **1.0.5** in `Cargo.toml` and `Cargo.lock`, and adds a **1.0.5** section to `CHANGELOG.md`.
> 
> The changelog records two evaluator fixes already shipped on main: **import glob wildcards** ([#103](https://github.com/jdx/pklr/pull/103)) and **hardened import glob matching** ([#105](https://github.com/jdx/pklr/pull/105)). This PR does not change library source—only release metadata and notes (release-plz).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fa548bd97e4484dd81f31c2a16d6e1c2f9f6d2ca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed support for import glob wildcards.
  * Enhanced robustness of import glob matching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->