### PR TITLE
fix(eval): harden import glob matching

### DIFF
--- a/src/eval.rs
+++ b/src/eval.rs
@@ -3817,12 +3817,14 @@ fn collect_glob_matches(
     for entry in entries {
         let entry = match entry {
             Ok(entry) => entry,
-            Err(_) => continue,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => continue,
+            Err(e) => return Err(Error::Io(dir.to_path_buf(), e)),
         };
         let path = entry.path();
         let file_type = match entry.file_type() {
             Ok(file_type) => file_type,
-            Err(_) => continue,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => continue,
+            Err(e) => return Err(Error::Io(path.clone(), e)),
         };
         if file_type.is_dir() {
             if max_depth.is_none_or(|max_depth| depth < max_depth) {
@@ -3853,7 +3855,16 @@ fn glob_matches_chars(pattern: &[char], path: &[char]) -> bool {
     let mut i = 0;
     while i < pattern.len() {
         let mut next = vec![false; path.len() + 1];
-        if pattern[i] == '*' && pattern.get(i + 1) == Some(&'*') {
+        if pattern[i] == '*' && pattern.get(i + 1) == Some(&'*') && pattern.get(i + 2) == Some(&'/')
+        {
+            next[0] = prev[0];
+            let mut can_consume_to_slash = prev[0];
+            for j in 1..=path.len() {
+                next[j] = prev[j] || (path[j - 1] == '/' && can_consume_to_slash);
+                can_consume_to_slash |= prev[j];
+            }
+            i += 3;
+        } else if pattern[i] == '*' && pattern.get(i + 1) == Some(&'*') {
             next[0] = prev[0];
             for j in 1..=path.len() {
                 next[j] = prev[j] || next[j - 1];
@@ -3911,7 +3922,7 @@ mod glob_tests {
 
     #[test]
     fn double_star_slash_keeps_literal_separator() {
-        assert!(!glob_matches("**/foo.pkl", "foo.pkl"));
+        assert!(glob_matches("**/foo.pkl", "foo.pkl"));
         assert!(glob_matches("**/foo.pkl", "config/foo.pkl"));
     }
 

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -3798,8 +3798,9 @@ pub fn expand_glob(base: &Path, pattern: &str) -> Result<Vec<PathBuf>> {
         };
     }
 
+    let max_depth = max_glob_depth(pattern);
     let mut results = Vec::new();
-    collect_glob_matches(base, base, pattern, &mut results)?;
+    collect_glob_matches(base, base, pattern, max_depth, 0, &mut results)?;
     results.sort();
     Ok(results)
 }
@@ -3808,15 +3809,25 @@ fn collect_glob_matches(
     base: &Path,
     dir: &Path,
     pattern: &str,
+    max_depth: Option<usize>,
+    depth: usize,
     results: &mut Vec<PathBuf>,
 ) -> Result<()> {
     let entries = std::fs::read_dir(dir).map_err(|e| Error::Io(dir.to_path_buf(), e))?;
     for entry in entries {
-        let entry = entry.map_err(|e| Error::Io(dir.to_path_buf(), e))?;
+        let entry = match entry {
+            Ok(entry) => entry,
+            Err(_) => continue,
+        };
         let path = entry.path();
-        let file_type = entry.file_type().map_err(|e| Error::Io(path.clone(), e))?;
+        let file_type = match entry.file_type() {
+            Ok(file_type) => file_type,
+            Err(_) => continue,
+        };
         if file_type.is_dir() {
-            collect_glob_matches(base, &path, pattern, results)?;
+            if max_depth.is_none_or(|max_depth| depth < max_depth) {
+                collect_glob_matches(base, &path, pattern, max_depth, depth + 1, results)?;
+            }
         } else if path.is_file() {
             let relative = pathdiff_or_full(&path, base);
             if glob_matches(pattern, &relative) {
@@ -3837,21 +3848,41 @@ fn glob_matches(pattern: &str, path: &str) -> bool {
 }
 
 fn glob_matches_chars(pattern: &[char], path: &[char]) -> bool {
-    if pattern.is_empty() {
-        return path.is_empty();
+    let mut prev = vec![false; path.len() + 1];
+    prev[0] = true;
+    let mut i = 0;
+    while i < pattern.len() {
+        let mut next = vec![false; path.len() + 1];
+        if pattern[i] == '*' && pattern.get(i + 1) == Some(&'*') {
+            next[0] = prev[0];
+            for j in 1..=path.len() {
+                next[j] = prev[j] || next[j - 1];
+            }
+            i += 2;
+        } else if pattern[i] == '*' {
+            next[0] = prev[0];
+            for j in 1..=path.len() {
+                next[j] = prev[j] || (path[j - 1] != '/' && next[j - 1]);
+            }
+            i += 1;
+        } else {
+            for j in 1..=path.len() {
+                next[j] = prev[j - 1] && pattern[i] == path[j - 1];
+            }
+            i += 1;
+        }
+        prev = next;
     }
+    prev[path.len()]
+}
 
-    if pattern.starts_with(&['*', '*']) {
-        return glob_matches_chars(&pattern[2..], path)
-            || (!path.is_empty() && glob_matches_chars(pattern, &path[1..]));
+fn max_glob_depth(pattern: &str) -> Option<usize> {
+    let pattern = normalize_pkl_path(pattern);
+    if pattern.contains("**") {
+        None
+    } else {
+        Some(pattern.chars().filter(|c| *c == '/').count())
     }
-
-    if pattern[0] == '*' {
-        return glob_matches_chars(&pattern[1..], path)
-            || (!path.is_empty() && path[0] != '/' && glob_matches_chars(pattern, &path[1..]));
-    }
-
-    !path.is_empty() && pattern[0] == path[0] && glob_matches_chars(&pattern[1..], &path[1..])
 }
 
 /// Get a relative path string from `path` relative to `base`, or the full path if not a prefix.
@@ -3866,6 +3897,36 @@ fn pathdiff_or_full(path: &Path, base: &Path) -> String {
 
 fn normalize_pkl_path(path: &str) -> String {
     path.replace('\\', "/")
+}
+
+#[cfg(test)]
+mod glob_tests {
+    use super::{glob_matches, max_glob_depth};
+
+    #[test]
+    fn double_star_crosses_directories() {
+        assert!(glob_matches("**.pkl", "config/foo.pkl"));
+        assert!(glob_matches("a/**/b.pkl", "a/x/y/b.pkl"));
+    }
+
+    #[test]
+    fn double_star_slash_keeps_literal_separator() {
+        assert!(!glob_matches("**/foo.pkl", "foo.pkl"));
+        assert!(glob_matches("**/foo.pkl", "config/foo.pkl"));
+    }
+
+    #[test]
+    fn star_stays_in_one_directory_segment() {
+        assert!(glob_matches("*/*.pkl", "config/foo.pkl"));
+        assert!(!glob_matches("*/*.pkl", "nested/config/foo.pkl"));
+    }
+
+    #[test]
+    fn non_recursive_patterns_have_bounded_depth() {
+        assert_eq!(max_glob_depth("*.pkl"), Some(0));
+        assert_eq!(max_glob_depth("*/*.pkl"), Some(1));
+        assert_eq!(max_glob_depth("**.pkl"), None);
+    }
 }
 
 fn local_module_path(current_path: &Path, uri: &str) -> Option<PathBuf> {

--- a/tests/pkl_features.rs
+++ b/tests/pkl_features.rs
@@ -1155,6 +1155,28 @@ has_nested = Index.containsKey("nested/config/bar.pkl")
     assert_eq!(val["has_nested"], false);
 }
 
+#[tokio::test]
+async fn import_glob_double_star_slash_matches_root_and_nested_files() {
+    let temp = TestTempDir::new("pklr_test_import_glob_double_star_slash");
+    let dir = temp.path();
+    std::fs::create_dir_all(dir.join("nested")).unwrap();
+    std::fs::write(dir.join("foo.pkl"), r#"value = "root""#).unwrap();
+    std::fs::write(dir.join("nested/foo.pkl"), r#"value = "nested""#).unwrap();
+    std::fs::write(
+        dir.join("main.pkl"),
+        r#"
+import* "**/foo.pkl" as Index
+root_value = Index["foo.pkl"].value
+nested_value = Index["nested/foo.pkl"].value
+"#,
+    )
+    .unwrap();
+
+    let val = pklr::eval_to_json(&dir.join("main.pkl")).await.unwrap();
+    assert_eq!(val["root_value"], "root");
+    assert_eq!(val["nested_value"], "nested");
+}
+
 #[cfg(unix)]
 #[tokio::test]
 async fn import_glob_matches_symlinked_files() {

--- a/tests/pkl_features.rs
+++ b/tests/pkl_features.rs
@@ -1176,6 +1176,28 @@ value = Index["linked.pkl"].value
     assert_eq!(val["value"], "foo");
 }
 
+#[cfg(unix)]
+#[tokio::test]
+async fn import_glob_skips_broken_symlinks() {
+    let temp = TestTempDir::new("pklr_test_import_glob_broken_symlinks");
+    let dir = temp.path();
+    std::fs::write(dir.join("good.pkl"), r#"value = "good""#).unwrap();
+    std::os::unix::fs::symlink(dir.join("missing.pkl"), dir.join("broken.pkl")).unwrap();
+    std::fs::write(
+        dir.join("main.pkl"),
+        r#"
+import* "*.pkl" as Index
+value = Index["good.pkl"].value
+has_broken = Index.containsKey("broken.pkl")
+"#,
+    )
+    .unwrap();
+
+    let val = pklr::eval_to_json(&dir.join("main.pkl")).await.unwrap();
+    assert_eq!(val["value"], "good");
+    assert_eq!(val["has_broken"], false);
+}
+
 #[tokio::test]
 async fn unused_import_is_not_evaluated() {
     let temp = TestTempDir::new("pklr_test_unused_import");


### PR DESCRIPTION
Follow-up to #103 after post-merge review feedback.

## Summary
- prune glob directory traversal for non-recursive patterns
- replace recursive glob matching with iterative DP matching
- skip unreadable directory entries during glob expansion
- add regressions for `**/` separator semantics and broken symlinks

## Tests
- `cargo test import_glob`
- `cargo test glob_tests`
- `cargo test`

*This PR was generated by Claude Code.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core import glob semantics and filesystem walking; incorrect matching or depth bounds could omit or mis-bind modules, though behavior is covered by new tests.
> 
> **Overview**
> Hardens **local `import*` glob** expansion used when evaluating Pkl modules.
> 
> **Traversal:** Non-recursive patterns now cap directory depth via `max_glob_depth` (slash count; unbounded when `**` is present). `read_dir` / `file_type` **NotFound** errors skip entries instead of failing the whole import—so broken symlinks no longer break `import* "*.pkl"`.
> 
> **Matching:** Recursive `glob_matches_chars` is replaced with an iterative DP matcher that distinguishes `*`, `**`, and `**/` (root and nested paths for patterns like `**/foo.pkl`).
> 
> **Tests:** Unit tests in `glob_tests` plus integration tests for `**/foo.pkl` and broken symlinks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 28d445f9da54cc0502d6af929751fb674039a113. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * More robust glob matching with bounded-depth support and improved handling of recursive patterns.

* **Bug Fixes**
  * Glob expansion now skips unreadable or unstatable directories and ignores broken symlinks during imports.
  * Improved correctness for `**` and `*` pattern semantics across nested paths.

* **Tests**
  * Added coverage for recursive glob behavior, literal-separator cases, and broken-symlink handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->