### PR TITLE
fix(eval): preserve mapping annotation value types

### DIFF
--- a/src/eval.rs
+++ b/src/eval.rs
@@ -1027,7 +1027,9 @@ impl Evaluator {
         depth: usize,
     ) -> Result<Option<Value>> {
         if let Some(expr) = &prop.value {
-            return Ok(Some(self.eval_expr(expr, scope, depth).await?));
+            let mut value = self.eval_expr(expr, scope, depth).await?;
+            apply_mapping_type_annotation(&mut value, prop.type_ann.as_ref());
+            return Ok(Some(value));
         }
         if let Some(body) = &prop.body {
             // `foo { ... }` — object body amendment.
@@ -3126,6 +3128,81 @@ fn mapping_entry_body(expr: &Expr) -> Option<&[Entry]> {
         Expr::ObjectBody(body) => Some(body),
         Expr::New(Some(_), body, _) => Some(body),
         _ => None,
+    }
+}
+
+fn apply_mapping_type_annotation(value: &mut Value, type_ann: Option<&crate::parser::TypeExpr>) {
+    let Some(type_ann) = type_ann else {
+        return;
+    };
+    let type_names = mapping_value_type_names(type_ann);
+    if type_names.is_empty() {
+        return;
+    }
+    let Value::Object(_, src_slot) = value else {
+        return;
+    };
+
+    let mut src = src_slot
+        .as_ref()
+        .map(|src| (**src).clone())
+        .unwrap_or_else(|| ObjectSource {
+            entries: Vec::new(),
+            scope: IndexMap::new(),
+            is_open: true,
+            type_name: None,
+            mapping_value_types: Vec::new(),
+            deprecated: IndexMap::new(),
+        });
+    for name in type_names {
+        if !src.mapping_value_types.contains(&name) {
+            src.mapping_value_types.push(name);
+        }
+    }
+    *src_slot = Some(Arc::new(src));
+}
+
+fn mapping_value_type_names(type_ann: &crate::parser::TypeExpr) -> Vec<String> {
+    use crate::parser::TypeExpr;
+
+    let TypeExpr::Generic(name, params) = type_ann else {
+        return Vec::new();
+    };
+    if name != "Mapping" && name != "Map" {
+        return Vec::new();
+    }
+    let Some(value_type) = params.get(1) else {
+        return Vec::new();
+    };
+
+    let mut names = Vec::new();
+    collect_mapping_value_type_names(value_type, &mut names);
+    names
+}
+
+fn collect_mapping_value_type_names(type_ann: &crate::parser::TypeExpr, names: &mut Vec<String>) {
+    use crate::parser::TypeExpr;
+
+    match type_ann {
+        TypeExpr::Named(name) | TypeExpr::Constrained(name, _) => {
+            if !names.contains(name) {
+                names.push(name.clone());
+            }
+        }
+        // Keep only the top-level value type. For example,
+        // Mapping<String, Mapping<String, Step>> needs a structured Mapping
+        // default, not Step as the default for the outer mapping's entries.
+        TypeExpr::Generic(name, _) => {
+            if !names.contains(name) {
+                names.push(name.clone());
+            }
+        }
+        TypeExpr::Nullable(inner) => collect_mapping_value_type_names(inner, names),
+        TypeExpr::Union(variants) => {
+            for variant in variants {
+                collect_mapping_value_type_names(variant, names);
+            }
+        }
     }
 }
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -215,6 +215,46 @@ hooks {
 }
 
 #[test]
+fn eval_mapping_amendment_uses_union_type_annotation_defaults() {
+    let src = r#"
+class Step {
+    check: String?
+}
+
+class Group {
+    steps: Mapping<String, Step> = new Mapping<String, Step> {}
+}
+
+class Hook {
+    steps: Mapping<String, Step | Group> = new Mapping<String, Step> {}
+}
+
+local formatters = new Mapping<String, Step> {
+    ["echo"] {
+        check = "echo ok"
+    }
+}
+
+local baseHook = new Hook {
+    steps {
+        ["formatters"] = new Group {
+            steps = formatters
+        }
+    }
+}
+
+hooks {
+    ["check"] = baseHook
+}
+"#;
+    let json = eval_src(src);
+    assert_eq!(
+        json["hooks"]["check"]["steps"]["formatters"]["steps"]["echo"]["check"],
+        "echo ok"
+    );
+}
+
+#[test]
 fn eval_spread_operator() {
     let src = r#"
 amends "pkl/Config.pkl"


### PR DESCRIPTION
## Summary
- preserve value type candidates from `Mapping`/`Map` property annotations on evaluated mapping defaults
- include union variants such as `Step | Group` when later amending mapping entries
- add a regression test for the hk discussion #981 config shape

## Test
- `cargo test`

Fixes the pklr side of https://github.com/jdx/hk/discussions/981.

*This PR was generated by Codex.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core evaluator semantics for typed mapping properties and amendments; regression is covered by a new integration test but behavior shifts for configs that relied on the old missing metadata.
> 
> **Overview**
> Fixes mapping evaluation so **`Mapping`/`Map` property type annotations** (not just `new Mapping<...>` literals) populate `ObjectSource.mapping_value_types` on the evaluated value.
> 
> After a property’s value is computed, **`eval_property`** now calls **`apply_mapping_type_annotation`**, which parses `Mapping`/`Map` generics and records value-type names—including **union members** like `Step | Group`—so later **mapping body amendments** still use the type-aware path (`eval_mapping_entries_with_type_default`) and nested entries inherit the right defaults.
> 
> Adds **`eval_mapping_amendment_uses_union_type_annotation_defaults`** to lock in nested `steps` under a `Group` inside a union-typed `Hook.steps` mapping (hk #981 shape).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8eb6df65ce3e7c4345ef1a32d8fe5fa832624583. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->