### PR TITLE
chore: release v1.0.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.6](https://github.com/jdx/pklr/compare/v1.0.5...v1.0.6) - 2026-06-11
+
+### Fixed
+
+- *(eval)* preserve mapping annotation value types ([#106](https://github.com/jdx/pklr/pull/106))
+
 ## [1.0.5](https://github.com/jdx/pklr/compare/v1.0.4...v1.0.5) - 2026-06-11
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -651,7 +651,7 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pklr"
-version = "1.0.5"
+version = "1.0.6"
 dependencies = [
  "async-recursion",
  "indexmap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "pklr"
-version     = "1.0.5"
+version     = "1.0.6"
 edition      = "2024"
 rust-version = "1.88"
 description = "Pure Rust pkl configuration language parser and evaluator"


### PR DESCRIPTION



## 🤖 New release

* `pklr`: 1.0.5 -> 1.0.6 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [1.0.6](https://github.com/jdx/pklr/compare/v1.0.5...v1.0.6) - 2026-06-11

### Fixed

- *(eval)* preserve mapping annotation value types ([#106](https://github.com/jdx/pklr/pull/106))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical version and changelog updates only; no runtime code changes in this PR.
> 
> **Overview**
> Bumps **pklr** from **1.0.5** to **1.0.6** for crates.io and syncs `Cargo.lock`.
> 
> `CHANGELOG.md` documents the release (2026-06-11) with the user-facing fix from [#106](https://github.com/jdx/pklr/pull/106): the evaluator now **preserves mapping annotation value types** when evaluating properties and mapping bodies.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 607e4ccb19691aaaf9eef08b077dcb968d43f500. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->