### PR TITLE
fix(eval): support filter() on Map/Mapping

### DIFF
--- a/src/eval.rs
+++ b/src/eval.rs
@@ -2457,6 +2457,21 @@ impl Evaluator {
                 }
                 Ok(Some(Value::Object(Arc::new(result), None)))
             }
+            (Value::Object(map, _), "filter") => {
+                let lambda = args
+                    .first()
+                    .ok_or_else(|| Error::Eval("filter requires a function".into()))?;
+                let mut result = IndexMap::new();
+                for (k, v) in map.iter() {
+                    let keep = self
+                        .invoke_lambda(lambda, &[Value::String(k.clone()), v.clone()], depth)
+                        .await?;
+                    if is_truthy(&keep) {
+                        result.insert(k.clone(), v.clone());
+                    }
+                }
+                Ok(Some(Value::Object(Arc::new(result), None)))
+            }
             (Value::Object(..), "toList") => Ok(Some(obj.clone())),
             (Value::Object(map, _), "toDynamic") => Ok(Some(Value::Object(map.clone(), None))),
 

--- a/tests/pkl_features.rs
+++ b/tests/pkl_features.rs
@@ -1706,7 +1706,6 @@ all_positive = items.every((n) -> n > 0)
 // ============================================================
 
 #[test]
-#[ignore = "Map/Mapping does not yet implement filter()"]
 fn map_filter() {
     let json = eval(
         r#"
@@ -1724,7 +1723,6 @@ x = items.toMap().filter((k, v) -> v > 1).toMapping()
 }
 
 #[test]
-#[ignore = "Map/Mapping does not yet implement filter()"]
 fn map_filter_then_map_values_chain() {
     // toMap().filter().mapValues().toMapping() is a common transformation chain.
     let json = eval(

--- a/tests/pkl_features.rs
+++ b/tests/pkl_features.rs
@@ -1701,6 +1701,52 @@ all_positive = items.every((n) -> n > 0)
     assert_eq!(json["all_positive"], true);
 }
 
+// ============================================================
+// Higher-order methods on Map / Mapping
+// ============================================================
+
+#[test]
+#[ignore = "Map/Mapping does not yet implement filter()"]
+fn map_filter() {
+    let json = eval(
+        r#"
+local items = new Mapping<String, Int> {
+    ["a"] = 1
+    ["b"] = 2
+    ["c"] = 3
+}
+x = items.toMap().filter((k, v) -> v > 1).toMapping()
+"#,
+    );
+    assert_eq!(json["x"]["b"], 2);
+    assert_eq!(json["x"]["c"], 3);
+    assert!(json["x"].get("a").is_none());
+}
+
+#[test]
+#[ignore = "Map/Mapping does not yet implement filter()"]
+fn map_filter_then_map_values_chain() {
+    // toMap().filter().mapValues().toMapping() is a common transformation chain.
+    let json = eval(
+        r#"
+local items = new Mapping<String, Int> {
+    ["a"] = 1
+    ["b"] = 2
+    ["c"] = 3
+}
+x =
+    items
+        .toMap()
+        .filter((k, v) -> v > 1)
+        .mapValues((k, v) -> v * 10)
+        .toMapping()
+"#,
+    );
+    assert_eq!(json["x"]["b"], 20);
+    assert_eq!(json["x"]["c"], 30);
+    assert!(json["x"].get("a").is_none());
+}
+
 #[test]
 fn object_amendment_with_named_property() {
     let json = eval(


### PR DESCRIPTION
In my hk config I use filter on a Map/Mapping. Broke with the introduction of `pklr`, so added a reproduction case and fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `filter` method for objects and maps, allowing you to evaluate predicates on each key-value pair and create a new collection containing only matching entries. Supports chaining with operations like `mapValues` for complex transformations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->