### PR TITLE
fix(eval): resolve relative imports/amends against a remote base URL

### DIFF
--- a/src/eval.rs
+++ b/src/eval.rs
@@ -239,6 +239,8 @@ impl Evaluator {
         uri: &str,
         path: &Path,
     ) -> Result<Option<(String, String)>> {
+        let resolved = resolve_remote_relative(path, uri);
+        let uri = resolved.as_deref().unwrap_or(uri);
         if uri.starts_with("https://") || uri.starts_with("http://") {
             let source = self.fetch_source(uri).await?;
             return Ok(Some((source, uri.to_string())));
@@ -467,7 +469,9 @@ impl Evaluator {
 
         // Process imports
         for import in &module.imports {
-            let uri = &import.uri;
+            // A relative import inside a remote module resolves against that URL.
+            let resolved_uri = resolve_remote_relative(path, &import.uri);
+            let uri: &str = resolved_uri.as_deref().unwrap_or(&import.uri);
 
             // Handle glob imports: import* "dir/*.pkl" as Alias
             if import.is_glob {
@@ -618,7 +622,10 @@ impl Evaluator {
 
         // Process amends: load base module as starting values
         let mut base_obj = IndexMap::new();
-        if let Some(uri) = &module.amends {
+        if let Some(amends_uri) = &module.amends {
+            // A relative amends inside a remote module resolves against that URL.
+            let resolved_amends = resolve_remote_relative(path, amends_uri);
+            let uri: &str = resolved_amends.as_deref().unwrap_or(amends_uri);
             if uri.starts_with("https://") || uri.starts_with("http://") {
                 // HTTP amends
                 let source = self.fetch_source(uri).await?;
@@ -705,7 +712,9 @@ impl Evaluator {
         // class definitions from its return value.
         // Also remove inherited class definitions from base_obj so they don't
         // appear in the amending module's data output.
-        if let Some(uri) = &module.amends {
+        if let Some(amends_uri) = &module.amends {
+            let resolved_amends = resolve_remote_relative(path, amends_uri);
+            let uri: &str = resolved_amends.as_deref().unwrap_or(amends_uri);
             let base_source = if uri.starts_with("https://") || uri.starts_with("http://") {
                 // HTTP source was already fetched and cached
                 self.http_cache.get(uri).cloned()
@@ -773,7 +782,10 @@ impl Evaluator {
         }
 
         // Process extends: load base module, inherit all members and scope
-        if let Some(uri) = &module.extends {
+        if let Some(extends_uri) = &module.extends {
+            // A relative extends inside a remote module resolves against that URL.
+            let resolved_extends = resolve_remote_relative(path, extends_uri);
+            let uri: &str = resolved_extends.as_deref().unwrap_or(extends_uri);
             if !uri.contains("://") || uri.starts_with("file://") {
                 let extends_path = if let Some(rel) = uri.strip_prefix("file://") {
                     PathBuf::from(rel)
@@ -4035,11 +4047,68 @@ fn local_module_path(current_path: &Path, uri: &str) -> Option<PathBuf> {
     if uri.contains("://") && !uri.starts_with("file://") {
         return None;
     }
+    // A relative reference inside a remote (http/https) module is not a local file.
+    if !uri.starts_with("file://")
+        && let Some(base) = current_path.to_str()
+        && (base.starts_with("http://") || base.starts_with("https://"))
+    {
+        return None;
+    }
     Some(if let Some(rel) = uri.strip_prefix("file://") {
         PathBuf::from(rel)
     } else {
         current_path.parent().unwrap_or(Path::new(".")).join(uri)
     })
+}
+
+/// If `current_path` is a remote (http/https) module URL and `uri` is a
+/// relative reference (no scheme), resolve `uri` against that URL so the
+/// referenced module is fetched over HTTP rather than from the local
+/// filesystem. Returns the rewritten absolute URL, or `None` when no rewrite
+/// applies (local base module, or `uri` already carries a scheme).
+fn resolve_remote_relative(current_path: &Path, uri: &str) -> Option<String> {
+    if uri.contains("://") || uri.starts_with("pkl:") {
+        return None;
+    }
+    let base = current_path.to_str()?;
+    if !(base.starts_with("http://") || base.starts_with("https://")) {
+        return None;
+    }
+    Some(join_url(base, uri))
+}
+
+/// Resolve a relative reference against a base URL, collapsing `.`/`..`
+/// segments. Covers the cases pkl imports use: relative paths (`../x.pkl`)
+/// and absolute-from-root paths (`/x.pkl`).
+fn join_url(base: &str, rel: &str) -> String {
+    let Some(scheme_end) = base.find("://").map(|i| i + 3) else {
+        return rel.to_string();
+    };
+    let (prefix, after) = base.split_at(scheme_end);
+    let (authority, base_path) = match after.find('/') {
+        Some(i) => (&after[..i], &after[i..]),
+        None => (after, "/"),
+    };
+    let combined = if rel.starts_with('/') {
+        rel.to_string()
+    } else {
+        let dir = match base_path.rfind('/') {
+            Some(i) => &base_path[..=i],
+            None => "/",
+        };
+        format!("{dir}{rel}")
+    };
+    let mut segments: Vec<&str> = Vec::new();
+    for seg in combined.split('/') {
+        match seg {
+            "" | "." => {}
+            ".." => {
+                segments.pop();
+            }
+            s => segments.push(s),
+        }
+    }
+    format!("{prefix}{authority}/{}", segments.join("/"))
 }
 
 fn same_local_path(left: &Path, right: &Path) -> bool {

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -4074,41 +4074,10 @@ fn resolve_remote_relative(current_path: &Path, uri: &str) -> Option<String> {
     if !(base.starts_with("http://") || base.starts_with("https://")) {
         return None;
     }
-    Some(join_url(base, uri))
-}
-
-/// Resolve a relative reference against a base URL, collapsing `.`/`..`
-/// segments. Covers the cases pkl imports use: relative paths (`../x.pkl`)
-/// and absolute-from-root paths (`/x.pkl`).
-fn join_url(base: &str, rel: &str) -> String {
-    let Some(scheme_end) = base.find("://").map(|i| i + 3) else {
-        return rel.to_string();
-    };
-    let (prefix, after) = base.split_at(scheme_end);
-    let (authority, base_path) = match after.find('/') {
-        Some(i) => (&after[..i], &after[i..]),
-        None => (after, "/"),
-    };
-    let combined = if rel.starts_with('/') {
-        rel.to_string()
-    } else {
-        let dir = match base_path.rfind('/') {
-            Some(i) => &base_path[..=i],
-            None => "/",
-        };
-        format!("{dir}{rel}")
-    };
-    let mut segments: Vec<&str> = Vec::new();
-    for seg in combined.split('/') {
-        match seg {
-            "" | "." => {}
-            ".." => {
-                segments.pop();
-            }
-            s => segments.push(s),
-        }
-    }
-    format!("{prefix}{authority}/{}", segments.join("/"))
+    reqwest::Url::parse(base)
+        .ok()
+        .and_then(|base| base.join(uri).ok())
+        .map(|url| url.to_string())
 }
 
 fn same_local_path(left: &Path, right: &Path) -> bool {

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -404,7 +404,6 @@ fn spawn_test_http_server(routes: Vec<(&'static str, &'static str)>) -> String {
 /// A module loaded over HTTP that itself uses a relative `import` should
 /// resolve that import against its own (HTTP) URL, not the local filesystem.
 #[tokio::test]
-#[ignore = "relative imports inside an HTTP-loaded module are not resolved against the base URL"]
 async fn http_module_resolves_relative_import() {
     let base = spawn_test_http_server(vec![
         (
@@ -430,7 +429,6 @@ async fn http_module_resolves_relative_import() {
 /// resolve that base against its own (HTTP) URL. With the relative base
 /// unresolved, properties inherited through it (here `version`) go missing.
 #[tokio::test]
-#[ignore = "relative amends inside an HTTP-loaded module are not resolved against the base URL"]
 async fn http_module_resolves_relative_amends() {
     let base = spawn_test_http_server(vec![
         (

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -340,6 +340,119 @@ hooks {
     assert!(result.is_ok());
 }
 
+/// Minimal, hermetic HTTP/1.1 server for tests. Serves a fixed set of
+/// `path -> body` responses on a background thread and returns its base URL
+/// (e.g. `http://127.0.0.1:PORT`). The thread runs for the lifetime of the
+/// test process; each request gets `Connection: close` so the client does not
+/// reuse connections.
+fn spawn_test_http_server(routes: Vec<(&'static str, &'static str)>) -> String {
+    use std::collections::HashMap;
+    use std::io::{BufRead, BufReader, Write};
+    use std::net::TcpListener;
+
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let port = listener.local_addr().unwrap().port();
+    let routes: HashMap<String, String> = routes
+        .into_iter()
+        .map(|(p, b)| (p.to_string(), b.to_string()))
+        .collect();
+
+    std::thread::spawn(move || {
+        for stream in listener.incoming() {
+            let mut stream = match stream {
+                Ok(s) => s,
+                Err(_) => continue,
+            };
+            let mut reader = BufReader::new(stream.try_clone().unwrap());
+            let mut request_line = String::new();
+            if reader.read_line(&mut request_line).is_err() {
+                continue;
+            }
+            // "GET /path HTTP/1.1"
+            let path = request_line
+                .split_whitespace()
+                .nth(1)
+                .unwrap_or("/")
+                .to_string();
+            // Drain remaining request headers.
+            loop {
+                let mut line = String::new();
+                match reader.read_line(&mut line) {
+                    Ok(0) => break,
+                    Ok(_) if line == "\r\n" || line == "\n" => break,
+                    Ok(_) => {}
+                    Err(_) => break,
+                }
+            }
+            let response = match routes.get(&path) {
+                Some(body) => format!(
+                    "HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                    body.len(),
+                    body
+                ),
+                None => "HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
+                    .to_string(),
+            };
+            let _ = stream.write_all(response.as_bytes());
+            let _ = stream.flush();
+        }
+    });
+
+    format!("http://127.0.0.1:{port}")
+}
+
+/// A module loaded over HTTP that itself uses a relative `import` should
+/// resolve that import against its own (HTTP) URL, not the local filesystem.
+#[tokio::test]
+#[ignore = "relative imports inside an HTTP-loaded module are not resolved against the base URL"]
+async fn http_module_resolves_relative_import() {
+    let base = spawn_test_http_server(vec![
+        (
+            "/cfg/Main.pkl",
+            "import \"../Lib.pkl\"\nvalue = Lib.value\n",
+        ),
+        ("/Lib.pkl", "value = 42\n"),
+    ]);
+    let src = format!("import \"{base}/cfg/Main.pkl\" as Main\nresult = Main.value\n");
+
+    let mut evaluator = pklr::Evaluator::new();
+    let result = evaluator
+        .eval_source(&src, std::path::Path::new("entry.pkl"))
+        .await;
+    if let Err(ref e) = result {
+        eprintln!("error: {e}");
+    }
+    let json = result.unwrap().to_json();
+    assert_eq!(json["result"], 42);
+}
+
+/// A module loaded over HTTP that itself uses a relative `amends` should
+/// resolve that base against its own (HTTP) URL. With the relative base
+/// unresolved, properties inherited through it (here `version`) go missing.
+#[tokio::test]
+#[ignore = "relative amends inside an HTTP-loaded module are not resolved against the base URL"]
+async fn http_module_resolves_relative_amends() {
+    let base = spawn_test_http_server(vec![
+        (
+            "/cfg/Main.pkl",
+            "amends \"../Base.pkl\"\nname = \"override\"\n",
+        ),
+        ("/Base.pkl", "name = \"base\"\nversion = 1\n"),
+    ]);
+    let src = format!("amends \"{base}/cfg/Main.pkl\"\n");
+
+    let mut evaluator = pklr::Evaluator::new();
+    let result = evaluator
+        .eval_source(&src, std::path::Path::new("entry.pkl"))
+        .await;
+    if let Err(ref e) = result {
+        eprintln!("error: {e}");
+    }
+    let json = result.unwrap().to_json();
+    assert_eq!(json["name"], "override");
+    assert_eq!(json["version"], 1);
+}
+
 #[tokio::test]
 async fn test_step_amend_minimal() {
     // Test: does amending a class with many properties hang?

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -451,6 +451,31 @@ async fn http_module_resolves_relative_amends() {
     assert_eq!(json["version"], 1);
 }
 
+/// A module loaded over HTTP that itself uses a relative `extends` should
+/// resolve that base against its own (HTTP) URL, not the local filesystem.
+#[tokio::test]
+async fn http_module_resolves_relative_extends() {
+    let base = spawn_test_http_server(vec![
+        (
+            "/cfg/Main.pkl",
+            "extends \"../Base.pkl\"\nname = \"override\"\n",
+        ),
+        ("/Base.pkl", "name = \"base\"\nversion = 1\n"),
+    ]);
+    let src = format!("import \"{base}/cfg/Main.pkl\" as Main\nresult = Main\n");
+
+    let mut evaluator = pklr::Evaluator::new();
+    let result = evaluator
+        .eval_source(&src, std::path::Path::new("entry.pkl"))
+        .await;
+    if let Err(ref e) = result {
+        eprintln!("error: {e}");
+    }
+    let json = result.unwrap().to_json();
+    assert_eq!(json["result"]["name"], "override");
+    assert_eq!(json["result"]["version"], 1);
+}
+
 #[tokio::test]
 async fn test_step_amend_minimal() {
     // Test: does amending a class with many properties hang?


### PR DESCRIPTION
I'm loading config for hk via https, the loaded config contains relative references. This broke with the introduction of `pklr`. Added reproduction cases for loading resources with relative references and a proposed fix.