### PR TITLE
fix(eval): short-circuit && and ||

### DIFF
--- a/src/eval.rs
+++ b/src/eval.rs
@@ -2583,6 +2583,23 @@ impl Evaluator {
             return Ok(merge_values(base, overlay));
         }
 
+        // Logical `&&` and `||` short-circuit: the right operand must not be
+        // evaluated when the left already determines the result (e.g.
+        // `x is Foo && x.fooField` must not touch `fooField` when `x` is not a
+        // `Foo`).
+        if matches!(op, BinOp::And | BinOp::Or) {
+            let left_truthy = is_truthy(&self.eval_expr(left, scope, depth + 1).await?);
+            let short_circuit = match op {
+                BinOp::And => !left_truthy,
+                _ => left_truthy,
+            };
+            if short_circuit {
+                return Ok(Value::Bool(left_truthy));
+            }
+            let right_truthy = is_truthy(&self.eval_expr(right, scope, depth + 1).await?);
+            return Ok(Value::Bool(right_truthy));
+        }
+
         let l = self.eval_expr(left, scope, depth + 1).await?;
         let r = self.eval_expr(right, scope, depth + 1).await?;
         match op {

--- a/tests/pkl_features.rs
+++ b/tests/pkl_features.rs
@@ -517,6 +517,31 @@ fn logical_not() {
     assert_eq!(json["x"], true);
 }
 
+#[test]
+fn logical_and_short_circuits() {
+    // The right operand must not be evaluated when the left is false:
+    // `missing.field` would error if it were touched.
+    let json = eval(
+        r#"
+local v = new Dynamic { other = 1 }
+x = if (false && v.missing) "y" else "n"
+"#,
+    );
+    assert_eq!(json["x"], "n");
+}
+
+#[test]
+fn logical_or_short_circuits() {
+    // The right operand must not be evaluated when the left is true.
+    let json = eval(
+        r#"
+local v = new Dynamic { other = 1 }
+x = if (true || v.missing) "y" else "n"
+"#,
+    );
+    assert_eq!(json["x"], "y");
+}
+
 // ============================================================
 // Null coalescing
 // ============================================================


### PR DESCRIPTION
Logical `&&` and `||` evaluated both operands eagerly before combining them, so the right operand ran even when the left already decided the result. This breaks guards like `x is Foo && x.fooField`, which must not touch `fooField` when `x` is not a `Foo`.

Evaluate the left operand first and skip the right when it cannot change the outcome.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Logical AND and OR operators now properly short-circuit, preventing unnecessary evaluation of the right operand when the result is already determined.

* **Tests**
  * Added tests to verify short-circuit evaluation behavior for logical operators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->