### PR TITLE
fix(eval): bind local lambdas in declaration order in object bodies

### DIFF
--- a/src/eval.rs
+++ b/src/eval.rs
@@ -1145,8 +1145,10 @@ impl Evaluator {
                     let val = self.eval_expr(expr, &child_scope, depth).await?;
                     child_scope.set(prop.name.clone(), val);
                     if matches!(expr, crate::parser::Expr::Lambda(..)) {
-                        // Also re-evaluate lambda locals at the end so they
-                        // capture the final scope (late binding of overrides).
+                        // Lambda evaluation only captures the current scope; it
+                        // does not run the body. Bind once for declaration-order
+                        // visibility, then re-bind after properties for late
+                        // binding of overrides.
                         deferred_lambdas.push((prop.name.clone(), expr));
                     }
                 }
@@ -2725,8 +2727,10 @@ impl Evaluator {
                     let val = self.eval_expr(expr, &entry_scope, depth).await?;
                     entry_scope.set(prop.name.clone(), val);
                     if matches!(expr, crate::parser::Expr::Lambda(..)) {
-                        // Also re-evaluate lambda locals at the end so they
-                        // capture the final scope (late binding of overrides).
+                        // Lambda evaluation only captures the current scope; it
+                        // does not run the body. Bind once for declaration-order
+                        // visibility, then re-bind after properties for late
+                        // binding of overrides.
                         deferred_lambdas.push((prop.name.clone(), expr));
                     }
                 }

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -1139,12 +1139,15 @@ impl Evaluator {
                     if has_modifier(&prop.modifiers, Modifier::Local) && prop.value.is_some() =>
                 {
                     let expr = prop.value.as_ref().unwrap();
+                    // Bind every local in declaration order so later locals and
+                    // entries can reference it (e.g. a non-lambda local that
+                    // calls a lambda local defined just above it).
+                    let val = self.eval_expr(expr, &child_scope, depth).await?;
+                    child_scope.set(prop.name.clone(), val);
                     if matches!(expr, crate::parser::Expr::Lambda(..)) {
-                        // Defer lambda locals so they capture the final scope
+                        // Also re-evaluate lambda locals at the end so they
+                        // capture the final scope (late binding of overrides).
                         deferred_lambdas.push((prop.name.clone(), expr));
-                    } else {
-                        let val = self.eval_expr(expr, &child_scope, depth).await?;
-                        child_scope.set(prop.name.clone(), val);
                     }
                 }
                 Entry::ClassDef(name, class_mods, parent, body) => {
@@ -2716,11 +2719,15 @@ impl Evaluator {
                     if has_modifier(&prop.modifiers, Modifier::Local) && prop.value.is_some() =>
                 {
                     let expr = prop.value.as_ref().unwrap();
+                    // Bind every local in declaration order so later locals and
+                    // entries can reference it (e.g. a non-lambda local that
+                    // calls a lambda local defined just above it).
+                    let val = self.eval_expr(expr, &entry_scope, depth).await?;
+                    entry_scope.set(prop.name.clone(), val);
                     if matches!(expr, crate::parser::Expr::Lambda(..)) {
+                        // Also re-evaluate lambda locals at the end so they
+                        // capture the final scope (late binding of overrides).
                         deferred_lambdas.push((prop.name.clone(), expr));
-                    } else {
-                        let val = self.eval_expr(expr, &entry_scope, depth).await?;
-                        entry_scope.set(prop.name.clone(), val);
                     }
                 }
                 Entry::Property(prop)

--- a/tests/pkl_features.rs
+++ b/tests/pkl_features.rs
@@ -4368,6 +4368,36 @@ values = new Mapping<String, String> {
 }
 
 #[test]
+fn mapping_local_lambda_is_visible_to_sibling_local() {
+    // A lambda local must be in scope for a later (non-lambda) local that uses it.
+    let json = eval(
+        r#"
+values = new Mapping<String, Int> {
+    local f = (k, v) -> v * 2
+    local doubled = (new Mapping<String, Int> { ["a"] = 1 }).toMap().mapValues(f).toMapping()
+    ["out"] = doubled["a"]
+}
+"#,
+    );
+    assert_eq!(json["values"]["out"], 2);
+}
+
+#[test]
+fn mapping_local_lambda_is_visible_to_sibling_local_untyped() {
+    // Same, for an untyped `new Mapping {}` body (different eval path).
+    let json = eval(
+        r#"
+values = new Mapping {
+    local f = (x) -> x + 1
+    local g = f.apply(10)
+    ["out"] = g
+}
+"#,
+    );
+    assert_eq!(json["values"]["out"], 11);
+}
+
+#[test]
 fn mapping_local_body_is_visible_to_dynamic_entries() {
     let json = eval(
         r#"

--- a/tests/pkl_features.rs
+++ b/tests/pkl_features.rs
@@ -4398,6 +4398,36 @@ values = new Mapping {
 }
 
 #[test]
+fn object_local_lambda_does_not_capture_later_local_for_early_call() {
+    let msg = eval_fails(
+        r#"
+values {
+    local f = (x) -> x + h
+    local g = f.apply(1)
+    local h = 42
+    out = g
+}
+"#,
+    );
+    assert!(msg.contains("undefined variable: h"), "{msg}");
+}
+
+#[test]
+fn mapping_local_lambda_does_not_capture_later_local_for_early_call() {
+    let msg = eval_fails(
+        r#"
+values = new Mapping {
+    local f = (x) -> x + h
+    local g = f.apply(1)
+    local h = 42
+    ["out"] = g
+}
+"#,
+    );
+    assert!(msg.contains("undefined variable: h"), "{msg}");
+}
+
+#[test]
 fn mapping_local_body_is_visible_to_dynamic_entries() {
     let json = eval(
         r#"


### PR DESCRIPTION
Lambda-valued locals inside a `new Mapping {}` / object body were deferred to the end of evaluation, so a sibling local (or entry) that referenced one failed with "undefined variable". Bind every local in declaration order so earlier-declared lambdas are visible, while still re-binding lambdas at the end to preserve late binding of overrides.

Applies to both object bodies (eval_entries) and typed-mapping bodies (eval_mapping_entries_with_type_default).