### PR TITLE
chore: release v1.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.1](https://github.com/jdx/pklr/compare/v1.1.0...v1.1.1) - 2026-06-26
+
+### Fixed
+
+- *(eval)* support filter() on Map/Mapping ([#111](https://github.com/jdx/pklr/pull/111))
+- *(eval)* short-circuit && and || ([#113](https://github.com/jdx/pklr/pull/113))
+
+### Other
+
+- *(deps)* lock file maintenance lockfile maintenance ([#118](https://github.com/jdx/pklr/pull/118))
+
 ## [1.1.0](https://github.com/jdx/pklr/compare/v1.0.6...v1.1.0) - 2026-06-14
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -650,7 +650,7 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pklr"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "async-recursion",
  "indexmap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "pklr"
-version     = "1.1.0"
+version     = "1.1.1"
 edition      = "2024"
 rust-version = "1.88"
 description = "Pure Rust pkl configuration language parser and evaluator"


### PR DESCRIPTION



## 🤖 New release

* `pklr`: 1.1.0 -> 1.1.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [1.1.1](https://github.com/jdx/pklr/compare/v1.1.0...v1.1.1) - 2026-06-26

### Fixed

- *(eval)* support filter() on Map/Mapping ([#111](https://github.com/jdx/pklr/pull/111))
- *(eval)* short-circuit && and || ([#113](https://github.com/jdx/pklr/pull/113))

### Other

- *(deps)* lock file maintenance lockfile maintenance ([#118](https://github.com/jdx/pklr/pull/118))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> No runtime or API code changes—only version and changelog updates for a patch release.
> 
> **Overview**
> **Release-only PR** that publishes **pklr 1.1.1** by bumping `version` in `Cargo.toml`, syncing the `pklr` entry in `Cargo.lock`, and adding a **1.1.1** section to `CHANGELOG.md`.
> 
> The changelog text records evaluator fixes already landed on the main line (**`filter()` on Map/Mapping**, **short-circuit `&&` / `||`**) plus dependency lockfile maintenance; this diff does not modify evaluator source—only release metadata.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1cd91a81420260f9f16837849b1b1d979333d520. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->