### PR TITLE
chore: release v1.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.1](https://github.com/jdx/pklr/compare/v1.1.0...v1.1.1) - 2026-07-01
+
+### Fixed
+
+- *(eval)* track import generic param fields ([#124](https://github.com/jdx/pklr/pull/124))
+- *(eval)* resolve relative imports/amends against a remote base URL ([#112](https://github.com/jdx/pklr/pull/112))
+- *(eval)* bind local lambdas in declaration order in object bodies ([#114](https://github.com/jdx/pklr/pull/114))
+- *(eval)* preserve class identity (type_name) through amendment ([#115](https://github.com/jdx/pklr/pull/115))
+- *(eval)* avoid evaluating unused import fields ([#123](https://github.com/jdx/pklr/pull/123))
+- *(eval)* support filter() on Map/Mapping ([#111](https://github.com/jdx/pklr/pull/111))
+- *(eval)* short-circuit && and || ([#113](https://github.com/jdx/pklr/pull/113))
+
+### Other
+
+- *(deps)* lock file maintenance lockfile maintenance ([#118](https://github.com/jdx/pklr/pull/118))
+
 ## [1.1.0](https://github.com/jdx/pklr/compare/v1.0.6...v1.1.0) - 2026-06-14
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -650,7 +650,7 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pklr"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "async-recursion",
  "indexmap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "pklr"
-version     = "1.1.0"
+version     = "1.1.1"
 edition      = "2024"
 rust-version = "1.88"
 description = "Pure Rust pkl configuration language parser and evaluator"


### PR DESCRIPTION



## 🤖 New release

* `pklr`: 1.1.0 -> 1.1.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [1.1.1](https://github.com/jdx/pklr/compare/v1.1.0...v1.1.1) - 2026-07-01

### Fixed

- *(eval)* track import generic param fields ([#124](https://github.com/jdx/pklr/pull/124))
- *(eval)* resolve relative imports/amends against a remote base URL ([#112](https://github.com/jdx/pklr/pull/112))
- *(eval)* bind local lambdas in declaration order in object bodies ([#114](https://github.com/jdx/pklr/pull/114))
- *(eval)* preserve class identity (type_name) through amendment ([#115](https://github.com/jdx/pklr/pull/115))
- *(eval)* avoid evaluating unused import fields ([#123](https://github.com/jdx/pklr/pull/123))
- *(eval)* support filter() on Map/Mapping ([#111](https://github.com/jdx/pklr/pull/111))
- *(eval)* short-circuit && and || ([#113](https://github.com/jdx/pklr/pull/113))

### Other

- *(deps)* lock file maintenance lockfile maintenance ([#118](https://github.com/jdx/pklr/pull/118))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version and changelog/lockfile metadata only; evaluator behavior changes were shipped in earlier PRs, not in this diff.
> 
> **Overview**
> **Release-only PR** that publishes **pklr 1.1.1** by bumping the crate version in `Cargo.toml` and `Cargo.lock`, and moving the accumulated **1.1.1** notes out of `[Unreleased]` into a dated section in `CHANGELOG.md`.
> 
> The changelog documents evaluator fixes already landed on main (import generics, remote relative imports/amends, lambda binding order, class identity through amendment, lazy unused import fields, `filter()` on Map/Mapping, short-circuit `&&`/`||`) plus dependency lockfile maintenance. **No application source changes** appear in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cdc25d80487ae71dcb12ce271f8395f5d126e682. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->