### PR TITLE
fix(eval): track import generic param fields

### DIFF
--- a/src/eval.rs
+++ b/src/eval.rs
@@ -3564,7 +3564,7 @@ fn collect_expr_import_field_uses(
                 }
             }
             for param in generic_params {
-                record_whole_import_use(uses, shadows, param);
+                record_type_name_import_use(uses, shadows, param);
             }
             collect_entry_import_field_uses(entries, uses, shadows);
         }

--- a/tests/pkl_features.rs
+++ b/tests/pkl_features.rs
@@ -1611,6 +1611,41 @@ enabled = steps["a"].enabled
 }
 
 #[tokio::test]
+async fn partial_import_includes_generic_param_fields() {
+    let temp = TestTempDir::new("pklr_test_partial_import_generic_param");
+    let dir = temp.path();
+    std::fs::write(
+        dir.join("types.pkl"),
+        r#"
+Step = new Dynamic {
+    enabled = true
+}
+Other = "other"
+broken = missing.field
+"#,
+    )
+    .unwrap();
+    std::fs::write(
+        dir.join("main.pkl"),
+        r#"
+import "types.pkl" as Types
+other = Types.Other
+steps = new Mapping<String, Types.Step> {
+    ["a"] {
+        name = "alpha"
+    }
+}
+enabled = steps["a"].enabled
+"#,
+    )
+    .unwrap();
+
+    let val = pklr::eval_to_json(&dir.join("main.pkl")).await.unwrap();
+    assert_eq!(val["other"], "other");
+    assert_eq!(val["enabled"], true);
+}
+
+#[tokio::test]
 async fn partial_import_ignores_imports_used_only_by_skipped_properties() {
     let temp = TestTempDir::new("pklr_test_partial_import_skipped_import");
     let dir = temp.path();


### PR DESCRIPTION
## Summary
- record qualified generic params like `Types.Step` as field-level import uses
- add a regression for partial imports feeding `new Mapping<String, Types.Step>`

## Tests
- `cargo fmt --check`
- `cargo test --test pkl_features partial_import_includes_generic_param_fields`
- `cargo test --test pkl_features partial_import`
- `cargo test --test pkl_features`
- `cargo clippy --all-targets -- -D warnings`

Follow-up to #123 post-merge review feedback.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line change in static import-use analysis plus a test; no runtime eval path changes beyond more accurate partial import field requests.
> 
> **Overview**
> Fixes **partial import** analysis for `new` expressions so generic type parameters are recorded the same way as in type annotations.
> 
> When building import field uses from `Expr::New`, generic params like `Types.Step` in `new Mapping<String, Types.Step>` now go through `record_type_name_import_use` instead of `record_whole_import_use`. Qualified names count as **field-level** uses on the import alias (e.g. `Types` → `Step`), so partially evaluated dependencies can still expose types needed for mapping value defaults without loading the whole module or tripping over unused broken properties.
> 
> Adds regression test `partial_import_includes_generic_param_fields` for `steps["a"].enabled` with a broken unused field in `types.pkl`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a9fab15221c992cf2dfecdddf179bc13bca63af0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->