### PR TITLE
ci: remove release-plz rust toolchain action

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -24,8 +24,6 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
       - name: Authenticate with crates.io
         id: crates-io-auth
         uses: rust-lang/crates-io-auth-action@c6f97d42243bad5fab37ca0427f495c86d5b1a18 # v1.0.5
@@ -74,8 +72,6 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.RELEASE_PLZ_TOKEN }}
           persist-credentials: false
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
       - name: Run release-plz
         uses: release-plz/action@e8792575c7f2366cf6ff3ccc33ead9ace5b691c7 # v0.5.130
         with:


### PR DESCRIPTION
## Summary
- remove the pinned `dtolnay/rust-toolchain` steps from `release-plz.yml`
- rely on the GitHub runner image's default Rust toolchain for release-plz jobs

## Tests
- `git diff --check`
- confirmed no `dtolnay/rust-toolchain` references remain

Fixes the zizmor `impostor-commit` failure on the release-plz workflow.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only change with no application code impact; minor risk if runner Rust version diverges from what release-plz expects.
> 
> **Overview**
> Removes the pinned **`dtolnay/rust-toolchain`** steps from both **`release-plz-release`** and **`release-plz-pr`** in `release-plz.yml`, so those jobs use the **ubuntu-latest** runner’s preinstalled Rust instead of an explicit toolchain action.
> 
> This addresses a **zizmor `impostor-commit`** finding on that workflow; release and release-PR behavior is unchanged aside from where Rust comes from.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit da46952f80eafeac2745fa209c691d3dbccd2cd3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->