### PR TITLE
fix(eval): treat object methods as whole import uses

### DIFF
--- a/src/eval.rs
+++ b/src/eval.rs
@@ -3569,7 +3569,11 @@ fn collect_expr_import_field_uses(
             collect_entry_import_field_uses(entries, uses, shadows);
         }
         Expr::Call(callee, args) => {
-            collect_expr_import_field_uses(callee, uses, shadows);
+            if let Some(name) = object_method_import_receiver(callee.as_ref()) {
+                record_whole_import_use(uses, shadows, name);
+            } else {
+                collect_expr_import_field_uses(callee, uses, shadows);
+            }
             for arg in args {
                 collect_expr_import_field_uses(arg, uses, shadows);
             }
@@ -3609,6 +3613,30 @@ fn collect_expr_import_field_uses(
         }
         Expr::Null | Expr::Bool(_) | Expr::Int(_) | Expr::Float(_) | Expr::String(_) => {}
     }
+}
+
+fn object_method_import_receiver(expr: &Expr) -> Option<&str> {
+    let (base, method) = match expr {
+        Expr::Field(base, method) | Expr::NullSafeField(base, method) => (base.as_ref(), method),
+        _ => return None,
+    };
+    if !is_intrinsic_object_method(method) {
+        return None;
+    }
+    match base {
+        Expr::Ident(name) => Some(name),
+        _ => None,
+    }
+}
+
+fn is_intrinsic_object_method(method: &str) -> bool {
+    // Import aliases evaluate to module objects. Only methods dispatched for
+    // `Value::Object` are whole-object uses here; list/string method names can
+    // still be user-defined exported methods such as `Dep.map()`.
+    matches!(
+        method,
+        "containsKey" | "toMap" | "toMapping" | "mapValues" | "filter" | "toList" | "toDynamic"
+    )
 }
 
 fn collect_type_import_field_uses(

--- a/tests/pkl_features.rs
+++ b/tests/pkl_features.rs
@@ -1672,6 +1672,83 @@ result = Dep.wanted
     assert_eq!(val["result"], "ok");
 }
 
+#[tokio::test]
+async fn partial_import_treats_object_method_receiver_as_whole_import() {
+    let temp = TestTempDir::new("pklr_test_partial_import_object_method");
+    let dir = temp.path();
+    std::fs::write(
+        dir.join("dep.pkl"),
+        r#"
+first = "one"
+second = "two"
+"#,
+    )
+    .unwrap();
+    std::fs::write(
+        dir.join("main.pkl"),
+        r#"
+import "dep.pkl" as Dep
+result = Dep.toMap().toMapping()
+"#,
+    )
+    .unwrap();
+
+    let val = pklr::eval_to_json(&dir.join("main.pkl")).await.unwrap();
+    assert_eq!(val["result"]["first"], "one");
+    assert_eq!(val["result"]["second"], "two");
+}
+
+#[tokio::test]
+async fn partial_import_treats_object_map_values_receiver_as_whole_import() {
+    let temp = TestTempDir::new("pklr_test_partial_import_map_values");
+    let dir = temp.path();
+    std::fs::write(
+        dir.join("dep.pkl"),
+        r#"
+first = 1
+second = 2
+"#,
+    )
+    .unwrap();
+    std::fs::write(
+        dir.join("main.pkl"),
+        r#"
+import "dep.pkl" as Dep
+result = Dep.mapValues((k, v) -> v + 1).toMapping()
+"#,
+    )
+    .unwrap();
+
+    let val = pklr::eval_to_json(&dir.join("main.pkl")).await.unwrap();
+    assert_eq!(val["result"]["first"], 2);
+    assert_eq!(val["result"]["second"], 3);
+}
+
+#[tokio::test]
+async fn partial_import_keeps_user_defined_method_names_field_scoped() {
+    let temp = TestTempDir::new("pklr_test_partial_import_user_method");
+    let dir = temp.path();
+    std::fs::write(
+        dir.join("dep.pkl"),
+        r#"
+map = (n) -> n + 1
+broken = missing.field
+"#,
+    )
+    .unwrap();
+    std::fs::write(
+        dir.join("main.pkl"),
+        r#"
+import "dep.pkl" as Dep
+result = Dep.map(41)
+"#,
+    )
+    .unwrap();
+
+    let val = pklr::eval_to_json(&dir.join("main.pkl")).await.unwrap();
+    assert_eq!(val["result"], 42);
+}
+
 #[test]
 fn object_entries_can_be_separated_by_semicolons() {
     let json = eval(


### PR DESCRIPTION
## Summary
- Treat imported module receivers of intrinsic object/map methods as whole-import uses during partial import analysis
- Preserve field-only pruning for user-defined method calls like `Dep.foo()`
- Add a regression test for `Dep.toMap().toMapping()` returning all imported fields

## Tests
- `cargo test partial_import_treats_object_method_receiver_as_whole_import`
- `cargo test --test pkl_features`
- `cargo fmt --check`
- `cargo test`
- `cargo clippy --all-targets -- -D warnings`

*This PR was generated by Codex.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes static import-use analysis that drives which fields get evaluated on dependencies; wrong classification could skip needed fields or over-fetch, but scope is narrow and covered by new tests.
> 
> **Overview**
> **Partial import analysis** now marks an import alias as a **whole-module** dependency when a call uses built-in **object/map** methods on that alias (e.g. `Dep.toMap()`, `Dep.mapValues(...)`), instead of treating the method name like a single exported field.
> 
> For `Expr::Call`, the static walker recognizes `Ident.intrinsicMethod(...)` via a fixed list (`containsKey`, `toMap`, `toMapping`, `mapValues`, `filter`, `toList`, `toDynamic`) and records `ImportUse::Whole`. Names that can also be user exports—such as **`map`** on a module object—still go through field-scoped tracking so unused/broken fields in the dependency are not pulled in.
> 
> Regression tests cover `toMap().toMapping()`, `mapValues`, and `Dep.map(41)` staying field-only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9871051760e184be65887f8fe9bfb00825590222. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->