### PR TITLE
chore: release v1.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.2](https://github.com/jdx/pklr/compare/v1.1.1...v1.1.2) - 2026-07-01
+
+### Fixed
+
+- *(eval)* treat object methods as whole import uses ([#126](https://github.com/jdx/pklr/pull/126))
+
 ## [1.1.1](https://github.com/jdx/pklr/compare/v1.1.0...v1.1.1) - 2026-07-01
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -650,7 +650,7 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pklr"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "async-recursion",
  "indexmap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "pklr"
-version     = "1.1.1"
+version     = "1.1.2"
 edition      = "2024"
 rust-version = "1.88"
 description = "Pure Rust pkl configuration language parser and evaluator"


### PR DESCRIPTION



## 🤖 New release

* `pklr`: 1.1.1 -> 1.1.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [1.1.2](https://github.com/jdx/pklr/compare/v1.1.1...v1.1.2) - 2026-07-01

### Fixed

- *(eval)* treat object methods as whole import uses ([#126](https://github.com/jdx/pklr/pull/126))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release metadata only in the diff; the documented fix is a targeted import-use analysis change with API-compatible semver patch.
> 
> **Overview**
> **Release v1.1.2** bumps the crate from **1.1.1** to **1.1.2** in `Cargo.toml` and `Cargo.lock`, and documents the release in **CHANGELOG.md**.
> 
> The only functional note in this release is an **eval** fix ([#126](https://github.com/jdx/pklr/pull/126)): **object method calls on imports** (e.g. intrinsic methods on an imported module) are now treated as **whole-import uses**, so the evaluator loads/evaluates the full imported module instead of incorrectly limiting work to tracked field subsets.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3a0b5a2f56f10b49d3bd4174a315462ae305a42d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->