### PR TITLE
fix(eval): include sibling functions in partial imports

### DIFF
--- a/src/eval.rs
+++ b/src/eval.rs
@@ -3734,7 +3734,7 @@ fn expand_requested_fields(entries: &[Entry], requested: &HashSet<String>) -> Ha
                 continue;
             }
             let mut refs = HashSet::new();
-            let shadows = declared_entry_roots(entries);
+            let shadows = HashSet::new();
             if let Some(ty) = &prop.type_ann {
                 collect_type_refs(ty, &mut refs, &shadows);
             }

--- a/tests/pkl_features.rs
+++ b/tests/pkl_features.rs
@@ -1749,6 +1749,32 @@ result = Dep.map(41)
     assert_eq!(val["result"], 42);
 }
 
+#[tokio::test]
+async fn partial_import_includes_sibling_function_called_by_requested_function() {
+    let temp = TestTempDir::new("pklr_test_partial_import_sibling_function");
+    let dir = temp.path();
+    std::fs::write(
+        dir.join("dep.pkl"),
+        r#"
+function helper(): String = "ok"
+function picked(): String = helper()
+broken = missing.field
+"#,
+    )
+    .unwrap();
+    std::fs::write(
+        dir.join("main.pkl"),
+        r#"
+import "dep.pkl" as Dep
+result = Dep.picked()
+"#,
+    )
+    .unwrap();
+
+    let val = pklr::eval_to_json(&dir.join("main.pkl")).await.unwrap();
+    assert_eq!(val["result"], "ok");
+}
+
 #[test]
 fn object_entries_can_be_separated_by_semicolons() {
     let json = eval(


### PR DESCRIPTION
## Summary

Fix partial import evaluation for imported functions that depend on sibling declarations from the same module.

This looks like a regression from #123 (`c089a83`, `fix(eval): avoid evaluating unused import fields`). The field-pruning optimization correctly avoids evaluating unused imported fields, but it can currently prune sibling functions that are required by the requested function's body.

## Minimal Reproduction

`dep.pkl`:

```pkl
function helper(): String = "ok"
function picked(): String = helper()
broken = missing.field
```

`main.pkl`:

```pkl
import "dep.pkl" as Dep
result = Dep.picked()
```

`main.pkl` only accesses `Dep.picked`, so pklr requests just the `picked` field from `dep.pkl`. While evaluating that partial module, `helper` has been filtered out, and `picked()` fails with:

```text
Eval error: undefined variable: helper
```

The reduced case is valid Pkl and works with Apple Pkl 0.31.1:

```sh
tmp=$(mktemp -d)
cat > "$tmp/dep.pkl" <<'PKL'
function helper(): String = "ok"
function picked(): String = helper()
broken = missing.field
PKL
cat > "$tmp/main.pkl" <<'PKL'
import "dep.pkl" as Dep
result = Dep.picked()
PKL
mise x pkl@0.31.1 -- pkl eval "$tmp/main.pkl"
```

Output:

```text
result = "ok"
```

## Cause

`function` declarations are parsed as lambda-valued properties. During `expand_requested_fields()`, dependency collection starts with `declared_entry_roots(entries)` as the shadow set. That makes bare sibling references like `helper()` appear shadowed, so the sibling function is not added to the expanded requested-field set.

## Fix

Use an empty top-level shadow set while expanding requested field dependencies. Local `let` bindings and lambda parameters are still treated as shadows by `collect_expr_refs()`, but module-level sibling references can now be discovered and included.

## Tests

Added a regression test for a requested imported function calling a sibling function.

Ran:

```sh
cargo test partial_import --test pkl_features -- --nocapture
cargo test --test pkl_features
cargo test
```
