### PR TITLE
feat: support parser-only and capability-backed builds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -686,6 +686,7 @@ dependencies = [
  "serde_json",
  "thiserror",
  "tokio",
+ "url",
  "zip",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,18 +11,42 @@ keywords    = ["pkl", "config", "parser"]
 categories  = ["config", "parsing"]
 include     = ["/src/**/*", "/tests/**/*", "/Cargo.toml", "/README.md", "/LICENSE"]
 
+[features]
+default = [
+  "parse",
+  "eval-core",
+  "native-io",
+  "http",
+  "package-zip",
+  "miette-diagnostics",
+]
+parse = []
+eval-core = ["parse", "dep:async-recursion"]
+native-io = ["eval-core"]
+http = ["eval-core", "dep:reqwest"]
+package-zip = ["http", "native-io", "dep:zip"]
+miette-diagnostics = ["dep:miette"]
+
 [dependencies]
 indexmap    = "2"
-miette     = { version = "7", features = ["derive"] }
+miette     = { version = "7", features = ["derive"], optional = true }
 serde_json = "1"
 thiserror  = "2"
-async-recursion = "1"
-reqwest         = { version = "0.13", default-features = false, features = ["rustls"] }
-tokio           = { version = "1", features = ["rt"] }
-zip             = { version = "8", default-features = false, features = ["deflate"] }
+async-recursion = { version = "1", optional = true }
+reqwest         = { version = "0.13", default-features = false, features = ["rustls"], optional = true }
+tokio           = { version = "1", features = ["rt"], optional = true }
+zip             = { version = "8", default-features = false, features = ["deflate"], optional = true }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
+
+[[test]]
+name = "integration"
+required-features = ["native-io", "http", "package-zip"]
+
+[[test]]
+name = "pkl_features"
+required-features = ["native-io", "http", "package-zip"]
 
 [profile.dev]
 debug = 1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ default = [
   "miette-diagnostics",
 ]
 parse = []
-eval-core = ["parse", "dep:async-recursion"]
+eval-core = ["parse", "dep:async-recursion", "dep:url"]
 native-io = ["eval-core"]
 http = ["eval-core", "dep:reqwest"]
 package-zip = ["http", "native-io", "dep:zip"]
@@ -36,6 +36,7 @@ async-recursion = { version = "1", optional = true }
 reqwest         = { version = "0.13", default-features = false, features = ["rustls"], optional = true }
 tokio           = { version = "1", features = ["rt"], optional = true }
 zip             = { version = "8", default-features = false, features = ["deflate"], optional = true }
+url             = { version = "2", optional = true }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }

--- a/src/capabilities.rs
+++ b/src/capabilities.rs
@@ -100,7 +100,13 @@ impl EvalCapabilities for NativeCapabilities {
                         crate::Error::Eval(format!("HTTP fetch failed for {url}: {error}"))
                     })?
                     .error_for_status()
-                    .map_err(|error| crate::Error::Eval(format!("HTTP error for {url}: {error}")))?
+                    .map_err(|error| {
+                        if error.status() == Some(reqwest::StatusCode::NOT_FOUND) {
+                            crate::Error::ImportNotFound(url.to_string())
+                        } else {
+                            crate::Error::Eval(format!("HTTP error for {url}: {error}"))
+                        }
+                    })?
                     .text()
                     .await
                     .map_err(|error| {
@@ -130,7 +136,13 @@ impl EvalCapabilities for NativeCapabilities {
                         crate::Error::Eval(format!("HTTP fetch failed for {url}: {error}"))
                     })?
                     .error_for_status()
-                    .map_err(|error| crate::Error::Eval(format!("HTTP error for {url}: {error}")))?
+                    .map_err(|error| {
+                        if error.status() == Some(reqwest::StatusCode::NOT_FOUND) {
+                            crate::Error::ImportNotFound(url.to_string())
+                        } else {
+                            crate::Error::Eval(format!("HTTP error for {url}: {error}"))
+                        }
+                    })?
                     .bytes()
                     .await
                     .map_err(|error| {

--- a/src/capabilities.rs
+++ b/src/capabilities.rs
@@ -1,6 +1,8 @@
 use std::future::Future;
 use std::path::{Path, PathBuf};
 use std::pin::Pin;
+#[cfg(feature = "http")]
+use std::time::Duration;
 
 use crate::Result;
 
@@ -10,7 +12,7 @@ pub type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + 'a>>;
 ///
 /// The default evaluator still uses the native implementation, but embedders
 /// can provide their own file, environment, HTTP, temp-dir, and glob behavior.
-pub trait EvalCapabilities {
+pub trait EvalCapabilities: Send {
     fn read_to_string<'a>(&'a mut self, path: &'a Path) -> BoxFuture<'a, Result<String>>;
 
     fn read_env<'a>(&'a mut self, name: &'a str) -> BoxFuture<'a, Result<Option<String>>>;
@@ -18,6 +20,11 @@ pub trait EvalCapabilities {
     fn fetch_text<'a>(&'a mut self, url: &'a str) -> BoxFuture<'a, Result<String>>;
 
     fn fetch_bytes<'a>(&'a mut self, url: &'a str) -> BoxFuture<'a, Result<Vec<u8>>>;
+
+    #[cfg(feature = "http")]
+    fn set_http_client(&mut self, client: reqwest::Client) {
+        drop(client);
+    }
 
     fn temp_dir<'a>(&'a mut self, prefix: &'a str) -> BoxFuture<'a, Result<PathBuf>>;
 
@@ -29,8 +36,42 @@ pub trait EvalCapabilities {
 }
 
 #[cfg(feature = "native-io")]
-#[derive(Debug, Clone, Default)]
-pub struct NativeCapabilities;
+#[derive(Debug, Clone)]
+pub struct NativeCapabilities {
+    #[cfg(feature = "http")]
+    http_client: reqwest::Client,
+}
+
+#[cfg(feature = "native-io")]
+impl NativeCapabilities {
+    pub fn new() -> Self {
+        Self {
+            #[cfg(feature = "http")]
+            http_client: default_http_client(),
+        }
+    }
+
+    #[cfg(feature = "http")]
+    pub fn with_http_client(http_client: reqwest::Client) -> Self {
+        Self { http_client }
+    }
+}
+
+#[cfg(feature = "native-io")]
+impl Default for NativeCapabilities {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(all(feature = "native-io", feature = "http"))]
+fn default_http_client() -> reqwest::Client {
+    reqwest::Client::builder()
+        .connect_timeout(Duration::from_secs(10))
+        .timeout(Duration::from_secs(30))
+        .build()
+        .expect("default reqwest client should build")
+}
 
 #[cfg(feature = "native-io")]
 impl EvalCapabilities for NativeCapabilities {
@@ -46,10 +87,12 @@ impl EvalCapabilities for NativeCapabilities {
     }
 
     fn fetch_text<'a>(&'a mut self, url: &'a str) -> BoxFuture<'a, Result<String>> {
+        #[cfg(feature = "http")]
+        let client = self.http_client.clone();
         Box::pin(async move {
             #[cfg(feature = "http")]
             {
-                reqwest::Client::new()
+                client
                     .get(url)
                     .send()
                     .await
@@ -74,10 +117,12 @@ impl EvalCapabilities for NativeCapabilities {
     }
 
     fn fetch_bytes<'a>(&'a mut self, url: &'a str) -> BoxFuture<'a, Result<Vec<u8>>> {
+        #[cfg(feature = "http")]
+        let client = self.http_client.clone();
         Box::pin(async move {
             #[cfg(feature = "http")]
             {
-                let bytes = reqwest::Client::new()
+                let bytes = client
                     .get(url)
                     .send()
                     .await
@@ -100,6 +145,11 @@ impl EvalCapabilities for NativeCapabilities {
                 )))
             }
         })
+    }
+
+    #[cfg(feature = "http")]
+    fn set_http_client(&mut self, client: reqwest::Client) {
+        self.http_client = client;
     }
 
     fn temp_dir<'a>(&'a mut self, prefix: &'a str) -> BoxFuture<'a, Result<PathBuf>> {

--- a/src/capabilities.rs
+++ b/src/capabilities.rs
@@ -1,6 +1,8 @@
 use std::future::Future;
 use std::path::{Path, PathBuf};
 use std::pin::Pin;
+#[cfg(feature = "native-io")]
+use std::sync::atomic::{AtomicU64, Ordering};
 #[cfg(feature = "http")]
 use std::time::Duration;
 
@@ -14,6 +16,10 @@ pub type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + 'a>>;
 /// can provide their own file, environment, HTTP, temp-dir, and glob behavior.
 pub trait EvalCapabilities: Send {
     fn read_to_string<'a>(&'a mut self, path: &'a Path) -> BoxFuture<'a, Result<String>>;
+
+    fn path_exists<'a>(&'a mut self, path: &'a Path) -> BoxFuture<'a, Result<bool>>;
+
+    fn canonicalize<'a>(&'a mut self, path: &'a Path) -> BoxFuture<'a, Result<PathBuf>>;
 
     fn read_env<'a>(&'a mut self, name: &'a str) -> BoxFuture<'a, Result<Option<String>>>;
 
@@ -78,6 +84,17 @@ impl EvalCapabilities for NativeCapabilities {
     fn read_to_string<'a>(&'a mut self, path: &'a Path) -> BoxFuture<'a, Result<String>> {
         Box::pin(async move {
             std::fs::read_to_string(path)
+                .map_err(|error| crate::Error::Io(path.to_path_buf(), error))
+        })
+    }
+
+    fn path_exists<'a>(&'a mut self, path: &'a Path) -> BoxFuture<'a, Result<bool>> {
+        Box::pin(async move { Ok(path.exists()) })
+    }
+
+    fn canonicalize<'a>(&'a mut self, path: &'a Path) -> BoxFuture<'a, Result<PathBuf>> {
+        Box::pin(async move {
+            path.canonicalize()
                 .map_err(|error| crate::Error::Io(path.to_path_buf(), error))
         })
     }
@@ -165,13 +182,7 @@ impl EvalCapabilities for NativeCapabilities {
     }
 
     fn temp_dir<'a>(&'a mut self, prefix: &'a str) -> BoxFuture<'a, Result<PathBuf>> {
-        Box::pin(async move {
-            let dir = std::env::temp_dir().join(prefix);
-            std::fs::create_dir_all(&dir).map_err(|error| {
-                crate::Error::Eval(format!("mkdir failed for {}: {error}", dir.display()))
-            })?;
-            Ok(dir)
-        })
+        Box::pin(async move { unique_temp_dir(prefix) })
     }
 
     fn glob<'a>(
@@ -180,5 +191,56 @@ impl EvalCapabilities for NativeCapabilities {
         pattern: &'a str,
     ) -> BoxFuture<'a, Result<Vec<PathBuf>>> {
         Box::pin(async move { crate::eval::expand_glob(base, pattern) })
+    }
+}
+
+#[cfg(feature = "native-io")]
+static TEMP_DIR_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+#[cfg(feature = "native-io")]
+fn unique_temp_dir(prefix: &str) -> Result<PathBuf> {
+    let base = std::env::temp_dir();
+    for _ in 0..100 {
+        let counter = TEMP_DIR_COUNTER.fetch_add(1, Ordering::Relaxed);
+        let dir = base.join(format!("{prefix}-{}-{counter}", std::process::id()));
+        match std::fs::create_dir(&dir) {
+            Ok(()) => return Ok(dir),
+            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => continue,
+            Err(error) => {
+                return Err(crate::Error::Eval(format!(
+                    "mkdir failed for {}: {error}",
+                    dir.display()
+                )));
+            }
+        }
+    }
+    Err(crate::Error::Eval(format!(
+        "mkdir failed for {}: unable to create a unique directory",
+        base.join(prefix).display()
+    )))
+}
+
+#[cfg(all(test, feature = "native-io"))]
+mod tests {
+    use super::{EvalCapabilities, NativeCapabilities};
+
+    #[tokio::test]
+    async fn native_temp_dirs_are_unique_and_empty() {
+        let mut capabilities = NativeCapabilities::new();
+        let first = capabilities
+            .temp_dir("pklr-capabilities-test")
+            .await
+            .unwrap();
+        let second = capabilities
+            .temp_dir("pklr-capabilities-test")
+            .await
+            .unwrap();
+
+        assert_ne!(first, second);
+        assert!(std::fs::read_dir(&first).unwrap().next().is_none());
+        assert!(std::fs::read_dir(&second).unwrap().next().is_none());
+
+        std::fs::remove_dir(&first).unwrap();
+        std::fs::remove_dir(&second).unwrap();
     }
 }

--- a/src/capabilities.rs
+++ b/src/capabilities.rs
@@ -1,0 +1,122 @@
+use std::future::Future;
+use std::path::{Path, PathBuf};
+use std::pin::Pin;
+
+use crate::Result;
+
+pub type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + 'a>>;
+
+/// Host-provided IO for evaluating Pkl modules.
+///
+/// The default evaluator still uses the native implementation, but embedders
+/// can provide their own file, environment, HTTP, temp-dir, and glob behavior.
+pub trait EvalCapabilities {
+    fn read_to_string<'a>(&'a mut self, path: &'a Path) -> BoxFuture<'a, Result<String>>;
+
+    fn read_env<'a>(&'a mut self, name: &'a str) -> BoxFuture<'a, Result<Option<String>>>;
+
+    fn fetch_text<'a>(&'a mut self, url: &'a str) -> BoxFuture<'a, Result<String>>;
+
+    fn fetch_bytes<'a>(&'a mut self, url: &'a str) -> BoxFuture<'a, Result<Vec<u8>>>;
+
+    fn temp_dir<'a>(&'a mut self, prefix: &'a str) -> BoxFuture<'a, Result<PathBuf>>;
+
+    fn glob<'a>(
+        &'a mut self,
+        base: &'a Path,
+        pattern: &'a str,
+    ) -> BoxFuture<'a, Result<Vec<PathBuf>>>;
+}
+
+#[cfg(feature = "native-io")]
+#[derive(Debug, Clone, Default)]
+pub struct NativeCapabilities;
+
+#[cfg(feature = "native-io")]
+impl EvalCapabilities for NativeCapabilities {
+    fn read_to_string<'a>(&'a mut self, path: &'a Path) -> BoxFuture<'a, Result<String>> {
+        Box::pin(async move {
+            std::fs::read_to_string(path)
+                .map_err(|error| crate::Error::Io(path.to_path_buf(), error))
+        })
+    }
+
+    fn read_env<'a>(&'a mut self, name: &'a str) -> BoxFuture<'a, Result<Option<String>>> {
+        Box::pin(async move { Ok(std::env::var(name).ok()) })
+    }
+
+    fn fetch_text<'a>(&'a mut self, url: &'a str) -> BoxFuture<'a, Result<String>> {
+        Box::pin(async move {
+            #[cfg(feature = "http")]
+            {
+                reqwest::Client::new()
+                    .get(url)
+                    .send()
+                    .await
+                    .map_err(|error| {
+                        crate::Error::Eval(format!("HTTP fetch failed for {url}: {error}"))
+                    })?
+                    .error_for_status()
+                    .map_err(|error| crate::Error::Eval(format!("HTTP error for {url}: {error}")))?
+                    .text()
+                    .await
+                    .map_err(|error| {
+                        crate::Error::Eval(format!("HTTP read failed for {url}: {error}"))
+                    })
+            }
+            #[cfg(not(feature = "http"))]
+            {
+                Err(crate::Error::Unsupported(format!(
+                    "HTTP fetch requires pklr's 'http' feature: {url}"
+                )))
+            }
+        })
+    }
+
+    fn fetch_bytes<'a>(&'a mut self, url: &'a str) -> BoxFuture<'a, Result<Vec<u8>>> {
+        Box::pin(async move {
+            #[cfg(feature = "http")]
+            {
+                let bytes = reqwest::Client::new()
+                    .get(url)
+                    .send()
+                    .await
+                    .map_err(|error| {
+                        crate::Error::Eval(format!("HTTP fetch failed for {url}: {error}"))
+                    })?
+                    .error_for_status()
+                    .map_err(|error| crate::Error::Eval(format!("HTTP error for {url}: {error}")))?
+                    .bytes()
+                    .await
+                    .map_err(|error| {
+                        crate::Error::Eval(format!("HTTP read failed for {url}: {error}"))
+                    })?;
+                Ok(bytes.to_vec())
+            }
+            #[cfg(not(feature = "http"))]
+            {
+                Err(crate::Error::Unsupported(format!(
+                    "HTTP byte fetch requires pklr's 'http' feature: {url}"
+                )))
+            }
+        })
+    }
+
+    fn temp_dir<'a>(&'a mut self, prefix: &'a str) -> BoxFuture<'a, Result<PathBuf>> {
+        Box::pin(async move {
+            let dir = std::env::temp_dir().join(prefix);
+            std::fs::create_dir_all(&dir).map_err(|error| {
+                crate::Error::Eval(format!("mkdir failed for {}: {error}", dir.display()))
+            })?;
+            Ok(dir)
+        })
+    }
+
+    fn glob<'a>(
+        &'a mut self,
+        base: &'a Path,
+        pattern: &'a str,
+    ) -> BoxFuture<'a, Result<Vec<PathBuf>>> {
+        Box::pin(async move { crate::eval::expand_glob(base, pattern) })
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,35 +1,45 @@
-// The Lex/Parse variant fields are read by miette's Diagnostic derive macro,
-// but rustc can't see through the proc-macro expansion.
-#![allow(unused_assignments)]
-
 use std::path::PathBuf;
 
+#[cfg(feature = "miette-diagnostics")]
 use miette::NamedSource;
 
 pub type Result<T> = std::result::Result<T, Error>;
 
-#[derive(Debug, miette::Diagnostic, thiserror::Error)]
+#[cfg_attr(feature = "miette-diagnostics", derive(miette::Diagnostic))]
+#[derive(Debug, thiserror::Error)]
 pub enum Error {
     #[error("IO error reading {0}: {1}")]
     Io(PathBuf, #[source] std::io::Error),
 
     #[error("{message}")]
-    #[diagnostic()]
+    #[cfg_attr(feature = "miette-diagnostics", diagnostic())]
     Lex {
+        #[cfg(feature = "miette-diagnostics")]
         #[source_code]
         src: NamedSource<String>,
+        #[cfg(feature = "miette-diagnostics")]
         #[label("{message}")]
         span: miette::SourceOffset,
+        #[cfg(not(feature = "miette-diagnostics"))]
+        source_name: String,
+        #[cfg(not(feature = "miette-diagnostics"))]
+        offset: usize,
         message: String,
     },
 
     #[error("{message}")]
-    #[diagnostic()]
+    #[cfg_attr(feature = "miette-diagnostics", diagnostic())]
     Parse {
+        #[cfg(feature = "miette-diagnostics")]
         #[source_code]
         src: NamedSource<String>,
+        #[cfg(feature = "miette-diagnostics")]
         #[label("{message}")]
         span: miette::SourceOffset,
+        #[cfg(not(feature = "miette-diagnostics"))]
+        source_name: String,
+        #[cfg(not(feature = "miette-diagnostics"))]
+        offset: usize,
         message: String,
     },
 
@@ -41,4 +51,56 @@ pub enum Error {
 
     #[error("Unsupported feature: {0}")]
     Unsupported(String),
+}
+
+impl Error {
+    pub fn lex(source_name: &str, source: &str, offset: usize, message: String) -> Self {
+        #[cfg(feature = "miette-diagnostics")]
+        {
+            Self::Lex {
+                src: NamedSource::new(source_name, source.to_string()),
+                span: miette::SourceOffset::from(offset),
+                message,
+            }
+        }
+        #[cfg(not(feature = "miette-diagnostics"))]
+        {
+            let _ = source;
+            Self::Lex {
+                source_name: source_name.to_string(),
+                offset,
+                message,
+            }
+        }
+    }
+
+    pub fn parse(source_name: &str, source: &str, offset: usize, message: String) -> Self {
+        #[cfg(feature = "miette-diagnostics")]
+        {
+            Self::Parse {
+                src: NamedSource::new(source_name, source.to_string()),
+                span: miette::SourceOffset::from(offset),
+                message,
+            }
+        }
+        #[cfg(not(feature = "miette-diagnostics"))]
+        {
+            let _ = source;
+            Self::Parse {
+                source_name: source_name.to_string(),
+                offset,
+                message,
+            }
+        }
+    }
+
+    pub fn source_offset(&self) -> Option<usize> {
+        match self {
+            #[cfg(feature = "miette-diagnostics")]
+            Self::Lex { span, .. } | Self::Parse { span, .. } => Some(span.offset()),
+            #[cfg(not(feature = "miette-diagnostics"))]
+            Self::Lex { offset, .. } | Self::Parse { offset, .. } => Some(*offset),
+            _ => None,
+        }
+    }
 }

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -284,7 +284,7 @@ impl Evaluator {
             let base = path.parent().unwrap_or(Path::new("."));
             base.join(uri)
         };
-        if !import_path.exists() {
+        if !self.capabilities.path_exists(&import_path).await? {
             return Ok(None);
         }
         let source = self.capabilities.read_to_string(&import_path).await?;
@@ -328,7 +328,7 @@ impl Evaluator {
     pub async fn eval_source(&mut self, source: &str, path: &Path) -> Result<Value> {
         self.converters.clear();
         // Seed import cache for the entry file so circular back-references work
-        if let Ok(canonical) = path.canonicalize() {
+        if let Ok(canonical) = self.capabilities.canonicalize(path).await {
             self.import_cache
                 .insert(canonical, Value::Object(Arc::new(IndexMap::new()), None));
         }
@@ -337,7 +337,7 @@ impl Evaluator {
         let module = parser::parse_named(&tokens, source, &name)?;
         let val = self.eval_module(&module, path, 0).await?;
         // Update cache with real value
-        if let Ok(canonical) = path.canonicalize() {
+        if let Ok(canonical) = self.capabilities.canonicalize(path).await {
             self.import_cache.insert(canonical, val.clone());
         }
         Ok(val)
@@ -351,9 +351,7 @@ impl Evaluator {
     /// Read, lex, parse, and evaluate a local file (with caching).
     /// Inserts a placeholder before evaluation to break circular imports.
     async fn eval_file(&mut self, path: &Path, depth: usize) -> Result<Value> {
-        let canonical = path
-            .canonicalize()
-            .map_err(|e| Error::Io(path.to_path_buf(), e))?;
+        let canonical = self.capabilities.canonicalize(path).await?;
         if let Some(cached) = self.import_cache.get(&canonical) {
             return Ok(cached.clone());
         }
@@ -379,9 +377,7 @@ impl Evaluator {
         if requested_fields.is_none() {
             return self.eval_file(path, depth).await;
         }
-        let canonical = path
-            .canonicalize()
-            .map_err(|e| Error::Io(path.to_path_buf(), e))?;
+        let canonical = self.capabilities.canonicalize(path).await?;
         if let Some(cached) = self.import_cache.get(&canonical) {
             return Ok(cached.clone());
         }
@@ -428,9 +424,7 @@ impl Evaluator {
         if inherited_scope.is_none() {
             return self.eval_file(path, depth).await;
         }
-        let canonical = path
-            .canonicalize()
-            .map_err(|e| Error::Io(path.to_path_buf(), e))?;
+        let canonical = self.capabilities.canonicalize(path).await?;
         if !self.scoped_imports_in_flight.insert(canonical.clone()) {
             return Ok(Value::Object(Arc::new(IndexMap::new()), None));
         }
@@ -544,7 +538,7 @@ impl Evaluator {
                 let matched = self.capabilities.glob(base_dir, uri).await?;
                 let mut mapping = IndexMap::new();
                 for matched_path in matched {
-                    if same_local_path(&matched_path, path) {
+                    if self.same_local_path(&matched_path, path).await? {
                         continue;
                     }
                     let rel_key = pathdiff_or_full(&matched_path, base_dir);
@@ -682,13 +676,17 @@ impl Evaluator {
                 // reported only if the imported binding is actually referenced.
                 continue;
             }
-            if !import_path.exists() {
+            if !self.capabilities.path_exists(&import_path).await? {
                 return Err(Error::ImportNotFound(import_path.display().to_string()));
             }
-            if let Some(inherited_path) = inherited_local_paths
-                .iter()
-                .find(|inherited_path| same_local_path(inherited_path, &import_path))
-            {
+            let mut inherited_path = None;
+            for candidate in &inherited_local_paths {
+                if self.same_local_path(candidate, &import_path).await? {
+                    inherited_path = Some(candidate);
+                    break;
+                }
+            }
+            if let Some(inherited_path) = inherited_path {
                 deferred_inherited_imports.push((alias, inherited_path.clone()));
                 continue;
             }
@@ -781,17 +779,18 @@ impl Evaluator {
                     let base = path.parent().unwrap_or(Path::new("."));
                     base.join(uri)
                 };
-                if amends_path.exists() {
+                if self.capabilities.path_exists(&amends_path).await? {
                     let base_val = self
                         .eval_file_with_scope(&amends_path, depth + 1, Some(scope.clone()))
                         .await?;
                     if let Value::Object(m, _) = &base_val {
-                        bind_deferred_inherited_imports(
+                        self.bind_deferred_inherited_imports(
                             &deferred_inherited_imports,
                             &amends_path,
                             &base_val,
                             &mut scope,
-                        );
+                        )
+                        .await?;
                         base_obj = (**m).clone();
                     }
                 }
@@ -860,7 +859,7 @@ impl Evaluator {
                     let base = path.parent().unwrap_or(Path::new("."));
                     base.join(uri)
                 };
-                if extends_path.exists() {
+                if self.capabilities.path_exists(&extends_path).await? {
                     let ext_val = self
                         .eval_file_with_scope(&extends_path, depth + 1, Some(scope.clone()))
                         .await?;
@@ -869,12 +868,13 @@ impl Evaluator {
                     let tokens = lexer::lex_named(&source, &name)?;
                     let ext_module = parser::parse_named(&tokens, &source, &name)?;
                     if let Value::Object(m, _) = &ext_val {
-                        bind_deferred_inherited_imports(
+                        self.bind_deferred_inherited_imports(
                             &deferred_inherited_imports,
                             &extends_path,
                             &ext_val,
                             &mut scope,
-                        );
+                        )
+                        .await?;
                         base_obj = (**m).clone();
                     }
                     // Also evaluate the base module's scope (classes, locals) into our scope
@@ -4657,39 +4657,11 @@ fn resolve_remote_relative(current_path: &Path, uri: &str) -> Option<String> {
 }
 
 fn resolve_http_relative(base: &str, uri: &str) -> Option<String> {
-    let scheme_end = base.find("://")? + 3;
-    let authority_end = base[scheme_end..]
-        .find(['/', '?', '#'])
-        .map(|offset| scheme_end + offset);
-    let (origin, base_path) = match authority_end {
-        Some(path_start) if base[path_start..].starts_with('/') => {
-            let (origin, path_and_suffix) = base.split_at(path_start);
-            let path_end = path_and_suffix
-                .find(['?', '#'])
-                .unwrap_or(path_and_suffix.len());
-            (origin, &path_and_suffix[..path_end])
-        }
-        Some(path_start) => base.split_at(path_start),
-        None => (base, ""),
-    };
-    if uri.starts_with('/') {
-        return Some(format!("{origin}{uri}"));
-    }
-    let base_dir = base_path
-        .rsplit_once('/')
-        .map(|(dir, _)| format!("{dir}/"))
-        .unwrap_or_else(|| "/".to_string());
-    let mut segments = Vec::new();
-    for segment in base_dir.split('/').chain(uri.split('/')) {
-        match segment {
-            "" | "." => {}
-            ".." => {
-                segments.pop();
-            }
-            segment => segments.push(segment),
-        }
-    }
-    Some(format!("{origin}/{}", segments.join("/")))
+    url::Url::parse(base)
+        .ok()?
+        .join(uri)
+        .ok()
+        .map(|url| url.to_string())
 }
 
 #[cfg(test)]
@@ -4731,24 +4703,64 @@ mod remote_relative_tests {
             Some("https://example.com/Lib.pkl")
         );
     }
+
+    #[test]
+    fn http_relative_resolves_query_only_references() {
+        assert_eq!(
+            resolve_http_relative("https://example.com/cfg/Main.pkl", "?v=2").as_deref(),
+            Some("https://example.com/cfg/Main.pkl?v=2")
+        );
+    }
+
+    #[test]
+    fn http_relative_resolves_fragment_only_references() {
+        assert_eq!(
+            resolve_http_relative("https://example.com/cfg/Main.pkl", "#frag").as_deref(),
+            Some("https://example.com/cfg/Main.pkl#frag")
+        );
+    }
+
+    #[test]
+    fn http_relative_resolves_network_path_references() {
+        assert_eq!(
+            resolve_http_relative("https://example.com/cfg/Main.pkl", "//cdn.example/Lib.pkl")
+                .as_deref(),
+            Some("https://cdn.example/Lib.pkl")
+        );
+    }
 }
 
-fn same_local_path(left: &Path, right: &Path) -> bool {
-    let left_key = left.canonicalize().unwrap_or_else(|_| left.to_path_buf());
-    let right_key = right.canonicalize().unwrap_or_else(|_| right.to_path_buf());
-    left_key == right_key
-}
-
-fn bind_deferred_inherited_imports(
-    deferred: &[(String, PathBuf)],
-    inherited_path: &Path,
-    inherited_val: &Value,
-    scope: &mut Scope,
-) {
-    for (alias, alias_path) in deferred {
-        if same_local_path(alias_path, inherited_path) {
-            scope.set(alias.clone(), inherited_val.clone());
+impl Evaluator {
+    async fn same_local_path(&mut self, left: &Path, right: &Path) -> Result<bool> {
+        if left == right {
+            return Ok(true);
         }
+        let left_key = self
+            .capabilities
+            .canonicalize(left)
+            .await
+            .unwrap_or_else(|_| left.to_path_buf());
+        let right_key = self
+            .capabilities
+            .canonicalize(right)
+            .await
+            .unwrap_or_else(|_| right.to_path_buf());
+        Ok(left_key == right_key)
+    }
+
+    async fn bind_deferred_inherited_imports(
+        &mut self,
+        deferred: &[(String, PathBuf)],
+        inherited_path: &Path,
+        inherited_val: &Value,
+        scope: &mut Scope,
+    ) -> Result<()> {
+        for (alias, alias_path) in deferred {
+            if self.same_local_path(alias_path, inherited_path).await? {
+                scope.set(alias.clone(), inherited_val.clone());
+            }
+        }
+        Ok(())
     }
 }
 

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -6,6 +6,7 @@ use async_recursion::async_recursion;
 use indexmap::IndexMap;
 use std::path::{Path, PathBuf};
 
+use crate::capabilities::EvalCapabilities;
 use crate::error::{Error, Result};
 use crate::lexer;
 use crate::parser::{self, BinOp, Entry, Expr, Modifier, Module, Property, StringInterpPart, UnOp};
@@ -23,8 +24,12 @@ pub struct Evaluator {
     /// Local files currently being evaluated with inherited scope.
     scoped_imports_in_flight: HashSet<PathBuf>,
     /// Reusable HTTP client for connection pooling
+    #[cfg(feature = "http")]
     http_client: reqwest::Client,
+    /// Host-provided IO for files, environment, HTTP, packages, and globs.
+    capabilities: Box<dyn EvalCapabilities>,
     /// Extracted package zip directories (zip URL → temp dir path)
+    #[cfg(feature = "package-zip")]
     package_dirs: HashMap<String, PathBuf>,
     /// HTTP URL rewrite rules (source_prefix → target_prefix).
     /// Longest matching prefix wins.
@@ -51,6 +56,7 @@ fn regex_value(pattern: Value) -> Value {
     Value::Object(Arc::new(map), None)
 }
 
+#[cfg(feature = "native-io")]
 impl Default for Evaluator {
     fn default() -> Self {
         Self {
@@ -59,7 +65,10 @@ impl Default for Evaluator {
             http_cache: HashMap::new(),
             import_cache: HashMap::new(),
             scoped_imports_in_flight: HashSet::new(),
+            #[cfg(feature = "http")]
             http_client: reqwest::Client::new(),
+            capabilities: Box::new(crate::capabilities::NativeCapabilities),
+            #[cfg(feature = "package-zip")]
             package_dirs: HashMap::new(),
             http_rewrites: Vec::new(),
             converters: Vec::new(),
@@ -69,8 +78,27 @@ impl Default for Evaluator {
 }
 
 impl Evaluator {
+    #[cfg(feature = "native-io")]
     pub fn new() -> Self {
         Self::default()
+    }
+
+    pub fn with_capabilities(capabilities: impl EvalCapabilities + 'static) -> Self {
+        Self {
+            base_path: PathBuf::from("."),
+            max_depth: 32,
+            http_cache: HashMap::new(),
+            import_cache: HashMap::new(),
+            scoped_imports_in_flight: HashSet::new(),
+            #[cfg(feature = "http")]
+            http_client: reqwest::Client::new(),
+            capabilities: Box::new(capabilities),
+            #[cfg(feature = "package-zip")]
+            package_dirs: HashMap::new(),
+            http_rewrites: Vec::new(),
+            converters: Vec::new(),
+            warned_deprecated: std::collections::HashSet::new(),
+        }
     }
 
     pub fn set_base_path(&mut self, path: &Path) {
@@ -79,6 +107,7 @@ impl Evaluator {
 
     /// Set a custom HTTP client for fetching remote imports and packages.
     /// Use this to configure proxy settings, CA certificates, timeouts, etc.
+    #[cfg(feature = "http")]
     pub fn set_http_client(&mut self, client: reqwest::Client) {
         self.http_client = client;
     }
@@ -146,17 +175,16 @@ impl Evaluator {
     async fn read_resource(&mut self, uri: &str) -> Result<Value> {
         if let Some(path) = uri.strip_prefix("file://") {
             // file:// — read local file
-            let content = std::fs::read_to_string(path)
-                .map_err(|e| Error::Eval(format!("read() failed for {uri}: {e}")))?;
+            let content = self.capabilities.read_to_string(Path::new(path)).await?;
             Ok(Value::String(content))
         } else if let Some(var_name) = uri.strip_prefix("env:") {
             // env: — read environment variable
-            match std::env::var(var_name) {
-                Ok(val) => Ok(Value::String(val)),
-                Err(_) => Err(Error::Eval(format!(
+            let Some(val) = self.capabilities.read_env(var_name).await? else {
+                return Err(Error::Eval(format!(
                     "environment variable not found: {var_name}"
-                ))),
-            }
+                )));
+            };
+            Ok(Value::String(val))
         } else if let Some(prop_name) = uri.strip_prefix("prop:") {
             // prop: — system properties (not standard in Rust, return empty)
             Err(Error::Eval(format!(
@@ -169,8 +197,7 @@ impl Evaluator {
         } else {
             // Bare path — treat as file relative to base_path
             let file_path = self.base_path.join(uri);
-            let content = std::fs::read_to_string(&file_path)
-                .map_err(|e| Error::Eval(format!("read() failed for {uri}: {e}")))?;
+            let content = self.capabilities.read_to_string(&file_path).await?;
             Ok(Value::String(content))
         }
     }
@@ -186,6 +213,7 @@ impl Evaluator {
         } else {
             fetch_url.to_string()
         };
+        #[cfg(feature = "http")]
         let body = self
             .http_client
             .get(fetch_url)
@@ -197,6 +225,12 @@ impl Evaluator {
             .text()
             .await
             .map_err(|e| Error::Eval(format!("HTTP read failed for {err_ctx}: {e}")))?;
+        #[cfg(not(feature = "http"))]
+        let body = self
+            .capabilities
+            .fetch_text(fetch_url)
+            .await
+            .map_err(|error| Error::Eval(format!("HTTP fetch failed for {err_ctx}: {error}")))?;
         self.http_cache.insert(fetch_url.to_string(), body.clone());
         Ok(body)
     }
@@ -253,11 +287,20 @@ impl Evaluator {
                     return Ok(Some((source, url.clone())));
                 }
                 PackageSource::Zip(zip_url, entry) => {
-                    let pkg_dir = self.extract_package_zip(zip_url).await?;
-                    let local_path = pkg_dir.join(entry);
-                    let source = std::fs::read_to_string(&local_path)
-                        .map_err(|e| Error::Io(local_path.clone(), e))?;
-                    return Ok(Some((source, local_path.display().to_string())));
+                    #[cfg(feature = "package-zip")]
+                    {
+                        let pkg_dir = self.extract_package_zip(zip_url).await?;
+                        let local_path = pkg_dir.join(entry);
+                        let source = self.capabilities.read_to_string(&local_path).await?;
+                        return Ok(Some((source, local_path.display().to_string())));
+                    }
+                    #[cfg(not(feature = "package-zip"))]
+                    {
+                        let _ = entry;
+                        return Err(Error::Unsupported(format!(
+                            "package zip imports require pklr's 'package-zip' feature: {zip_url}"
+                        )));
+                    }
                 }
             }
         }
@@ -273,13 +316,13 @@ impl Evaluator {
         if !import_path.exists() {
             return Ok(None);
         }
-        let source =
-            std::fs::read_to_string(&import_path).map_err(|e| Error::Io(import_path.clone(), e))?;
+        let source = self.capabilities.read_to_string(&import_path).await?;
         Ok(Some((source, import_path.display().to_string())))
     }
 
     /// Download a package zip and extract it to a temp directory.
     /// Returns the path to the extracted directory. Caches by zip URL.
+    #[cfg(feature = "package-zip")]
     async fn extract_package_zip(&mut self, zip_url: &str) -> Result<PathBuf> {
         let rewritten = self.rewrite_url(zip_url);
         let fetch_url = rewritten.as_ref();
@@ -293,21 +336,17 @@ impl Evaluator {
             fetch_url.to_string()
         };
         let bytes = self
-            .http_client
-            .get(fetch_url)
-            .send()
-            .await
-            .map_err(|e| Error::Eval(format!("HTTP fetch failed for {err_ctx}: {e}")))?
-            .error_for_status()
-            .map_err(|e| Error::Eval(format!("HTTP error for {err_ctx}: {e}")))?
-            .bytes()
+            .capabilities
+            .fetch_bytes(fetch_url)
             .await
             .map_err(|e| Error::Eval(format!("HTTP read failed for {err_ctx}: {e}")))?;
         let cursor = std::io::Cursor::new(bytes);
         let mut archive =
             zip::ZipArchive::new(cursor).map_err(|e| Error::Eval(format!("zip error: {e}")))?;
-        let dir = std::env::temp_dir().join(format!("pklr-pkg-{}", self.package_dirs.len()));
-        std::fs::create_dir_all(&dir).map_err(|e| Error::Eval(format!("mkdir error: {e}")))?;
+        let dir = self
+            .capabilities
+            .temp_dir(&format!("pklr-pkg-{}", self.package_dirs.len()))
+            .await?;
         archive
             .extract(&dir)
             .map_err(|e| Error::Eval(format!("zip extract error: {e}")))?;
@@ -315,6 +354,7 @@ impl Evaluator {
         Ok(dir)
     }
 
+    #[cfg(all(test, feature = "package-zip"))]
     fn package_dir_for_zip(&self, zip_url: &str) -> Option<&PathBuf> {
         if let Some(dir) = self.package_dirs.get(zip_url) {
             return Some(dir);
@@ -400,7 +440,7 @@ impl Evaluator {
         depth: usize,
         requested_fields: Option<HashSet<String>>,
     ) -> Result<Value> {
-        let module = parse_file(path)?;
+        let module = self.parse_file(path).await?;
         self.eval_module_with_scope(&module, path, depth, None, requested_fields)
             .await
     }
@@ -445,11 +485,18 @@ impl Evaluator {
         depth: usize,
         inherited_scope: Option<Scope>,
     ) -> Result<Value> {
-        let module = parse_file(path)?;
+        let module = self.parse_file(path).await?;
         let val = self
             .eval_module_with_scope(&module, path, depth, inherited_scope, None)
             .await?;
         Ok(val)
+    }
+
+    async fn parse_file(&mut self, path: &Path) -> Result<Module> {
+        let source = self.capabilities.read_to_string(path).await?;
+        let name = path.display().to_string();
+        let tokens = lexer::lex_named(&source, &name)?;
+        parser::parse_named(&tokens, &source, &name)
     }
 
     async fn eval_module(&mut self, module: &Module, path: &Path, depth: usize) -> Result<Value> {
@@ -532,7 +579,7 @@ impl Evaluator {
                 }
 
                 let base_dir = path.parent().unwrap_or(Path::new("."));
-                let matched = expand_glob(base_dir, uri)?;
+                let matched = self.capabilities.glob(base_dir, uri).await?;
                 let mut mapping = IndexMap::new();
                 for matched_path in matched {
                     if same_local_path(&matched_path, path) {
@@ -598,13 +645,22 @@ impl Evaluator {
                 let requested = requested_fields_for_import(&import_field_uses, &alias);
                 // For zip packages, extract to temp dir and eval as local file
                 if let PackageSource::Zip(zip_url, _) = &pkg {
-                    let pkg_dir = self.extract_package_zip(zip_url).await?;
-                    let local_path = pkg_dir.join(file_path);
-                    let imported_val = self
-                        .eval_file_with_requested_fields(&local_path, depth + 1, requested)
-                        .await?;
-                    scope.set(alias, imported_val);
-                    continue;
+                    #[cfg(feature = "package-zip")]
+                    {
+                        let pkg_dir = self.extract_package_zip(zip_url).await?;
+                        let local_path = pkg_dir.join(file_path);
+                        let imported_val = self
+                            .eval_file_with_requested_fields(&local_path, depth + 1, requested)
+                            .await?;
+                        scope.set(alias, imported_val);
+                        continue;
+                    }
+                    #[cfg(not(feature = "package-zip"))]
+                    {
+                        return Err(Error::Unsupported(format!(
+                            "package zip imports require pklr's 'package-zip' feature: {zip_url}"
+                        )));
+                    }
                 }
                 let url = match &pkg {
                     PackageSource::Direct(url) => url.clone(),
@@ -709,24 +765,33 @@ impl Evaluator {
             } else if uri.starts_with("package://") {
                 let pkg = resolve_package_uri(uri)?;
                 if let PackageSource::Zip(zip_url, entry) = &pkg {
-                    let pkg_dir = self.extract_package_zip(zip_url).await?;
-                    let local_path = pkg_dir.join(entry);
-                    let source = std::fs::read_to_string(&local_path)
-                        .map_err(|e| Error::Io(local_path.clone(), e))?;
-                    let name = local_path.display().to_string();
-                    let tokens = lexer::lex_named(&source, &name)?;
-                    let base_module = parser::parse_named(&tokens, &source, &name)?;
-                    let base_val = self
-                        .eval_module_with_scope(
-                            &base_module,
-                            &local_path,
-                            depth + 1,
-                            Some(scope.clone()),
-                            None,
-                        )
-                        .await?;
-                    if let Value::Object(m, _) = base_val {
-                        base_obj = (*m).clone();
+                    #[cfg(feature = "package-zip")]
+                    {
+                        let pkg_dir = self.extract_package_zip(zip_url).await?;
+                        let local_path = pkg_dir.join(entry);
+                        let source = self.capabilities.read_to_string(&local_path).await?;
+                        let name = local_path.display().to_string();
+                        let tokens = lexer::lex_named(&source, &name)?;
+                        let base_module = parser::parse_named(&tokens, &source, &name)?;
+                        let base_val = self
+                            .eval_module_with_scope(
+                                &base_module,
+                                &local_path,
+                                depth + 1,
+                                Some(scope.clone()),
+                                None,
+                            )
+                            .await?;
+                        if let Value::Object(m, _) = base_val {
+                            base_obj = (*m).clone();
+                        }
+                    }
+                    #[cfg(not(feature = "package-zip"))]
+                    {
+                        let _ = entry;
+                        return Err(Error::Unsupported(format!(
+                            "package zip imports require pklr's 'package-zip' feature: {zip_url}"
+                        )));
                     }
                 } else if let PackageSource::Direct(url) = &pkg {
                     let source = self.fetch_source(url).await?;
@@ -781,36 +846,10 @@ impl Evaluator {
         if let Some(amends_uri) = &module.amends {
             let resolved_amends = resolve_remote_relative(path, amends_uri);
             let uri: &str = resolved_amends.as_deref().unwrap_or(amends_uri);
-            let base_source = if uri.starts_with("https://") || uri.starts_with("http://") {
-                // HTTP source was already fetched and cached
-                self.http_cache.get(uri).cloned()
-            } else if uri.starts_with("package://") {
-                // For package:// URIs with Direct source, the source was cached
-                if let Ok(pkg) = resolve_package_uri(uri) {
-                    match &pkg {
-                        PackageSource::Direct(url) => self.http_cache.get(url).cloned(),
-                        PackageSource::Zip(zip_url, entry) => {
-                            // For zip packages, read from the extracted directory
-                            self.package_dir_for_zip(zip_url)
-                                .and_then(|dir| std::fs::read_to_string(dir.join(entry)).ok())
-                        }
-                    }
-                } else {
-                    None
-                }
-            } else if !uri.starts_with("pkl:")
-                && (!uri.contains("://") || uri.starts_with("file://"))
-            {
-                let amends_path = if let Some(rel) = uri.strip_prefix("file://") {
-                    PathBuf::from(rel)
-                } else {
-                    let base = path.parent().unwrap_or(Path::new("."));
-                    base.join(uri)
-                };
-                std::fs::read_to_string(&amends_path).ok()
-            } else {
-                None
-            };
+            let base_source = self
+                .load_module_source(uri, path)
+                .await?
+                .map(|(source, _)| source);
             if let Some(src) = base_source
                 && let Ok(tokens) = lexer::lex(&src)
                 && let Ok(base_module) = parser::parse(&tokens)
@@ -864,8 +903,7 @@ impl Evaluator {
                         .eval_file_with_scope(&extends_path, depth + 1, Some(scope.clone()))
                         .await?;
                     let name = extends_path.display().to_string();
-                    let source = std::fs::read_to_string(&extends_path)
-                        .map_err(|e| Error::Io(extends_path.clone(), e))?;
+                    let source = self.capabilities.read_to_string(&extends_path).await?;
                     let tokens = lexer::lex_named(&source, &name)?;
                     let ext_module = parser::parse_named(&tokens, &source, &name)?;
                     if let Value::Object(m, _) = &ext_val {
@@ -3428,13 +3466,6 @@ fn object_declares_field(value: &Value, field: &str) -> bool {
         })
 }
 
-fn parse_file(path: &Path) -> Result<Module> {
-    let source = std::fs::read_to_string(path).map_err(|e| Error::Io(path.to_path_buf(), e))?;
-    let name = path.display().to_string();
-    let tokens = lexer::lex_named(&source, &name)?;
-    parser::parse_named(&tokens, &source, &name)
-}
-
 fn analysis_entries_for_requested_fields(
     entries: &[Entry],
     requested_fields: Option<&HashSet<String>>,
@@ -4660,10 +4691,33 @@ fn resolve_remote_relative(current_path: &Path, uri: &str) -> Option<String> {
     if !(base.starts_with("http://") || base.starts_with("https://")) {
         return None;
     }
-    reqwest::Url::parse(base)
-        .ok()
-        .and_then(|base| base.join(uri).ok())
-        .map(|url| url.to_string())
+    resolve_http_relative(base, uri)
+}
+
+fn resolve_http_relative(base: &str, uri: &str) -> Option<String> {
+    let scheme_end = base.find("://")? + 3;
+    let (origin, base_path) = match base[scheme_end..].find('/') {
+        Some(path_start) => base.split_at(scheme_end + path_start),
+        None => (base, ""),
+    };
+    if uri.starts_with('/') {
+        return Some(format!("{origin}{uri}"));
+    }
+    let base_dir = base_path
+        .rsplit_once('/')
+        .map(|(dir, _)| format!("{dir}/"))
+        .unwrap_or_else(|| "/".to_string());
+    let mut segments = Vec::new();
+    for segment in base_dir.split('/').chain(uri.split('/')) {
+        match segment {
+            "" | "." => {}
+            ".." => {
+                segments.pop();
+            }
+            segment => segments.push(segment),
+        }
+    }
+    Some(format!("{origin}/{}", segments.join("/")))
 }
 
 fn same_local_path(left: &Path, right: &Path) -> bool {
@@ -4724,9 +4778,12 @@ fn collection_to_items(v: Value) -> Vec<(Value, Value)> {
 
 #[cfg(test)]
 mod package_uri_tests {
+    #[cfg(all(feature = "native-io", feature = "package-zip"))]
     use std::path::PathBuf;
 
-    use super::{Evaluator, PackageSource, resolve_package_uri};
+    #[cfg(all(feature = "native-io", feature = "package-zip"))]
+    use super::Evaluator;
+    use super::{PackageSource, resolve_package_uri};
 
     #[test]
     fn generic_package_uri_resolves_to_zip_url() {
@@ -4742,6 +4799,7 @@ mod package_uri_tests {
     }
 
     #[test]
+    #[cfg(all(feature = "native-io", feature = "package-zip"))]
     fn package_dir_lookup_uses_rewritten_zip_url() {
         let mut evaluator = Evaluator::new();
         evaluator.set_http_rewrites(&["https://example.com/=https://mirror.local/".to_string()]);

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -23,9 +23,6 @@ pub struct Evaluator {
     import_cache: HashMap<PathBuf, Value>,
     /// Local files currently being evaluated with inherited scope.
     scoped_imports_in_flight: HashSet<PathBuf>,
-    /// Reusable HTTP client for connection pooling
-    #[cfg(feature = "http")]
-    http_client: reqwest::Client,
     /// Host-provided IO for files, environment, HTTP, packages, and globs.
     capabilities: Box<dyn EvalCapabilities>,
     /// Extracted package zip directories (zip URL → temp dir path)
@@ -65,9 +62,7 @@ impl Default for Evaluator {
             http_cache: HashMap::new(),
             import_cache: HashMap::new(),
             scoped_imports_in_flight: HashSet::new(),
-            #[cfg(feature = "http")]
-            http_client: reqwest::Client::new(),
-            capabilities: Box::new(crate::capabilities::NativeCapabilities),
+            capabilities: Box::new(crate::capabilities::NativeCapabilities::new()),
             #[cfg(feature = "package-zip")]
             package_dirs: HashMap::new(),
             http_rewrites: Vec::new(),
@@ -90,8 +85,6 @@ impl Evaluator {
             http_cache: HashMap::new(),
             import_cache: HashMap::new(),
             scoped_imports_in_flight: HashSet::new(),
-            #[cfg(feature = "http")]
-            http_client: reqwest::Client::new(),
             capabilities: Box::new(capabilities),
             #[cfg(feature = "package-zip")]
             package_dirs: HashMap::new(),
@@ -109,7 +102,7 @@ impl Evaluator {
     /// Use this to configure proxy settings, CA certificates, timeouts, etc.
     #[cfg(feature = "http")]
     pub fn set_http_client(&mut self, client: reqwest::Client) {
-        self.http_client = client;
+        self.capabilities.set_http_client(client);
     }
 
     /// Add HTTP URL rewrite rules. Each rule is a `"source_prefix=target_prefix"` string
@@ -213,19 +206,6 @@ impl Evaluator {
         } else {
             fetch_url.to_string()
         };
-        #[cfg(feature = "http")]
-        let body = self
-            .http_client
-            .get(fetch_url)
-            .send()
-            .await
-            .map_err(|e| Error::Eval(format!("HTTP fetch failed for {err_ctx}: {e}")))?
-            .error_for_status()
-            .map_err(|e| Error::Eval(format!("HTTP error for {err_ctx}: {e}")))?
-            .text()
-            .await
-            .map_err(|e| Error::Eval(format!("HTTP read failed for {err_ctx}: {e}")))?;
-        #[cfg(not(feature = "http"))]
         let body = self
             .capabilities
             .fetch_text(fetch_url)
@@ -4696,8 +4676,18 @@ fn resolve_remote_relative(current_path: &Path, uri: &str) -> Option<String> {
 
 fn resolve_http_relative(base: &str, uri: &str) -> Option<String> {
     let scheme_end = base.find("://")? + 3;
-    let (origin, base_path) = match base[scheme_end..].find('/') {
-        Some(path_start) => base.split_at(scheme_end + path_start),
+    let authority_end = base[scheme_end..]
+        .find(['/', '?', '#'])
+        .map(|offset| scheme_end + offset);
+    let (origin, base_path) = match authority_end {
+        Some(path_start) if base[path_start..].starts_with('/') => {
+            let (origin, path_and_suffix) = base.split_at(path_start);
+            let path_end = path_and_suffix
+                .find(['?', '#'])
+                .unwrap_or(path_and_suffix.len());
+            (origin, &path_and_suffix[..path_end])
+        }
+        Some(path_start) => base.split_at(path_start),
         None => (base, ""),
     };
     if uri.starts_with('/') {
@@ -4718,6 +4708,47 @@ fn resolve_http_relative(base: &str, uri: &str) -> Option<String> {
         }
     }
     Some(format!("{origin}/{}", segments.join("/")))
+}
+
+#[cfg(test)]
+mod remote_relative_tests {
+    use super::resolve_http_relative;
+
+    #[test]
+    fn http_relative_resolves_against_base_directory() {
+        assert_eq!(
+            resolve_http_relative("https://example.com/cfg/Main.pkl", "../Lib.pkl").as_deref(),
+            Some("https://example.com/Lib.pkl")
+        );
+    }
+
+    #[test]
+    fn http_relative_ignores_base_query_and_fragment() {
+        assert_eq!(
+            resolve_http_relative(
+                "https://example.com/cfg/Main.pkl?version=2#part",
+                "../Lib.pkl"
+            )
+            .as_deref(),
+            Some("https://example.com/Lib.pkl")
+        );
+    }
+
+    #[test]
+    fn http_relative_keeps_absolute_path_references_absolute() {
+        assert_eq!(
+            resolve_http_relative("https://example.com/cfg/Main.pkl", "/shared/Lib.pkl").as_deref(),
+            Some("https://example.com/shared/Lib.pkl")
+        );
+    }
+
+    #[test]
+    fn http_relative_clamps_above_root_segments() {
+        assert_eq!(
+            resolve_http_relative("https://example.com/Main.pkl", "../../Lib.pkl").as_deref(),
+            Some("https://example.com/Lib.pkl")
+        );
+    }
 }
 
 fn same_local_path(left: &Path, right: &Path) -> bool {

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -201,16 +201,7 @@ impl Evaluator {
         if let Some(cached) = self.http_cache.get(fetch_url) {
             return Ok(cached.clone());
         }
-        let err_ctx = if fetch_url != url {
-            format!("{url} (rewritten to {fetch_url})")
-        } else {
-            fetch_url.to_string()
-        };
-        let body = self
-            .capabilities
-            .fetch_text(fetch_url)
-            .await
-            .map_err(|error| Error::Eval(format!("HTTP fetch failed for {err_ctx}: {error}")))?;
+        let body = self.capabilities.fetch_text(fetch_url).await?;
         self.http_cache.insert(fetch_url.to_string(), body.clone());
         Ok(body)
     }
@@ -310,16 +301,7 @@ impl Evaluator {
         if let Some(dir) = self.package_dirs.get(fetch_url) {
             return Ok(dir.clone());
         }
-        let err_ctx = if fetch_url != zip_url {
-            format!("{zip_url} (rewritten to {fetch_url})")
-        } else {
-            fetch_url.to_string()
-        };
-        let bytes = self
-            .capabilities
-            .fetch_bytes(fetch_url)
-            .await
-            .map_err(|e| Error::Eval(format!("HTTP read failed for {err_ctx}: {e}")))?;
+        let bytes = self.capabilities.fetch_bytes(fetch_url).await?;
         let cursor = std::io::Cursor::new(bytes);
         let mut archive =
             zip::ZipArchive::new(cursor).map_err(|e| Error::Eval(format!("zip error: {e}")))?;

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -135,11 +135,7 @@ impl<'a> Lexer<'a> {
     }
 
     fn lex_error(&self, message: impl Into<String>) -> Error {
-        Error::Lex {
-            src: miette::NamedSource::new(&self.name, self.source.to_string()),
-            span: miette::SourceOffset::from(self.pos),
-            message: message.into(),
-        }
+        Error::lex(&self.name, self.source, self.pos, message.into())
     }
 
     fn peek(&self) -> Option<char> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,28 +1,43 @@
+#[cfg(feature = "eval-core")]
+pub mod capabilities;
 pub mod error;
+#[cfg(feature = "eval-core")]
 pub mod eval;
 pub mod lexer;
 pub mod parser;
+#[cfg(feature = "eval-core")]
 pub mod value;
 
+#[cfg(feature = "eval-core")]
+pub use capabilities::EvalCapabilities;
+#[cfg(feature = "native-io")]
+pub use capabilities::NativeCapabilities;
 pub use error::{Error, Result};
+#[cfg(feature = "eval-core")]
 pub use eval::Evaluator;
+#[cfg(feature = "eval-core")]
 pub use value::Value;
 
 /// Re-export reqwest so consumers can build a Client without a separate dependency.
+#[cfg(feature = "http")]
 pub use reqwest;
 
+#[cfg(feature = "native-io")]
 use std::path::Path;
 
 /// Evaluate a pkl file and return its contents as a JSON value.
 /// This is the primary entry point for use in tools like hk.
+#[cfg(feature = "native-io")]
 pub async fn eval_to_json(path: &Path) -> Result<serde_json::Value> {
     eval_to_json_with_client(path, None).await
 }
 
 /// Options for configuring the pkl evaluator.
+#[cfg(feature = "native-io")]
 #[derive(Default)]
 pub struct EvalOptions {
     /// Custom HTTP client for proxy/CA configuration.
+    #[cfg(feature = "http")]
     pub client: Option<reqwest::Client>,
     /// HTTP URL rewrite rules in `"source_prefix=target_prefix"` format.
     /// Matches pkl CLI's `--http-rewrite` behavior: longest matching prefix wins.
@@ -30,6 +45,7 @@ pub struct EvalOptions {
 }
 
 /// Evaluate a pkl file with a custom HTTP client for proxy/CA configuration.
+#[cfg(all(feature = "native-io", feature = "http"))]
 pub async fn eval_to_json_with_client(
     path: &Path,
     client: Option<reqwest::Client>,
@@ -44,7 +60,16 @@ pub async fn eval_to_json_with_client(
     .await
 }
 
+#[cfg(all(feature = "native-io", not(feature = "http")))]
+pub async fn eval_to_json_with_client(
+    path: &Path,
+    _client: Option<()>,
+) -> Result<serde_json::Value> {
+    eval_to_json_with_options(path, EvalOptions::default()).await
+}
+
 /// Evaluate a pkl file with full configuration options.
+#[cfg(feature = "native-io")]
 pub async fn eval_to_json_with_options(
     path: &Path,
     options: EvalOptions,
@@ -52,6 +77,7 @@ pub async fn eval_to_json_with_options(
     let source = std::fs::read_to_string(path).map_err(|e| Error::Io(path.to_path_buf(), e))?;
     let mut evaluator = Evaluator::new();
     evaluator.set_base_path(path.parent().unwrap_or(Path::new(".")));
+    #[cfg(feature = "http")]
     if let Some(client) = options.client {
         evaluator.set_http_client(client);
     }
@@ -64,6 +90,7 @@ pub async fn eval_to_json_with_options(
 }
 
 /// Analyze imports of a pkl file, returning all transitive local file dependencies.
+#[cfg(feature = "native-io")]
 pub fn analyze_imports(path: &Path) -> Result<Vec<std::path::PathBuf>> {
     let mut results = Vec::new();
     let mut visited = std::collections::HashSet::new();
@@ -72,6 +99,7 @@ pub fn analyze_imports(path: &Path) -> Result<Vec<std::path::PathBuf>> {
     Ok(results)
 }
 
+#[cfg(feature = "native-io")]
 fn analyze_imports_inner(
     path: &Path,
     visited: &mut std::collections::HashSet<std::path::PathBuf>,

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -232,11 +232,7 @@ impl<'a> Parser<'a> {
 
     fn parse_error(&self, message: impl Into<String>) -> Error {
         let tok = self.peek_tok();
-        Error::Parse {
-            src: miette::NamedSource::new(&self.name, self.source.clone()),
-            span: miette::SourceOffset::from(tok.offset),
-            message: message.into(),
-        }
+        Error::parse(&self.name, &self.source, tok.offset, message.into())
     }
 
     fn peek(&self) -> &TokenKind {
@@ -1393,11 +1389,12 @@ impl<'a> Parser<'a> {
         if let TokenKind::StringLit(s) = kind {
             Ok(s)
         } else {
-            Err(Error::Parse {
-                src: miette::NamedSource::new(&self.name, self.source.clone()),
-                span: miette::SourceOffset::from(offset),
-                message: format!("expected string, got {:?}", kind),
-            })
+            Err(Error::parse(
+                &self.name,
+                &self.source,
+                offset,
+                format!("expected string, got {:?}", kind),
+            ))
         }
     }
 
@@ -1413,11 +1410,12 @@ impl<'a> Parser<'a> {
             TokenKind::KwHidden => Ok("hidden".into()),
             TokenKind::KwNew => Ok("new".into()),
             TokenKind::KwModule => Ok("module".into()),
-            other => Err(Error::Parse {
-                src: miette::NamedSource::new(&self.name, self.source.clone()),
-                span: miette::SourceOffset::from(offset),
-                message: format!("expected identifier, got {:?}", other),
-            }),
+            other => Err(Error::parse(
+                &self.name,
+                &self.source,
+                offset,
+                format!("expected identifier, got {:?}", other),
+            )),
         }
     }
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -590,6 +590,26 @@ async fn native_capabilities_fetch_bytes_uses_configured_client() {
     assert_eq!(bytes, b"zip-bytes");
 }
 
+#[tokio::test]
+async fn native_capabilities_map_not_found_to_import_errors() {
+    let base = spawn_test_http_server(vec![]);
+    let mut capabilities = pklr::NativeCapabilities::new();
+
+    let text_url = format!("{base}/missing.pkl");
+    let text_error = capabilities.fetch_text(&text_url).await.unwrap_err();
+    assert!(matches!(
+        text_error,
+        pklr::Error::ImportNotFound(url) if url == text_url
+    ));
+
+    let bytes_url = format!("{base}/missing.zip");
+    let bytes_error = capabilities.fetch_bytes(&bytes_url).await.unwrap_err();
+    assert!(matches!(
+        bytes_error,
+        pklr::Error::ImportNotFound(url) if url == bytes_url
+    ));
+}
+
 /// A module loaded over HTTP that itself uses a relative `import` should
 /// resolve that import against its own (HTTP) URL, not the local filesystem.
 #[tokio::test]

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1,9 +1,98 @@
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
+
+use pklr::capabilities::{BoxFuture, EvalCapabilities};
 use pklr::eval::Evaluator;
 use pklr::lexer::{TokenKind, lex};
 use pklr::parser::{collect_imports, parse};
 
 fn lex_kinds(src: &str) -> Vec<TokenKind> {
     lex(src).unwrap().into_iter().map(|t| t.kind).collect()
+}
+
+struct MemoryCapabilities {
+    modules: HashMap<String, String>,
+    fetches: Arc<Mutex<Vec<String>>>,
+}
+
+impl EvalCapabilities for MemoryCapabilities {
+    fn read_to_string<'a>(&'a mut self, path: &'a Path) -> BoxFuture<'a, pklr::Result<String>> {
+        let path = path.display().to_string();
+        Box::pin(async move { Err(pklr::Error::ImportNotFound(path)) })
+    }
+
+    fn read_env<'a>(&'a mut self, _name: &'a str) -> BoxFuture<'a, pklr::Result<Option<String>>> {
+        Box::pin(async move { Ok(None) })
+    }
+
+    fn fetch_text<'a>(&'a mut self, url: &'a str) -> BoxFuture<'a, pklr::Result<String>> {
+        self.fetches.lock().unwrap().push(url.to_string());
+        let source = self.modules.get(url).cloned();
+        let url = url.to_string();
+        Box::pin(async move { source.ok_or(pklr::Error::ImportNotFound(url)) })
+    }
+
+    fn fetch_bytes<'a>(&'a mut self, url: &'a str) -> BoxFuture<'a, pklr::Result<Vec<u8>>> {
+        let url = url.to_string();
+        Box::pin(async move {
+            Err(pklr::Error::Unsupported(format!(
+                "byte fetch unavailable in test capabilities: {url}"
+            )))
+        })
+    }
+
+    fn temp_dir<'a>(&'a mut self, prefix: &'a str) -> BoxFuture<'a, pklr::Result<PathBuf>> {
+        let prefix = prefix.to_string();
+        Box::pin(async move {
+            Err(pklr::Error::Unsupported(format!(
+                "temp dir unavailable in test capabilities: {prefix}"
+            )))
+        })
+    }
+
+    fn glob<'a>(
+        &'a mut self,
+        _base: &'a Path,
+        _pattern: &'a str,
+    ) -> BoxFuture<'a, pklr::Result<Vec<PathBuf>>> {
+        Box::pin(async move { Ok(Vec::new()) })
+    }
+}
+
+#[test]
+fn evaluator_is_send() {
+    fn assert_send<T: Send>() {}
+    assert_send::<pklr::Evaluator>();
+}
+
+#[tokio::test]
+async fn custom_capabilities_handle_http_import() {
+    let fetches = Arc::new(Mutex::new(Vec::new()));
+    let mut modules = HashMap::new();
+    modules.insert(
+        "http://example.test/Main.pkl".to_string(),
+        "value = 42\n".to_string(),
+    );
+
+    let mut evaluator = pklr::Evaluator::with_capabilities(MemoryCapabilities {
+        modules,
+        fetches: fetches.clone(),
+    });
+    let json = evaluator
+        .eval_source(
+            "import \"http://example.test/Main.pkl\" as Main\nresult = Main.value\n",
+            Path::new("entry.pkl"),
+        )
+        .await
+        .unwrap()
+        .to_json();
+
+    assert_eq!(json["result"], 42);
+    assert_eq!(
+        *fetches.lock().unwrap(),
+        vec!["http://example.test/Main.pkl".to_string()]
+    );
 }
 
 // --- Lexer tests ---
@@ -399,6 +488,85 @@ fn spawn_test_http_server(routes: Vec<(&'static str, &'static str)>) -> String {
     });
 
     format!("http://127.0.0.1:{port}")
+}
+
+fn spawn_header_check_http_server(
+    path: &'static str,
+    header_name: &'static str,
+    header_value: &'static str,
+    body: &'static str,
+) -> String {
+    use std::io::{BufRead, BufReader, Write};
+    use std::net::TcpListener;
+
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let port = listener.local_addr().unwrap().port();
+    let expected_header = format!("{}: {}", header_name.to_ascii_lowercase(), header_value);
+
+    std::thread::spawn(move || {
+        for stream in listener.incoming() {
+            let mut stream = match stream {
+                Ok(s) => s,
+                Err(_) => continue,
+            };
+            let mut reader = BufReader::new(stream.try_clone().unwrap());
+            let mut request_line = String::new();
+            if reader.read_line(&mut request_line).is_err() {
+                continue;
+            }
+            let request_path = request_line.split_whitespace().nth(1).unwrap_or("/");
+            let mut has_header = false;
+            loop {
+                let mut line = String::new();
+                match reader.read_line(&mut line) {
+                    Ok(0) => break,
+                    Ok(_) if line == "\r\n" || line == "\n" => break,
+                    Ok(_) => {
+                        if line.trim_end().to_ascii_lowercase() == expected_header {
+                            has_header = true;
+                        }
+                    }
+                    Err(_) => break,
+                }
+            }
+            let response = if request_path == path && has_header {
+                format!(
+                    "HTTP/1.1 200 OK\r\nContent-Type: application/octet-stream\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                    body.len(),
+                    body
+                )
+            } else {
+                "HTTP/1.1 403 Forbidden\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
+                    .to_string()
+            };
+            let _ = stream.write_all(response.as_bytes());
+            let _ = stream.flush();
+        }
+    });
+
+    format!("http://127.0.0.1:{port}")
+}
+
+#[tokio::test]
+async fn native_capabilities_fetch_bytes_uses_configured_client() {
+    let base = spawn_header_check_http_server("/pkg.zip", "x-pklr-test", "ok", "zip-bytes");
+    let mut headers = pklr::reqwest::header::HeaderMap::new();
+    headers.insert(
+        pklr::reqwest::header::HeaderName::from_static("x-pklr-test"),
+        pklr::reqwest::header::HeaderValue::from_static("ok"),
+    );
+    let client = pklr::reqwest::Client::builder()
+        .default_headers(headers)
+        .build()
+        .unwrap();
+    let mut capabilities = pklr::NativeCapabilities::with_http_client(client);
+
+    let bytes = capabilities
+        .fetch_bytes(&format!("{base}/pkg.zip"))
+        .await
+        .unwrap();
+
+    assert_eq!(bytes, b"zip-bytes");
 }
 
 /// A module loaded over HTTP that itself uses a relative `import` should

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -95,6 +95,27 @@ async fn custom_capabilities_handle_http_import() {
     );
 }
 
+#[tokio::test]
+async fn custom_capabilities_preserve_fetch_errors() {
+    let fetches = Arc::new(Mutex::new(Vec::new()));
+    let mut evaluator = pklr::Evaluator::with_capabilities(MemoryCapabilities {
+        modules: HashMap::new(),
+        fetches,
+    });
+    let error = evaluator
+        .eval_source(
+            "import \"http://example.test/missing.pkl\" as Missing\nresult = Missing.value\n",
+            Path::new("entry.pkl"),
+        )
+        .await
+        .unwrap_err();
+
+    assert!(matches!(
+        error,
+        pklr::Error::ImportNotFound(url) if url == "http://example.test/missing.pkl"
+    ));
+}
+
 // --- Lexer tests ---
 
 #[test]

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -18,8 +18,20 @@ struct MemoryCapabilities {
 
 impl EvalCapabilities for MemoryCapabilities {
     fn read_to_string<'a>(&'a mut self, path: &'a Path) -> BoxFuture<'a, pklr::Result<String>> {
-        let path = path.display().to_string();
-        Box::pin(async move { Err(pklr::Error::ImportNotFound(path)) })
+        let key = path.display().to_string();
+        let source = self.modules.get(&key).cloned();
+        Box::pin(async move { source.ok_or(pklr::Error::ImportNotFound(key)) })
+    }
+
+    fn path_exists<'a>(&'a mut self, path: &'a Path) -> BoxFuture<'a, pklr::Result<bool>> {
+        let key = path.display().to_string();
+        let exists = self.modules.contains_key(&key);
+        Box::pin(async move { Ok(exists) })
+    }
+
+    fn canonicalize<'a>(&'a mut self, path: &'a Path) -> BoxFuture<'a, pklr::Result<PathBuf>> {
+        let path = path.to_path_buf();
+        Box::pin(async move { Ok(path) })
     }
 
     fn read_env<'a>(&'a mut self, _name: &'a str) -> BoxFuture<'a, pklr::Result<Option<String>>> {
@@ -114,6 +126,27 @@ async fn custom_capabilities_preserve_fetch_errors() {
         error,
         pklr::Error::ImportNotFound(url) if url == "http://example.test/missing.pkl"
     ));
+}
+
+#[tokio::test]
+async fn custom_capabilities_handle_virtual_local_import() {
+    let mut modules = HashMap::new();
+    modules.insert("virtual/Main.pkl".to_string(), "value = 42\n".to_string());
+
+    let mut evaluator = pklr::Evaluator::with_capabilities(MemoryCapabilities {
+        modules,
+        fetches: Arc::new(Mutex::new(Vec::new())),
+    });
+    let json = evaluator
+        .eval_source(
+            "import \"Main.pkl\" as Main\nresult = Main.value\n",
+            Path::new("virtual/entry.pkl"),
+        )
+        .await
+        .unwrap()
+        .to_json();
+
+    assert_eq!(json["result"], 42);
 }
 
 // --- Lexer tests ---


### PR DESCRIPTION
This keeps the default evaluator build unchanged.

It also lets parser-only users depend on `pklr` without native IO and lets hosts provide evaluator IO through `EvalCapabilities`.

Validation:

- `cargo fmt --check`
- `cargo test`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test --no-default-features --features parse`
- `cargo test --no-default-features --features eval-core`
- `cargo test --no-default-features --features eval-core,native-io`
- `cargo test --no-default-features --features eval-core,native-io,http,package-zip,miette-diagnostics`
- `cargo msrv verify`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Cargo feature flags for parsing/evaluation, native I/O, HTTP access, package ZIP support, and optional diagnostics.
  * Introduced a host-provided `EvalCapabilities` interface for routing evaluation I/O, enabling custom capability injection.
  * Added evaluator entry points for custom capabilities and feature-gated default/native capability support.

* **Bug Fixes**
  * Improved parse/lex error consistency across diagnostic modes with clearer error construction helpers.

* **Tests**
  * Expanded integration coverage with custom in-memory capabilities and hermetic HTTP server checks, including validation of configurable HTTP client behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->