### PR TITLE
chore: release v1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.0](https://github.com/jdx/pklr/compare/v1.1.3...v1.2.0) - 2026-07-16
+
+### Added
+
+- support parser-only and capability-backed builds ([#131](https://github.com/jdx/pklr/pull/131))
+
+### Fixed
+
+- *(eval)* restore evaluator sync compatibility ([#135](https://github.com/jdx/pklr/pull/135))
+
 ## [1.1.3](https://github.com/jdx/pklr/compare/v1.1.2...v1.1.3) - 2026-07-06
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -677,7 +677,7 @@ checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "pklr"
-version = "1.1.3"
+version = "1.2.0"
 dependencies = [
  "async-recursion",
  "indexmap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "pklr"
-version     = "1.1.3"
+version     = "1.2.0"
 edition      = "2024"
 rust-version = "1.88"
 description = "Pure Rust pkl configuration language parser and evaluator"


### PR DESCRIPTION



## 🤖 New release

* `pklr`: 1.1.3 -> 1.2.0 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [1.2.0](https://github.com/jdx/pklr/compare/v1.1.3...v1.2.0) - 2026-07-16

### Added

- support parser-only and capability-backed builds ([#131](https://github.com/jdx/pklr/pull/131))

### Fixed

- *(eval)* restore evaluator sync compatibility ([#135](https://github.com/jdx/pklr/pull/135))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only release (version and changelog); no source or behavior changes in this PR.
> 
> **Overview**
> Bumps the **pklr** crate from **1.1.3** to **1.2.0** in `Cargo.toml` and `Cargo.lock`, and publishes the **1.2.0** section in `CHANGELOG.md` (dated 2026-07-16).
> 
> The changelog for this release documents **parser-only / capability-backed Cargo feature builds** ([#131]) and a fix to **restore evaluator sync compatibility** ([#135]); those changes landed in earlier PRs—this diff only cuts the release metadata.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a7c54d02bc1169fd7df6dc4d507072b20b10d4f4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->