### PR TITLE
fix(eval): restore evaluator sync compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,8 +41,19 @@ jobs:
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       - uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
       - run: cargo msrv verify
+  semver:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
+      - name: Check for breaking API changes
+        uses: obi1kenobi/cargo-semver-checks-action@6b69fcf40e9b5fb17adeb57e4b6ecd020649a239 # v2
   final:
-    needs: [test, msrv]
+    needs: [test, msrv, semver]
     runs-on: ubuntu-latest
     timeout-minutes: 1
     permissions: {}
@@ -52,7 +63,7 @@ jobs:
     steps:
       - name: Check CI job results
         run: |
-          results=("${{ needs.test.result }}" "${{ needs.msrv.result }}")
+          results=("${{ needs.test.result }}" "${{ needs.msrv.result }}" "${{ needs.semver.result }}")
           for r in "${results[@]}"; do
             if [ "$r" != "success" ]; then
               echo "CI job failed or was skipped"

--- a/src/capabilities.rs
+++ b/src/capabilities.rs
@@ -14,7 +14,7 @@ pub type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + 'a>>;
 ///
 /// The default evaluator still uses the native implementation, but embedders
 /// can provide their own file, environment, HTTP, temp-dir, and glob behavior.
-pub trait EvalCapabilities: Send {
+pub trait EvalCapabilities: Send + Sync {
     fn read_to_string<'a>(&'a mut self, path: &'a Path) -> BoxFuture<'a, Result<String>>;
 
     fn path_exists<'a>(&'a mut self, path: &'a Path) -> BoxFuture<'a, Result<bool>>;

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,3 +1,7 @@
+// The Lex/Parse variant fields are read by miette's Diagnostic derive macro,
+// but rustc can't see through the proc-macro expansion.
+#![allow(unused_assignments)]
+
 use std::path::PathBuf;
 
 #[cfg(feature = "miette-diagnostics")]

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -4802,6 +4802,18 @@ fn collection_to_items(v: Value) -> Vec<(Value, Value)> {
 }
 
 #[cfg(test)]
+mod auto_trait_tests {
+    use super::Evaluator;
+
+    #[test]
+    fn evaluator_is_sync() {
+        fn assert_sync<T: Sync>() {}
+
+        assert_sync::<Evaluator>();
+    }
+}
+
+#[cfg(test)]
 mod package_uri_tests {
     #[cfg(all(feature = "native-io", feature = "package-zip"))]
     use std::path::PathBuf;


### PR DESCRIPTION
## Summary

- require host-provided evaluation capabilities to be `Sync`, restoring the `Evaluator: Sync` API from v1.1.3
- add a compile-time regression test for the auto-trait guarantee
- add `cargo-semver-checks` to pull request CI and include it in the aggregate `final` job
- restore the narrow `unused_assignments` allowance required by the `miette` derive macro so Clippy remains green

## Root cause

PR #131 changed `Evaluator` from storing a `reqwest::Client` to storing `Box<dyn EvalCapabilities>`. The new trait required `Send` but not `Sync`, so the public evaluator silently lost its `Sync` auto-trait. Release-plz detected that only after merge and proposed a semver-major release in PR #134.

The new CI job compares each PR against the latest published crate and fails on accidental breaking API changes before they reach `main`.

## Validation

- `cargo fmt --check`
- `cargo test`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test --no-default-features --features parse`
- `cargo test --no-default-features --features eval-core`
- `cargo test --no-default-features --features eval-core,native-io`
- `cargo semver-checks --baseline-version 1.1.3` (223 checks passed)

*This pull request was generated by Codex.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Public trait bound change affects custom capability implementations; otherwise the change is narrow API/CI hardening with low runtime risk.
> 
> **Overview**
> Restores the **v1.1.3 public guarantee** that `Evaluator` is `Sync` by extending `EvalCapabilities` from `Send` to **`Send + Sync`**, which was lost when the evaluator started holding `Box<dyn EvalCapabilities>`.
> 
> Adds a **compile-time regression test** (`assert_sync::<Evaluator>()`) and wires **`cargo-semver-checks`** into CI as a new `semver` job, with the aggregate `final` job failing if semver (or test/msrv) does not succeed.
> 
> Re-adds `#![allow(unused_assignments)]` on `error.rs` so **Clippy stays green** with the `miette::Diagnostic` derive on `Lex`/`Parse` variants.
> 
> **Embedders** with custom `EvalCapabilities` implementations must now be `Sync` as well as `Send`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 62b11631946ccacbf3fcae2504ff26172f3ef4dd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Reliability**
  * Improved thread-safety guarantees for evaluation components, supporting safer concurrent usage.

* **Quality Improvements**
  * Added automated checks to detect breaking API changes before release.
  * Expanded verification of concurrent evaluation behavior.
  * Improved compiler and diagnostic handling for more reliable builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->