### PR TITLE
feat: add blocking evaluation API

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,8 @@ native-io = ["eval-core"]
 http = ["eval-core", "dep:reqwest"]
 package-zip = ["http", "native-io", "dep:zip"]
 miette-diagnostics = ["dep:miette"]
+tokio = ["dep:tokio"]
+blocking = ["native-io", "tokio"]
 
 [dependencies]
 indexmap    = "2"

--- a/README.md
+++ b/README.md
@@ -16,8 +16,15 @@ No external binary or CLI required.
 ```rust
 use pklr::eval_to_json;
 
-let json = eval_to_json(std::path::Path::new("config.pkl"))?;
+let json = eval_to_json(std::path::Path::new("config.pkl")).await?;
 println!("{}", json);
+```
+
+Synchronous applications can enable the `blocking` feature and use the
+blocking entry point:
+
+```rust
+let json = pklr::eval_to_json_blocking(std::path::Path::new("config.pkl"))?;
 ```
 
 ## License

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,6 +89,36 @@ pub async fn eval_to_json_with_options(
     Ok(value.to_json())
 }
 
+/// Evaluate a pkl file synchronously and return its contents as a JSON value.
+///
+/// This entry point is available with the `blocking` feature. It is intended
+/// for synchronous applications; callers already running inside Tokio should
+/// use [`eval_to_json`] instead.
+#[cfg(feature = "blocking")]
+pub fn eval_to_json_blocking(path: &Path) -> Result<serde_json::Value> {
+    eval_to_json_with_options_blocking(path, EvalOptions::default())
+}
+
+/// Evaluate a pkl file synchronously with full evaluator options.
+#[cfg(feature = "blocking")]
+pub fn eval_to_json_with_options_blocking(
+    path: &Path,
+    options: EvalOptions,
+) -> Result<serde_json::Value> {
+    if tokio::runtime::Handle::try_current().is_ok() {
+        return Err(Error::Eval(
+            "blocking evaluation cannot run inside a Tokio runtime; use the async API instead"
+                .to_string(),
+        ));
+    }
+
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .map_err(|error| Error::Eval(format!("failed to create Tokio runtime: {error}")))?;
+    runtime.block_on(eval_to_json_with_options(path, options))
+}
+
 /// Analyze imports of a pkl file, returning all transitive local file dependencies.
 #[cfg(feature = "native-io")]
 pub fn analyze_imports(path: &Path) -> Result<Vec<std::path::PathBuf>> {
@@ -97,6 +127,43 @@ pub fn analyze_imports(path: &Path) -> Result<Vec<std::path::PathBuf>> {
     let mut seen_results = std::collections::HashSet::new();
     analyze_imports_inner(path, &mut visited, &mut seen_results, &mut results)?;
     Ok(results)
+}
+
+#[cfg(all(test, feature = "blocking"))]
+mod blocking_tests {
+    use super::{eval_to_json, eval_to_json_blocking};
+    use std::path::Path;
+
+    const FIXTURE: &str = "tests/fixtures/base.pkl";
+
+    #[test]
+    fn blocking_evaluation_matches_async_evaluation() {
+        let path = Path::new(FIXTURE);
+        let blocking = eval_to_json_blocking(path).unwrap();
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let asynchronous = runtime.block_on(eval_to_json(path)).unwrap();
+
+        assert_eq!(blocking, asynchronous);
+    }
+
+    #[test]
+    fn blocking_evaluation_rejects_an_active_runtime() {
+        let path = Path::new(FIXTURE);
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let error = runtime.block_on(async { eval_to_json_blocking(path).unwrap_err() });
+
+        assert!(
+            error
+                .to_string()
+                .contains("cannot run inside a Tokio runtime")
+        );
+    }
 }
 
 #[cfg(feature = "native-io")]


### PR DESCRIPTION
This adds feature-gated blocking entry points for applications that want to evaluate local Pkl configuration without creating their own Tokio runtime.

The existing async API is unchanged. With the new `blocking` feature, callers can use `eval_to_json_blocking` or `eval_to_json_with_options_blocking`; `pklr` owns the current-thread runtime internally. Calls made from an existing Tokio runtime return an error and can use the async API instead.

The README now documents both calling styles, and tests cover parity with async evaluation and nested-runtime rejection.

Validation:

- `cargo fmt --all -- --check`
- `cargo test`
- `cargo test --all-features`
- `cargo test --no-default-features --features parse`
- `cargo test --no-default-features --features eval-core`
- `cargo test --no-default-features --features native-io`
- `cargo test --no-default-features --features blocking`
- `cargo clippy --all-targets --all-features -- -D warnings`

`cargo-semver-checks` was not installed in the local environment; the repository CI runs it for pull requests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional blocking APIs for evaluating Pkl files synchronously.
  * Added support for configuring the `tokio` and `blocking` features.
  * Blocking evaluation now reports an error when called from an active Tokio runtime.

* **Documentation**
  * Updated usage examples for asynchronous JSON evaluation.
  * Added guidance for synchronous applications using the `blocking` feature.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->