### PR TITLE
feat: track environment reads during evaluation

### DIFF
--- a/src/eval.rs
+++ b/src/eval.rs
@@ -102,10 +102,12 @@ impl Evaluator {
         self.base_path = path.to_path_buf();
     }
 
-    /// Return the environment variables observed by this evaluator.
+    /// Return every environment variable observed by this evaluator.
     ///
     /// Missing variables are included with a `None` value. Entries are ordered
     /// by variable name so callers can serialize or hash them deterministically.
+    /// The record is cumulative because evaluated imports are cached for the
+    /// evaluator's lifetime; create a new evaluator for an isolated record.
     pub fn env_reads(&self) -> &BTreeMap<String, Option<String>> {
         &self.env_reads
     }

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::rc::Rc;
 use std::sync::Arc;
 
@@ -21,6 +21,8 @@ pub struct Evaluator {
     http_cache: HashMap<String, String>,
     /// Cache for evaluated local imports (canonical path → Value)
     import_cache: HashMap<PathBuf, Value>,
+    /// Environment variables read during evaluation (name → observed value).
+    env_reads: BTreeMap<String, Option<String>>,
     /// Local files currently being evaluated with inherited scope.
     scoped_imports_in_flight: HashSet<PathBuf>,
     /// Host-provided IO for files, environment, HTTP, packages, and globs.
@@ -61,6 +63,7 @@ impl Default for Evaluator {
             max_depth: 32,
             http_cache: HashMap::new(),
             import_cache: HashMap::new(),
+            env_reads: BTreeMap::new(),
             scoped_imports_in_flight: HashSet::new(),
             capabilities: Box::new(crate::capabilities::NativeCapabilities::new()),
             #[cfg(feature = "package-zip")]
@@ -84,6 +87,7 @@ impl Evaluator {
             max_depth: 32,
             http_cache: HashMap::new(),
             import_cache: HashMap::new(),
+            env_reads: BTreeMap::new(),
             scoped_imports_in_flight: HashSet::new(),
             capabilities: Box::new(capabilities),
             #[cfg(feature = "package-zip")]
@@ -96,6 +100,19 @@ impl Evaluator {
 
     pub fn set_base_path(&mut self, path: &Path) {
         self.base_path = path.to_path_buf();
+    }
+
+    /// Return the environment variables observed by this evaluator.
+    ///
+    /// Missing variables are included with a `None` value. Entries are ordered
+    /// by variable name so callers can serialize or hash them deterministically.
+    pub fn env_reads(&self) -> &BTreeMap<String, Option<String>> {
+        &self.env_reads
+    }
+
+    #[cfg(feature = "native-io")]
+    pub(crate) fn take_env_reads(&mut self) -> BTreeMap<String, Option<String>> {
+        std::mem::take(&mut self.env_reads)
     }
 
     /// Set a custom HTTP client for fetching remote imports and packages.
@@ -172,7 +189,9 @@ impl Evaluator {
             Ok(Value::String(content))
         } else if let Some(var_name) = uri.strip_prefix("env:") {
             // env: — read environment variable
-            let Some(val) = self.capabilities.read_env(var_name).await? else {
+            let value = self.capabilities.read_env(var_name).await?;
+            self.env_reads.insert(var_name.to_string(), value.clone());
+            let Some(val) = value else {
                 return Err(Error::Eval(format!(
                     "environment variable not found: {var_name}"
                 )));

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -102,12 +102,10 @@ impl Evaluator {
         self.base_path = path.to_path_buf();
     }
 
-    /// Return every environment variable observed by this evaluator.
+    /// Return the environment variables observed by the latest evaluation.
     ///
     /// Missing variables are included with a `None` value. Entries are ordered
     /// by variable name so callers can serialize or hash them deterministically.
-    /// The record is cumulative because evaluated imports are cached for the
-    /// evaluator's lifetime; create a new evaluator for an isolated record.
     pub fn env_reads(&self) -> &BTreeMap<String, Option<String>> {
         &self.env_reads
     }
@@ -115,6 +113,12 @@ impl Evaluator {
     #[cfg(feature = "native-io")]
     pub(crate) fn take_env_reads(&mut self) -> BTreeMap<String, Option<String>> {
         std::mem::take(&mut self.env_reads)
+    }
+
+    fn begin_evaluation(&mut self) {
+        self.env_reads.clear();
+        self.import_cache.clear();
+        self.scoped_imports_in_flight.clear();
     }
 
     /// Set a custom HTTP client for fetching remote imports and packages.
@@ -347,6 +351,7 @@ impl Evaluator {
     }
 
     pub async fn eval_source(&mut self, source: &str, path: &Path) -> Result<Value> {
+        self.begin_evaluation();
         self.converters.clear();
         // Seed import cache for the entry file so circular back-references work
         if let Ok(canonical) = self.capabilities.canonicalize(path).await {
@@ -366,6 +371,7 @@ impl Evaluator {
 
     /// Evaluate a local pkl file by path (public entry point).
     pub async fn eval_file_pub(&mut self, path: &Path) -> Result<Value> {
+        self.begin_evaluation();
         self.eval_file(path, 0).await
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,19 @@ pub use reqwest;
 #[cfg(feature = "native-io")]
 use std::path::Path;
 
+/// The result of an evaluation together with its environment dependencies.
+#[cfg(feature = "native-io")]
+#[derive(Debug, Clone, PartialEq)]
+pub struct EvalOutcome {
+    /// The evaluated pkl document as JSON.
+    pub json: serde_json::Value,
+    /// Environment variables read during evaluation (name → observed value).
+    ///
+    /// Missing variables are included with a `None` value. Entries are ordered
+    /// by variable name so callers can serialize or hash them deterministically.
+    pub env_reads: std::collections::BTreeMap<String, Option<String>>,
+}
+
 /// Evaluate a pkl file and return its contents as a JSON value.
 /// This is the primary entry point for use in tools like hk.
 #[cfg(feature = "native-io")]
@@ -74,6 +87,12 @@ pub async fn eval_to_json_with_options(
     path: &Path,
     options: EvalOptions,
 ) -> Result<serde_json::Value> {
+    Ok(eval_with_options(path, options).await?.json)
+}
+
+/// Evaluate a pkl file and return its JSON value and environment dependencies.
+#[cfg(feature = "native-io")]
+pub async fn eval_with_options(path: &Path, options: EvalOptions) -> Result<EvalOutcome> {
     let source = std::fs::read_to_string(path).map_err(|e| Error::Io(path.to_path_buf(), e))?;
     let mut evaluator = Evaluator::new();
     evaluator.set_base_path(path.parent().unwrap_or(Path::new(".")));
@@ -86,7 +105,10 @@ pub async fn eval_to_json_with_options(
     }
     let value = evaluator.eval_source(&source, path).await?;
     let value = evaluator.apply_converters(value).await?;
-    Ok(value.to_json())
+    Ok(EvalOutcome {
+        json: value.to_json(),
+        env_reads: evaluator.take_env_reads(),
+    })
 }
 
 /// Analyze imports of a pkl file, returning all transitive local file dependencies.

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -14,6 +14,7 @@ fn lex_kinds(src: &str) -> Vec<TokenKind> {
 struct MemoryCapabilities {
     modules: HashMap<String, String>,
     env: HashMap<String, String>,
+    env_fetches: Arc<Mutex<Vec<String>>>,
     fetches: Arc<Mutex<Vec<String>>>,
 }
 
@@ -36,6 +37,7 @@ impl EvalCapabilities for MemoryCapabilities {
     }
 
     fn read_env<'a>(&'a mut self, name: &'a str) -> BoxFuture<'a, pklr::Result<Option<String>>> {
+        self.env_fetches.lock().unwrap().push(name.to_string());
         let value = self.env.get(name).cloned();
         Box::pin(async move { Ok(value) })
     }
@@ -92,6 +94,7 @@ async fn custom_capabilities_handle_http_import() {
     let mut evaluator = pklr::Evaluator::with_capabilities(MemoryCapabilities {
         modules,
         env: HashMap::new(),
+        env_fetches: Arc::new(Mutex::new(Vec::new())),
         fetches: fetches.clone(),
     });
     let json = evaluator
@@ -116,6 +119,7 @@ async fn custom_capabilities_preserve_fetch_errors() {
     let mut evaluator = pklr::Evaluator::with_capabilities(MemoryCapabilities {
         modules: HashMap::new(),
         env: HashMap::new(),
+        env_fetches: Arc::new(Mutex::new(Vec::new())),
         fetches,
     });
     let error = evaluator
@@ -140,6 +144,7 @@ async fn custom_capabilities_handle_virtual_local_import() {
     let mut evaluator = pklr::Evaluator::with_capabilities(MemoryCapabilities {
         modules,
         env: HashMap::new(),
+        env_fetches: Arc::new(Mutex::new(Vec::new())),
         fetches: Arc::new(Mutex::new(Vec::new())),
     });
     let json = evaluator
@@ -162,6 +167,7 @@ async fn evaluator_records_environment_hits_and_misses_in_name_order() {
             ("ZEBRA".to_string(), "last".to_string()),
             ("ALPHA".to_string(), "first".to_string()),
         ]),
+        env_fetches: Arc::new(Mutex::new(Vec::new())),
         fetches: Arc::new(Mutex::new(Vec::new())),
     });
 
@@ -197,6 +203,7 @@ async fn evaluator_records_environment_reads_from_imported_modules() {
     let mut evaluator = pklr::Evaluator::with_capabilities(MemoryCapabilities {
         modules,
         env: HashMap::from([("IMPORTED_VALUE".to_string(), "transitive".to_string())]),
+        env_fetches: Arc::new(Mutex::new(Vec::new())),
         fetches: Arc::new(Mutex::new(Vec::new())),
     });
 
@@ -217,15 +224,48 @@ async fn evaluator_records_environment_reads_from_imported_modules() {
 }
 
 #[tokio::test]
-async fn evaluator_retains_environment_reads_for_cached_imports() {
+async fn evaluator_resets_environment_reads_between_evaluations() {
+    let mut evaluator = pklr::Evaluator::with_capabilities(MemoryCapabilities {
+        modules: HashMap::new(),
+        env: HashMap::from([
+            ("FIRST".to_string(), "one".to_string()),
+            ("SECOND".to_string(), "two".to_string()),
+        ]),
+        env_fetches: Arc::new(Mutex::new(Vec::new())),
+        fetches: Arc::new(Mutex::new(Vec::new())),
+    });
+
+    evaluator
+        .eval_source("value = read(\"env:FIRST\")\n", Path::new("first.pkl"))
+        .await
+        .unwrap();
+    evaluator
+        .eval_source("value = read(\"env:SECOND\")\n", Path::new("second.pkl"))
+        .await
+        .unwrap();
+
+    assert_eq!(
+        evaluator
+            .env_reads()
+            .keys()
+            .map(String::as_str)
+            .collect::<Vec<_>>(),
+        vec!["SECOND"]
+    );
+}
+
+#[tokio::test]
+async fn evaluator_reevaluates_imports_between_evaluations() {
     let mut modules = HashMap::new();
     modules.insert(
         "virtual/Imported.pkl".to_string(),
         "value = read(\"env:IMPORTED_VALUE\")\n".to_string(),
     );
+    let env_fetches = Arc::new(Mutex::new(Vec::new()));
     let mut evaluator = pklr::Evaluator::with_capabilities(MemoryCapabilities {
         modules,
         env: HashMap::from([("IMPORTED_VALUE".to_string(), "cached".to_string())]),
+        env_fetches: env_fetches.clone(),
         fetches: Arc::new(Mutex::new(Vec::new())),
     });
     let source = "import \"Imported.pkl\" as Imported\nresult = Imported.value\n";
@@ -242,6 +282,10 @@ async fn evaluator_retains_environment_reads_for_cached_imports() {
     assert_eq!(
         evaluator.env_reads()["IMPORTED_VALUE"].as_deref(),
         Some("cached")
+    );
+    assert_eq!(
+        *env_fetches.lock().unwrap(),
+        vec!["IMPORTED_VALUE", "IMPORTED_VALUE"]
     );
 }
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -217,6 +217,35 @@ async fn evaluator_records_environment_reads_from_imported_modules() {
 }
 
 #[tokio::test]
+async fn evaluator_retains_environment_reads_for_cached_imports() {
+    let mut modules = HashMap::new();
+    modules.insert(
+        "virtual/Imported.pkl".to_string(),
+        "value = read(\"env:IMPORTED_VALUE\")\n".to_string(),
+    );
+    let mut evaluator = pklr::Evaluator::with_capabilities(MemoryCapabilities {
+        modules,
+        env: HashMap::from([("IMPORTED_VALUE".to_string(), "cached".to_string())]),
+        fetches: Arc::new(Mutex::new(Vec::new())),
+    });
+    let source = "import \"Imported.pkl\" as Imported\nresult = Imported.value\n";
+
+    evaluator
+        .eval_source(source, Path::new("virtual/first.pkl"))
+        .await
+        .unwrap();
+    evaluator
+        .eval_source(source, Path::new("virtual/second.pkl"))
+        .await
+        .unwrap();
+
+    assert_eq!(
+        evaluator.env_reads()["IMPORTED_VALUE"].as_deref(),
+        Some("cached")
+    );
+}
+
+#[tokio::test]
 async fn eval_outcome_exposes_environment_reads() {
     let dir = std::env::temp_dir().join(format!(
         "pklr_test_eval_outcome_env_reads_{}",

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -13,18 +13,19 @@ fn lex_kinds(src: &str) -> Vec<TokenKind> {
 
 struct MemoryCapabilities {
     modules: HashMap<String, String>,
+    env: HashMap<String, String>,
     fetches: Arc<Mutex<Vec<String>>>,
 }
 
 impl EvalCapabilities for MemoryCapabilities {
     fn read_to_string<'a>(&'a mut self, path: &'a Path) -> BoxFuture<'a, pklr::Result<String>> {
-        let key = path.display().to_string();
+        let key = path.display().to_string().replace('\\', "/");
         let source = self.modules.get(&key).cloned();
         Box::pin(async move { source.ok_or(pklr::Error::ImportNotFound(key)) })
     }
 
     fn path_exists<'a>(&'a mut self, path: &'a Path) -> BoxFuture<'a, pklr::Result<bool>> {
-        let key = path.display().to_string();
+        let key = path.display().to_string().replace('\\', "/");
         let exists = self.modules.contains_key(&key);
         Box::pin(async move { Ok(exists) })
     }
@@ -34,8 +35,9 @@ impl EvalCapabilities for MemoryCapabilities {
         Box::pin(async move { Ok(path) })
     }
 
-    fn read_env<'a>(&'a mut self, _name: &'a str) -> BoxFuture<'a, pklr::Result<Option<String>>> {
-        Box::pin(async move { Ok(None) })
+    fn read_env<'a>(&'a mut self, name: &'a str) -> BoxFuture<'a, pklr::Result<Option<String>>> {
+        let value = self.env.get(name).cloned();
+        Box::pin(async move { Ok(value) })
     }
 
     fn fetch_text<'a>(&'a mut self, url: &'a str) -> BoxFuture<'a, pklr::Result<String>> {
@@ -89,6 +91,7 @@ async fn custom_capabilities_handle_http_import() {
 
     let mut evaluator = pklr::Evaluator::with_capabilities(MemoryCapabilities {
         modules,
+        env: HashMap::new(),
         fetches: fetches.clone(),
     });
     let json = evaluator
@@ -112,6 +115,7 @@ async fn custom_capabilities_preserve_fetch_errors() {
     let fetches = Arc::new(Mutex::new(Vec::new()));
     let mut evaluator = pklr::Evaluator::with_capabilities(MemoryCapabilities {
         modules: HashMap::new(),
+        env: HashMap::new(),
         fetches,
     });
     let error = evaluator
@@ -135,6 +139,7 @@ async fn custom_capabilities_handle_virtual_local_import() {
 
     let mut evaluator = pklr::Evaluator::with_capabilities(MemoryCapabilities {
         modules,
+        env: HashMap::new(),
         fetches: Arc::new(Mutex::new(Vec::new())),
     });
     let json = evaluator
@@ -147,6 +152,91 @@ async fn custom_capabilities_handle_virtual_local_import() {
         .to_json();
 
     assert_eq!(json["result"], 42);
+}
+
+#[tokio::test]
+async fn evaluator_records_environment_hits_and_misses_in_name_order() {
+    let mut evaluator = pklr::Evaluator::with_capabilities(MemoryCapabilities {
+        modules: HashMap::new(),
+        env: HashMap::from([
+            ("ZEBRA".to_string(), "last".to_string()),
+            ("ALPHA".to_string(), "first".to_string()),
+        ]),
+        fetches: Arc::new(Mutex::new(Vec::new())),
+    });
+
+    evaluator
+        .eval_source(
+            r#"
+zebra = read("env:ZEBRA")
+missing = read?("env:MISSING")
+alpha = read("env:ALPHA")
+"#,
+            Path::new("entry.pkl"),
+        )
+        .await
+        .unwrap();
+
+    let reads = evaluator.env_reads();
+    assert_eq!(
+        reads.keys().map(String::as_str).collect::<Vec<_>>(),
+        vec!["ALPHA", "MISSING", "ZEBRA"]
+    );
+    assert_eq!(reads["ALPHA"].as_deref(), Some("first"));
+    assert_eq!(reads["MISSING"], None);
+    assert_eq!(reads["ZEBRA"].as_deref(), Some("last"));
+}
+
+#[tokio::test]
+async fn evaluator_records_environment_reads_from_imported_modules() {
+    let mut modules = HashMap::new();
+    modules.insert(
+        "virtual/Imported.pkl".to_string(),
+        "value = read(\"env:IMPORTED_VALUE\")\n".to_string(),
+    );
+    let mut evaluator = pklr::Evaluator::with_capabilities(MemoryCapabilities {
+        modules,
+        env: HashMap::from([("IMPORTED_VALUE".to_string(), "transitive".to_string())]),
+        fetches: Arc::new(Mutex::new(Vec::new())),
+    });
+
+    let json = evaluator
+        .eval_source(
+            "import \"Imported.pkl\" as Imported\nresult = Imported.value\n",
+            Path::new("virtual/entry.pkl"),
+        )
+        .await
+        .unwrap()
+        .to_json();
+
+    assert_eq!(json["result"], "transitive");
+    assert_eq!(
+        evaluator.env_reads()["IMPORTED_VALUE"].as_deref(),
+        Some("transitive")
+    );
+}
+
+#[tokio::test]
+async fn eval_outcome_exposes_environment_reads() {
+    let dir = std::env::temp_dir().join(format!(
+        "pklr_test_eval_outcome_env_reads_{}",
+        std::process::id()
+    ));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    let path = dir.join("main.pkl");
+    std::fs::write(&path, "value = read?(\"env:PATH\")\n").unwrap();
+
+    let outcome = pklr::eval_with_options(&path, pklr::EvalOptions::default())
+        .await
+        .unwrap();
+
+    assert_eq!(outcome.env_reads["PATH"], std::env::var("PATH").ok());
+    assert_eq!(
+        outcome.json["value"].as_str(),
+        std::env::var("PATH").ok().as_deref()
+    );
+    let _ = std::fs::remove_dir_all(&dir);
 }
 
 // --- Lexer tests ---


### PR DESCRIPTION
## Summary

- record every `env:` resource read as `name -> Option<String>`, including missing variables
- expose the ordered record through `Evaluator::env_reads()` and a new `eval_with_options() -> EvalOutcome` API
- preserve the existing `eval_to_json_with_options()` signature and behavior
- cover values, misses, deterministic ordering, imported modules, and evaluator reuse

## Motivation

Evaluation consumers may cache JSON that depends on `read("env:...")` or `read?("env:...")`, but pklr previously returned no record of those inputs. Recording only successful reads would miss the important unset-to-set transition, so this records missing variables as `None` as well as present values.

For a downstream cache such as hk's, the variable names are only known after evaluation. The intended consumer flow is therefore:

1. On a cold evaluation, persist `env_reads` in a sidecar keyed by config content.
2. On later runs, load the names from that sidecar and read their current values before the cache lookup.
3. Fold the current `name=value` pairs into the cache key.

That gives different environments separate warm cache entries instead of repeatedly invalidating one shared slot. This is motivated by https://github.com/jdx/hk/discussions/1150.

## Compatibility and limitation

`eval_to_json_with_options()` still returns `Result<serde_json::Value>`; it now delegates to the additive outcome API and discards the dependency record.

This enables tracking for consumers using the pklr backend. A downstream `pkl` CLI backend cannot obtain the same read record, so it must use a separate strategy such as declining to cache environment-dependent evaluations.

## Testing

- `cargo test -- --skip read_file_uri` (365 passed locally; the skipped existing test constructs an invalid Windows `file://` fixture path)
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --check`
- `cargo check --no-default-features --features eval-core`
- `cargo check --no-default-features --features native-io`

Generated with Codex.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added evaluation results that include environment-variable reads alongside the evaluated JSON.
  * Environment-variable accesses are reported in a deterministic order, including variables that are missing.
  * Added support for evaluating configured environment values in native I/O scenarios.
* **Bug Fixes**
  * Improved environment-variable handling across imported modules and missing-variable errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
