### PR TITLE
chore: release v1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.0](https://github.com/jdx/pklr/compare/v1.2.0...v1.3.0) - 2026-08-03
+
+### Added
+
+- track environment reads during evaluation ([#145](https://github.com/jdx/pklr/pull/145))
+
 ## [1.2.0](https://github.com/jdx/pklr/compare/v1.1.3...v1.2.0) - 2026-07-16
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -677,7 +677,7 @@ checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "pklr"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "async-recursion",
  "indexmap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "pklr"
-version     = "1.2.0"
+version     = "1.3.0"
 edition      = "2024"
 rust-version = "1.88"
 description = "Pure Rust pkl configuration language parser and evaluator"


### PR DESCRIPTION



## 🤖 New release

* `pklr`: 1.2.0 -> 1.3.0 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [1.3.0](https://github.com/jdx/pklr/compare/v1.2.0...v1.3.0) - 2026-08-03

### Added

- track environment reads during evaluation ([#145](https://github.com/jdx/pklr/pull/145))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release-only metadata with no runtime code changes in this diff; low risk for consumers upgrading the published crate version.
> 
> **Overview**
> **Release v1.3.0** bumps the `pklr` crate from **1.2.0** to **1.3.0** in `Cargo.toml` and `Cargo.lock`, and moves the **1.3.0** changelog entry out of **Unreleased**.
> 
> The documented user-facing change for this release is **tracking environment variable reads during evaluation** ([#145](https://github.com/jdx/pklr/pull/145)); that behavior landed in prior work and is only noted here for the release notes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 67c1d2f2d73e0f1586476490d4f8ec3e4c94a625. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->