### PR TITLE
feat: persist package downloads for offline evaluation

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ No external binary or CLI required.
 - Lexer, parser, and evaluator written entirely in Rust
 - Evaluates `.pkl` files to `serde_json::Value`
 - Import and amends resolution for local files
+- Persistent caching and offline evaluation for `package://` imports
 - String interpolation, lambdas, higher-order methods
 - Rich error diagnostics via [miette](https://crates.io/crates/miette)
 
@@ -18,6 +19,19 @@ use pklr::eval_to_json;
 
 let json = eval_to_json(std::path::Path::new("config.pkl"))?;
 println!("{}", json);
+```
+
+Package downloads can be shared across evaluator instances and reused without
+network access:
+
+```rust
+async fn load_config() -> pklr::Result<serde_json::Value> {
+    pklr::EvaluatorBuilder::new()
+        .package_cache_dir(".pklr-cache")
+        .offline(true)
+        .eval_to_json(std::path::Path::new("config.pkl"))
+        .await
+}
 ```
 
 ## License

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -30,6 +30,12 @@ pub struct Evaluator {
     /// Extracted package zip directories (zip URL → temp dir path)
     #[cfg(feature = "package-zip")]
     package_dirs: HashMap<String, PathBuf>,
+    /// Directory used to persist downloaded package content across evaluators.
+    package_cache_dir: Option<PathBuf>,
+    /// HTTP URL roots whose sources belong to direct-download packages.
+    package_http_roots: HashSet<String>,
+    /// Whether network access is disabled for this evaluator.
+    offline: bool,
     /// HTTP URL rewrite rules (source_prefix → target_prefix).
     /// Longest matching prefix wins.
     http_rewrites: Vec<(String, String)>,
@@ -68,6 +74,9 @@ impl Default for Evaluator {
             capabilities: Box::new(crate::capabilities::NativeCapabilities::new()),
             #[cfg(feature = "package-zip")]
             package_dirs: HashMap::new(),
+            package_cache_dir: None,
+            package_http_roots: HashSet::new(),
+            offline: false,
             http_rewrites: Vec::new(),
             converters: Vec::new(),
             warned_deprecated: std::collections::HashSet::new(),
@@ -92,6 +101,9 @@ impl Evaluator {
             capabilities: Box::new(capabilities),
             #[cfg(feature = "package-zip")]
             package_dirs: HashMap::new(),
+            package_cache_dir: None,
+            package_http_roots: HashSet::new(),
+            offline: false,
             http_rewrites: Vec::new(),
             converters: Vec::new(),
             warned_deprecated: std::collections::HashSet::new(),
@@ -100,6 +112,16 @@ impl Evaluator {
 
     pub fn set_base_path(&mut self, path: &Path) {
         self.base_path = path.to_path_buf();
+    }
+
+    /// Persist downloaded package content under `path`.
+    pub fn set_package_cache_dir(&mut self, path: impl Into<PathBuf>) {
+        self.package_cache_dir = Some(path.into());
+    }
+
+    /// Disable network access. Package imports can still use the persistent cache.
+    pub fn set_offline(&mut self, offline: bool) {
+        self.offline = offline;
     }
 
     /// Return the environment variables observed by the latest evaluation.
@@ -221,10 +243,22 @@ impl Evaluator {
     }
 
     async fn fetch_source(&mut self, url: &str) -> Result<String> {
+        if self
+            .package_http_roots
+            .iter()
+            .any(|root| url.starts_with(root))
+        {
+            return self.fetch_package_source(url).await;
+        }
         let rewritten = self.rewrite_url(url);
         let fetch_url = rewritten.as_ref();
         if let Some(cached) = self.http_cache.get(fetch_url) {
             return Ok(cached.clone());
+        }
+        if self.offline {
+            return Err(Error::Eval(format!(
+                "offline mode prevented HTTP fetch for {url}"
+            )));
         }
         let body = self.capabilities.fetch_text(fetch_url).await?;
         self.http_cache.insert(fetch_url.to_string(), body.clone());
@@ -278,8 +312,8 @@ impl Evaluator {
         if uri.starts_with("package://") {
             let pkg = resolve_package_uri(uri)?;
             match &pkg {
-                PackageSource::Direct(url) => {
-                    let source = self.fetch_source(url).await?;
+                PackageSource::Direct { url, root } => {
+                    let source = self.fetch_direct_package_source(url, root).await?;
                     return Ok(Some((source, url.clone())));
                 }
                 PackageSource::Zip(zip_url, entry) => {
@@ -316,17 +350,108 @@ impl Evaluator {
         Ok(Some((source, import_path.display().to_string())))
     }
 
+    async fn fetch_package_source(&mut self, url: &str) -> Result<String> {
+        if let Some(cached) = self.http_cache.get(url) {
+            return Ok(cached.clone());
+        }
+        let bytes = self.fetch_package_bytes(url, "pkl").await?;
+        let source = String::from_utf8(bytes)
+            .map_err(|error| Error::Eval(format!("package source is not UTF-8: {url}: {error}")))?;
+        self.http_cache.insert(url.to_string(), source.clone());
+        Ok(source)
+    }
+
+    async fn fetch_direct_package_source(&mut self, url: &str, root: &str) -> Result<String> {
+        self.package_http_roots.insert(root.to_string());
+        self.fetch_package_source(url).await
+    }
+
+    async fn fetch_package_bytes(&mut self, url: &str, extension: &str) -> Result<Vec<u8>> {
+        match self.read_package_cache(url, extension) {
+            Ok(Some(bytes)) => match validate_package_bytes(url, extension, &bytes) {
+                Ok(()) => return Ok(bytes),
+                Err(error) if self.offline => return Err(error),
+                Err(_) => self.remove_package_cache(url, extension),
+            },
+            Ok(None) => {}
+            Err(error) if self.offline => return Err(error),
+            Err(_) => {
+                // The persistent cache is an optimization while online. If it
+                // is unreadable, fetch from the network and continue without it.
+            }
+        }
+        if self.offline {
+            let cache = self
+                .package_cache_dir
+                .as_ref()
+                .map(|path| path.display().to_string())
+                .unwrap_or_else(|| "<disabled>".to_string());
+            return Err(Error::Eval(format!(
+                "package is not cached and offline mode is enabled: {url} (cache: {cache})"
+            )));
+        }
+        let fetch_url = self.rewrite_url(url).into_owned();
+        let bytes = self.capabilities.fetch_bytes(&fetch_url).await?;
+        validate_package_bytes(url, extension, &bytes)?;
+        self.write_package_cache(url, extension, &bytes);
+        Ok(bytes)
+    }
+
+    fn read_package_cache(&self, url: &str, extension: &str) -> Result<Option<Vec<u8>>> {
+        let Some(cache_dir) = &self.package_cache_dir else {
+            return Ok(None);
+        };
+        let (data_path, url_path) = package_cache_paths(cache_dir, url, extension);
+        let cached_url = match std::fs::read_to_string(&url_path) {
+            Ok(cached_url) => cached_url,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+            Err(error) => return Err(Error::Io(url_path, error)),
+        };
+        if cached_url != url {
+            return Ok(None);
+        }
+        match std::fs::read(&data_path) {
+            Ok(bytes) => Ok(Some(bytes)),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),
+            Err(error) => Err(Error::Io(data_path, error)),
+        }
+    }
+
+    fn write_package_cache(&self, url: &str, extension: &str, bytes: &[u8]) {
+        let Some(cache_dir) = &self.package_cache_dir else {
+            return;
+        };
+        let (data_path, url_path) = package_cache_paths(cache_dir, url, extension);
+        let Some(parent) = data_path.parent() else {
+            return;
+        };
+        if std::fs::create_dir_all(parent).is_err() {
+            return;
+        }
+        if write_atomic(&data_path, bytes).is_err() {
+            return;
+        }
+        let _ = write_atomic(&url_path, url.as_bytes());
+    }
+
+    fn remove_package_cache(&self, url: &str, extension: &str) {
+        let Some(cache_dir) = &self.package_cache_dir else {
+            return;
+        };
+        let (data_path, url_path) = package_cache_paths(cache_dir, url, extension);
+        let _ = std::fs::remove_file(data_path);
+        let _ = std::fs::remove_file(url_path);
+    }
+
     /// Download a package zip and extract it to a temp directory.
     /// Returns the path to the extracted directory. Caches by zip URL.
     #[cfg(feature = "package-zip")]
     async fn extract_package_zip(&mut self, zip_url: &str) -> Result<PathBuf> {
-        let rewritten = self.rewrite_url(zip_url);
-        let fetch_url = rewritten.as_ref();
         // Check if already extracted
-        if let Some(dir) = self.package_dirs.get(fetch_url) {
+        if let Some(dir) = self.package_dirs.get(zip_url) {
             return Ok(dir.clone());
         }
-        let bytes = self.capabilities.fetch_bytes(fetch_url).await?;
+        let bytes = self.fetch_package_bytes(zip_url, "zip").await?;
         let cursor = std::io::Cursor::new(bytes);
         let mut archive =
             zip::ZipArchive::new(cursor).map_err(|e| Error::Eval(format!("zip error: {e}")))?;
@@ -337,17 +462,13 @@ impl Evaluator {
         archive
             .extract(&dir)
             .map_err(|e| Error::Eval(format!("zip extract error: {e}")))?;
-        self.package_dirs.insert(fetch_url.to_string(), dir.clone());
+        self.package_dirs.insert(zip_url.to_string(), dir.clone());
         Ok(dir)
     }
 
     #[cfg(all(test, feature = "package-zip"))]
     fn package_dir_for_zip(&self, zip_url: &str) -> Option<&PathBuf> {
-        if let Some(dir) = self.package_dirs.get(zip_url) {
-            return Some(dir);
-        }
-        let rewritten = self.rewrite_url(zip_url);
-        self.package_dirs.get(rewritten.as_ref())
+        self.package_dirs.get(zip_url)
     }
 
     pub async fn eval_source(&mut self, source: &str, path: &Path) -> Result<Value> {
@@ -646,10 +767,14 @@ impl Evaluator {
                     }
                 }
                 let url = match &pkg {
-                    PackageSource::Direct(url) => url.clone(),
+                    PackageSource::Direct { url, .. } => url.clone(),
                     PackageSource::Zip(..) => unreachable!(),
                 };
-                let source = self.fetch_source(&url).await?;
+                let root = match &pkg {
+                    PackageSource::Direct { root, .. } => root,
+                    PackageSource::Zip(..) => unreachable!(),
+                };
+                let source = self.fetch_direct_package_source(&url, root).await?;
                 let imported_val = {
                     let tokens = lexer::lex_named(&source, &url)?;
                     let imp_module = parser::parse_named(&tokens, &source, &url)?;
@@ -780,8 +905,8 @@ impl Evaluator {
                             "package zip imports require pklr's 'package-zip' feature: {zip_url}"
                         )));
                     }
-                } else if let PackageSource::Direct(url) = &pkg {
-                    let source = self.fetch_source(url).await?;
+                } else if let PackageSource::Direct { url, root } = &pkg {
+                    let source = self.fetch_direct_package_source(url, root).await?;
                     let tokens = lexer::lex_named(&source, url)?;
                     let base_module = parser::parse_named(&tokens, &source, url)?;
                     let base_val = self
@@ -4120,9 +4245,86 @@ impl Scope {
 #[derive(Debug)]
 enum PackageSource {
     /// Direct file download (pkg.pkl-lang.org format)
-    Direct(String),
+    Direct { url: String, root: String },
     /// Zip archive URL + path within the archive
     Zip(String, String),
+}
+
+fn package_cache_paths(cache_dir: &Path, url: &str, extension: &str) -> (PathBuf, PathBuf) {
+    // FNV-1a gives package URLs stable, filesystem-safe names without making
+    // the cache layout depend on platform path rules. The adjacent URL file
+    // detects the extraordinarily unlikely hash collision.
+    let mut hash = 0xcbf29ce484222325_u64;
+    for byte in url.as_bytes() {
+        hash ^= u64::from(*byte);
+        hash = hash.wrapping_mul(0x100000001b3);
+    }
+    let base = cache_dir.join("packages").join(format!("{hash:016x}"));
+    (base.with_extension(extension), base.with_extension("url"))
+}
+
+fn validate_package_bytes(url: &str, extension: &str, bytes: &[u8]) -> Result<()> {
+    if extension == "pkl" {
+        std::str::from_utf8(bytes)
+            .map_err(|error| Error::Eval(format!("package source is not UTF-8: {url}: {error}")))?;
+    }
+    #[cfg(feature = "package-zip")]
+    if extension == "zip" {
+        let mut archive = zip::ZipArchive::new(std::io::Cursor::new(bytes))
+            .map_err(|error| Error::Eval(format!("package archive is invalid: {url}: {error}")))?;
+        for index in 0..archive.len() {
+            let mut entry = archive.by_index(index).map_err(|error| {
+                Error::Eval(format!("package archive is invalid: {url}: {error}"))
+            })?;
+            std::io::copy(&mut entry, &mut std::io::sink()).map_err(|error| {
+                Error::Eval(format!(
+                    "package archive entry is invalid: {url}: {}: {error}",
+                    entry.name()
+                ))
+            })?;
+        }
+    }
+    Ok(())
+}
+
+fn write_atomic(path: &Path, bytes: &[u8]) -> std::io::Result<()> {
+    use std::io::Write;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+    let file_name = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("cache");
+    let temp_path = path.with_file_name(format!(
+        ".{file_name}.tmp-{}-{}",
+        std::process::id(),
+        COUNTER.fetch_add(1, Ordering::Relaxed)
+    ));
+    let mut file = std::fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(&temp_path)?;
+    let write_result = file.write_all(bytes).and_then(|()| file.sync_all());
+    drop(file);
+    if let Err(error) = write_result {
+        let _ = std::fs::remove_file(&temp_path);
+        return Err(error);
+    }
+    let rename_result = match std::fs::rename(&temp_path, path) {
+        Ok(()) => return Ok(()),
+        // Windows rename does not replace an existing file. There is a brief
+        // non-atomic gap on that platform, but the destination must not retain
+        // stale bytes while its URL sidecar is updated.
+        Err(_) if path.exists() => {
+            std::fs::remove_file(path).and_then(|()| std::fs::rename(&temp_path, path))
+        }
+        Err(error) => Err(error),
+    };
+    if rename_result.is_err() {
+        let _ = std::fs::remove_file(temp_path);
+    }
+    rename_result
 }
 
 /// Resolve a `package://` URI to a download source.
@@ -4160,9 +4362,11 @@ fn resolve_package_uri(uri: &str) -> Result<PackageSource> {
         && let Some((repo, version)) = repo_ver.split_once('@')
     {
         let file_path = sanitize_package_entry(fragment.strip_prefix('/').unwrap_or(fragment))?;
-        return Ok(PackageSource::Direct(format!(
-            "https://github.com/{repo}/releases/download/{version}/{file_path}"
-        )));
+        let root = format!("https://github.com/{repo}/releases/download/{version}/");
+        return Ok(PackageSource::Direct {
+            url: format!("{root}{file_path}"),
+            root,
+        });
     }
     // Format 2: package://pkg.pkl-lang.org/pkl-pantry/package@version#/path.pkl
     // These are under https://github.com/apple/pkl-pantry's release named `package@version`
@@ -4850,6 +5054,23 @@ mod package_uri_tests {
     use super::{PackageSource, resolve_package_uri};
 
     #[test]
+    fn atomic_write_replaces_existing_file() {
+        let test_dir = std::env::temp_dir().join(format!(
+            "pklr-write-atomic-{}-{:?}",
+            std::process::id(),
+            std::thread::current().id()
+        ));
+        std::fs::create_dir_all(&test_dir).unwrap();
+        let path = test_dir.join("package.pkl");
+
+        super::write_atomic(&path, b"old").unwrap();
+        super::write_atomic(&path, b"new").unwrap();
+
+        assert_eq!(std::fs::read(&path).unwrap(), b"new");
+        std::fs::remove_dir_all(test_dir).unwrap();
+    }
+
+    #[test]
     fn generic_package_uri_resolves_to_zip_url() {
         let pkg =
             resolve_package_uri("package://example.com/v1.26.0/hk@1.26.0#/Config.pkl").unwrap();
@@ -4858,19 +5079,51 @@ mod package_uri_tests {
                 assert_eq!(zip_url, "https://example.com/v1.26.0/hk@1.26.0.zip");
                 assert_eq!(entry, "Config.pkl");
             }
-            PackageSource::Direct(_) => panic!("expected zip package source"),
+            PackageSource::Direct { .. } => panic!("expected zip package source"),
         }
     }
 
     #[test]
+    #[cfg(feature = "package-zip")]
+    fn package_archive_validation_reads_entry_payloads() {
+        use std::io::Write;
+
+        let payload = b"payload whose checksum must be validated";
+        let mut bytes = Vec::new();
+        {
+            let cursor = std::io::Cursor::new(&mut bytes);
+            let mut archive = zip::ZipWriter::new(cursor);
+            archive
+                .start_file(
+                    "Config.pkl",
+                    zip::write::SimpleFileOptions::default()
+                        .compression_method(zip::CompressionMethod::Stored),
+                )
+                .unwrap();
+            archive.write_all(payload).unwrap();
+            archive.finish().unwrap();
+        }
+        let payload_start = bytes
+            .windows(payload.len())
+            .position(|window| window == payload)
+            .unwrap();
+        bytes[payload_start] ^= 0xff;
+
+        let error = super::validate_package_bytes("https://example.com/package.zip", "zip", &bytes)
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("package archive entry is invalid"));
+    }
+
+    #[test]
     #[cfg(all(feature = "native-io", feature = "package-zip"))]
-    fn package_dir_lookup_uses_rewritten_zip_url() {
+    fn package_dir_lookup_uses_source_zip_url() {
         let mut evaluator = Evaluator::new();
         evaluator.set_http_rewrites(&["https://example.com/=https://mirror.local/".to_string()]);
         let dir = PathBuf::from("/tmp/pklr-test-package");
         evaluator
             .package_dirs
-            .insert("https://mirror.local/pkg@1.0.zip".to_string(), dir.clone());
+            .insert("https://example.com/pkg@1.0.zip".to_string(), dir.clone());
 
         assert_eq!(
             evaluator

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,6 +57,74 @@ pub struct EvalOptions {
     pub http_rewrites: Vec<String>,
 }
 
+/// Extensible builder for configuring a Pkl evaluator.
+#[cfg(feature = "native-io")]
+#[derive(Default)]
+pub struct EvaluatorBuilder {
+    #[cfg(feature = "http")]
+    client: Option<reqwest::Client>,
+    http_rewrites: Vec<String>,
+    package_cache_dir: Option<std::path::PathBuf>,
+    offline: bool,
+}
+
+#[cfg(feature = "native-io")]
+impl EvaluatorBuilder {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Use a custom HTTP client for proxy, certificate, or timeout configuration.
+    #[cfg(feature = "http")]
+    pub fn http_client(mut self, client: reqwest::Client) -> Self {
+        self.client = Some(client);
+        self
+    }
+
+    /// Add HTTP URL rewrite rules in `"source_prefix=target_prefix"` format.
+    pub fn http_rewrites(mut self, rules: impl IntoIterator<Item = String>) -> Self {
+        self.http_rewrites.extend(rules);
+        self
+    }
+
+    /// Persist downloaded `package://` content under `path`.
+    pub fn package_cache_dir(mut self, path: impl Into<std::path::PathBuf>) -> Self {
+        self.package_cache_dir = Some(path.into());
+        self
+    }
+
+    /// Disable network access while allowing cached packages to load.
+    pub fn offline(mut self, offline: bool) -> Self {
+        self.offline = offline;
+        self
+    }
+
+    /// Build a configured evaluator for direct source evaluation.
+    pub fn build(self) -> Evaluator {
+        let mut evaluator = Evaluator::new();
+        #[cfg(feature = "http")]
+        if let Some(client) = self.client {
+            evaluator.set_http_client(client);
+        }
+        evaluator.set_http_rewrites(&self.http_rewrites);
+        if let Some(cache_dir) = self.package_cache_dir {
+            evaluator.set_package_cache_dir(cache_dir);
+        }
+        evaluator.set_offline(self.offline);
+        evaluator
+    }
+
+    /// Evaluate a Pkl file and return its JSON value.
+    pub async fn eval_to_json(self, path: &Path) -> Result<serde_json::Value> {
+        Ok(self.eval(path).await?.json)
+    }
+
+    /// Evaluate a Pkl file and return its JSON and environment dependencies.
+    pub async fn eval(self, path: &Path) -> Result<EvalOutcome> {
+        eval_with_evaluator(path, self.build()).await
+    }
+}
+
 /// Evaluate a pkl file with a custom HTTP client for proxy/CA configuration.
 #[cfg(all(feature = "native-io", feature = "http"))]
 pub async fn eval_to_json_with_client(
@@ -93,16 +161,18 @@ pub async fn eval_to_json_with_options(
 /// Evaluate a pkl file and return its JSON value and environment dependencies.
 #[cfg(feature = "native-io")]
 pub async fn eval_with_options(path: &Path, options: EvalOptions) -> Result<EvalOutcome> {
-    let source = std::fs::read_to_string(path).map_err(|e| Error::Io(path.to_path_buf(), e))?;
-    let mut evaluator = Evaluator::new();
-    evaluator.set_base_path(path.parent().unwrap_or(Path::new(".")));
+    let mut builder = EvaluatorBuilder::new().http_rewrites(options.http_rewrites);
     #[cfg(feature = "http")]
     if let Some(client) = options.client {
-        evaluator.set_http_client(client);
+        builder = builder.http_client(client);
     }
-    if !options.http_rewrites.is_empty() {
-        evaluator.set_http_rewrites(&options.http_rewrites);
-    }
+    builder.eval(path).await
+}
+
+#[cfg(feature = "native-io")]
+async fn eval_with_evaluator(path: &Path, mut evaluator: Evaluator) -> Result<EvalOutcome> {
+    let source = std::fs::read_to_string(path).map_err(|e| Error::Io(path.to_path_buf(), e))?;
+    evaluator.set_base_path(path.parent().unwrap_or(Path::new(".")));
     let value = evaluator.eval_source(&source, path).await?;
     let value = evaluator.apply_converters(value).await?;
     Ok(EvalOutcome {

--- a/tests/pkl_features.rs
+++ b/tests/pkl_features.rs
@@ -5305,3 +5305,209 @@ hooks {
 
     assert_eq!(json["hooks"]["check"]["steps"]["echo"]["check"], "echo ok!");
 }
+
+#[test]
+fn package_cache_survives_across_offline_evaluators() {
+    use std::io::{Read, Write};
+    use std::net::TcpListener;
+    use std::thread;
+
+    let temp = TestTempDir::new("pklr_test_persistent_package_cache");
+    let cache_dir = temp.path().join("cache");
+    let mut zip_bytes = Vec::new();
+    {
+        let cursor = std::io::Cursor::new(&mut zip_bytes);
+        let mut zip = zip::ZipWriter::new(cursor);
+        zip.start_file("Config.pkl", zip::write::SimpleFileOptions::default())
+            .unwrap();
+        zip.write_all(b"answer = 42\n").unwrap();
+        zip.finish().unwrap();
+    }
+
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let addr = listener.local_addr().unwrap();
+    let server = thread::spawn(move || {
+        let (mut stream, _) = listener.accept().unwrap();
+        let mut request = [0_u8; 1024];
+        let _ = stream.read(&mut request).unwrap();
+        write!(
+            stream,
+            "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+            zip_bytes.len()
+        )
+        .unwrap();
+        stream.write_all(&zip_bytes).unwrap();
+    });
+
+    let config_path = temp.path().join("config.pkl");
+    std::fs::write(
+        &config_path,
+        "amends \"package://example.com/pkg@1.0.0#/Config.pkl\"\n",
+    )
+    .unwrap();
+    let rewrite = format!("https://example.com/=http://{addr}/");
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    let first = rt
+        .block_on(
+            pklr::EvaluatorBuilder::new()
+                .http_rewrites([rewrite.clone()])
+                .package_cache_dir(cache_dir.clone())
+                .eval_to_json(&config_path),
+        )
+        .unwrap();
+    server.join().unwrap();
+    assert_eq!(first["answer"], 42);
+
+    // A new evaluator succeeds after the one-shot server has shut down.
+    let second = rt
+        .block_on(
+            pklr::EvaluatorBuilder::new()
+                .http_rewrites([rewrite])
+                .package_cache_dir(cache_dir)
+                .offline(true)
+                .eval_to_json(&config_path),
+        )
+        .unwrap();
+    assert_eq!(second["answer"], 42);
+}
+
+#[test]
+fn direct_package_relatives_survive_across_offline_evaluators() {
+    use std::io::{Read, Write};
+    use std::net::TcpListener;
+    use std::thread;
+
+    let temp = TestTempDir::new("pklr_test_direct_package_relative_cache");
+    let cache_dir = temp.path().join("cache");
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let addr = listener.local_addr().unwrap();
+    let server = thread::spawn(move || {
+        for _ in 0..2 {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut request = [0_u8; 2048];
+            let length = stream.read(&mut request).unwrap();
+            let request = String::from_utf8_lossy(&request[..length]);
+            let body = if request.starts_with("GET /Config.pkl ") {
+                "amends \"./Base.pkl\"\nanswer = 42\n"
+            } else if request.starts_with("GET /Base.pkl ") {
+                "base = 41\n"
+            } else {
+                panic!("unexpected request: {request}");
+            };
+            write!(
+                stream,
+                "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                body.len()
+            )
+            .unwrap();
+        }
+    });
+
+    let config_path = temp.path().join("config.pkl");
+    std::fs::write(
+        &config_path,
+        "amends \"package://pkg.pkl-lang.org/github.com/acme/pkg@v1#/Config.pkl\"\n",
+    )
+    .unwrap();
+    let rewrite = format!("https://github.com/acme/pkg/releases/download/v1/=http://{addr}/");
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    let first = rt
+        .block_on(
+            pklr::EvaluatorBuilder::new()
+                .http_rewrites([rewrite.clone()])
+                .package_cache_dir(cache_dir.clone())
+                .eval_to_json(&config_path),
+        )
+        .unwrap();
+    server.join().unwrap();
+    assert_eq!(first["base"], 41);
+    assert_eq!(first["answer"], 42);
+
+    let second = rt
+        .block_on(
+            pklr::EvaluatorBuilder::new()
+                .http_rewrites([rewrite])
+                .package_cache_dir(cache_dir)
+                .offline(true)
+                .eval_to_json(&config_path),
+        )
+        .unwrap();
+    assert_eq!(second["base"], 41);
+    assert_eq!(second["answer"], 42);
+}
+
+#[test]
+fn unreadable_package_cache_is_a_miss_while_online() {
+    use std::io::{Read, Write};
+    use std::net::TcpListener;
+    use std::thread;
+
+    let temp = TestTempDir::new("pklr_test_unreadable_package_cache");
+    let cache_path = temp.path().join("cache");
+    std::fs::write(&cache_path, "not a directory").unwrap();
+    let mut zip_bytes = Vec::new();
+    {
+        let cursor = std::io::Cursor::new(&mut zip_bytes);
+        let mut zip = zip::ZipWriter::new(cursor);
+        zip.start_file("Config.pkl", zip::write::SimpleFileOptions::default())
+            .unwrap();
+        zip.write_all(b"answer = 42\n").unwrap();
+        zip.finish().unwrap();
+    }
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let addr = listener.local_addr().unwrap();
+    let server = thread::spawn(move || {
+        let (mut stream, _) = listener.accept().unwrap();
+        let mut request = [0_u8; 1024];
+        let _ = stream.read(&mut request).unwrap();
+        write!(
+            stream,
+            "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+            zip_bytes.len()
+        )
+        .unwrap();
+        stream.write_all(&zip_bytes).unwrap();
+    });
+
+    let config_path = temp.path().join("config.pkl");
+    std::fs::write(
+        &config_path,
+        "amends \"package://example.com/pkg@1.0.0#/Config.pkl\"\n",
+    )
+    .unwrap();
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    let json = rt
+        .block_on(
+            pklr::EvaluatorBuilder::new()
+                .http_rewrites([format!("https://example.com/=http://{addr}/")])
+                .package_cache_dir(cache_path)
+                .eval_to_json(&config_path),
+        )
+        .unwrap();
+    server.join().unwrap();
+    assert_eq!(json["answer"], 42);
+}
+
+#[test]
+fn offline_package_cache_miss_is_actionable() {
+    let temp = TestTempDir::new("pklr_test_offline_package_cache_miss");
+    let config_path = temp.path().join("config.pkl");
+    std::fs::write(
+        &config_path,
+        "amends \"package://example.com/pkg@1.0.0#/Config.pkl\"\n",
+    )
+    .unwrap();
+
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    let error = rt
+        .block_on(
+            pklr::EvaluatorBuilder::new()
+                .package_cache_dir(temp.path().join("cache"))
+                .offline(true)
+                .eval_to_json(&config_path),
+        )
+        .unwrap_err()
+        .to_string();
+    assert!(error.contains("package is not cached and offline mode is enabled"));
+    assert!(error.contains("https://example.com/pkg@1.0.0.zip"));
+}


### PR DESCRIPTION
## Summary

- add an optional persistent cache for downloaded `package://` content
- add offline evaluation that reuses cached packages while blocking network access
- validate cached package data and replace corrupt entries when online
- write cache entries atomically for safe concurrent evaluator processes

## Motivation

Consumers such as hk already cache their fully evaluated configuration, but a cold or invalidated consumer cache causes pklr to download the same package again. That makes configuration evaluation depend on the package host after config edits, upgrades, or cache cleanup.

The new private-field `EvaluatorBuilder` lets hosts configure persistent package caching and offline evaluation without breaking callers that construct the existing public `EvalOptions` struct. Cache misses in offline mode are deterministic and actionable instead of attempting the network.

## Validation

- `cargo test`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo semver-checks check-release` (223/223 checks passed)
- hermetic test that downloads from a one-request server, destroys the first evaluator and server, then evaluates successfully with a new offline evaluator
- offline cache-miss error test

Dependent integration: [jdx/hk#1199](https://github.com/jdx/hk/pull/1199) adopts this API and is intentionally red until a pklr release containing it is available.

*AI-assisted — Tool: Codex; model: unavailable/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes package import and network I/O behavior (caching, offline, relative package URLs); mistakes could cause stale packages or unexpected fetch failures, but scope is isolated to package/HTTP paths with strong integration tests.
> 
> **Overview**
> Adds **persistent on-disk caching** for `package://` downloads and an **offline** mode so evaluation can reuse cached packages without hitting the network.
> 
> Hosts configure this via a new **`EvaluatorBuilder`** (`package_cache_dir`, `offline`, plus existing HTTP client/rewrites). `eval_with_options` is wired through the builder without extending the public `EvalOptions` struct.
> 
> Package fetches (`.pkl` and `.zip`) go through **`fetch_package_bytes`**: read cache by FNV-keyed paths with a URL sidecar, validate content (UTF-8 for sources, full zip entry reads when enabled), fetch on miss when online, and write with **atomic** temp-and-rename. Corrupt cache entries are dropped and refetched online; offline misses return a clear error. **Direct** GitHub-style packages now carry an HTTP **root** so relative imports under that release path use the same package cache path instead of generic HTTP fetch (which offline blocks).
> 
> Zip extraction keys in-memory dirs by the **source** zip URL (not the rewritten mirror URL). README documents the builder usage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9100b1ab858c3a662cbb73ed8c080a1fc73e56b6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->