### PR TITLE
chore: release v1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.4.0](https://github.com/jdx/pklr/compare/v1.3.0...v1.4.0) - 2026-08-12
+
+### Added
+
+- persist package downloads for offline evaluation ([#153](https://github.com/jdx/pklr/pull/153))
+
 ## [1.3.0](https://github.com/jdx/pklr/compare/v1.2.0...v1.3.0) - 2026-08-03
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -677,7 +677,7 @@ checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "pklr"
-version = "1.3.0"
+version = "1.4.0"
 dependencies = [
  "async-recursion",
  "indexmap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "pklr"
-version     = "1.3.0"
+version     = "1.4.0"
 edition      = "2024"
 rust-version = "1.88"
 description = "Pure Rust pkl configuration language parser and evaluator"


### PR DESCRIPTION



## 🤖 New release

* `pklr`: 1.3.0 -> 1.4.0 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [1.4.0](https://github.com/jdx/pklr/compare/v1.3.0...v1.4.0) - 2026-08-12

### Added

- persist package downloads for offline evaluation ([#153](https://github.com/jdx/pklr/pull/153))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical release metadata only; no runtime or API code changes in this diff.
> 
> **Overview**
> **Release v1.4.0** — bumps `pklr` from **1.3.0** to **1.4.0** in `Cargo.toml` / `Cargo.lock` and documents the release in `CHANGELOG.md`.
> 
> The changelog calls out **persisting package downloads for offline evaluation** ([#153](https://github.com/jdx/pklr/pull/153)) as the user-facing addition in this version; this PR does not include that implementation, only the version and release notes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8c210a7df01bf57701e486fdc2770d37067cd98f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->