### PR TITLE
feat: add preload_package to seed the package cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ No external binary or CLI required.
 - Lexer, parser, and evaluator written entirely in Rust
 - Evaluates `.pkl` files to `serde_json::Value`
 - Import and amends resolution for local files
-- Persistent caching and offline evaluation for `package://` imports
+- Persistent caching, cache preloading, and offline evaluation for `package://` imports
 - String interpolation, lambdas, higher-order methods
 - Rich error diagnostics via [miette](https://crates.io/crates/miette)
 
@@ -33,6 +33,25 @@ async fn load_config() -> pklr::Result<serde_json::Value> {
         .await
 }
 ```
+
+A host that already ships a copy of a package can seed the cache with it,
+so a config importing that package evaluates without any network round trip:
+
+```rust
+static PACKAGE: &[u8] = include_bytes!("pkg@1.0.0.zip");
+
+async fn load_bundled_config() -> pklr::Result<serde_json::Value> {
+    pklr::EvaluatorBuilder::new()
+        .package_cache_dir(".pklr-cache")
+        .preload_package("https://example.com/pkg@1.0.0.zip", "zip", PACKAGE)
+        .eval_to_json(std::path::Path::new("config.pkl"))
+        .await
+}
+```
+
+Cached content already on disk wins, so preloading never overrides a package
+fetched from the network, and a config pinning a different version still
+resolves that version normally.
 
 ## License
 

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -417,21 +417,29 @@ impl Evaluator {
         }
     }
 
+    /// Cache `bytes` for `url`, ignoring failures.
+    ///
+    /// The cache is an optimization for downloads, so a cache that cannot be
+    /// written must not fail an evaluation that already has the bytes.
     fn write_package_cache(&self, url: &str, extension: &str, bytes: &[u8]) {
+        let _ = self.write_package_cache_checked(url, extension, bytes);
+    }
+
+    /// Cache `bytes` for `url`, reporting why the write failed.
+    ///
+    /// Callers that treat a cache entry as the only copy of a package need to
+    /// know it was actually stored.
+    fn write_package_cache_checked(&self, url: &str, extension: &str, bytes: &[u8]) -> Result<()> {
         let Some(cache_dir) = &self.package_cache_dir else {
-            return;
+            return Ok(());
         };
         let (data_path, url_path) = package_cache_paths(cache_dir, url, extension);
         let Some(parent) = data_path.parent() else {
-            return;
+            return Ok(());
         };
-        if std::fs::create_dir_all(parent).is_err() {
-            return;
-        }
-        if write_atomic(&data_path, bytes).is_err() {
-            return;
-        }
-        let _ = write_atomic(&url_path, url.as_bytes());
+        std::fs::create_dir_all(parent).map_err(|error| Error::Io(parent.to_path_buf(), error))?;
+        write_atomic(&data_path, bytes).map_err(|error| Error::Io(data_path, error))?;
+        write_atomic(&url_path, url.as_bytes()).map_err(|error| Error::Io(url_path, error))
     }
 
     /// Seed the persistent package cache with `bytes` for `url`.
@@ -441,8 +449,14 @@ impl Evaluator {
     /// archive packages and `"pkl"` for direct file downloads.
     ///
     /// A cache entry that is already present and valid wins, so preloading
-    /// never overrides content fetched from the network. Does nothing when no
-    /// package cache directory is configured.
+    /// never overrides content fetched from the network. Like the rest of the
+    /// cache this check is not synchronized across processes: an evaluator
+    /// racing a download of the same URL can still replace it, which is
+    /// harmless because both hold that URL's version of the package.
+    ///
+    /// Does nothing when no package cache directory is configured. Returns an
+    /// error when the bytes are not a valid package or could not be stored, so
+    /// a host cannot mistake a failed seed for a usable cache entry.
     pub fn preload_package(&self, url: &str, extension: &str, bytes: &[u8]) -> Result<()> {
         if self.package_cache_dir.is_none() {
             return Ok(());
@@ -453,8 +467,7 @@ impl Evaluator {
             return Ok(());
         }
         validate_package_bytes(url, extension, bytes)?;
-        self.write_package_cache(url, extension, bytes);
-        Ok(())
+        self.write_package_cache_checked(url, extension, bytes)
     }
 
     fn remove_package_cache(&self, url: &str, extension: &str) {

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -393,8 +393,7 @@ impl Evaluator {
         let fetch_url = self.rewrite_url(url).into_owned();
         let bytes = self.capabilities.fetch_bytes(&fetch_url).await?;
         validate_package_bytes(url, extension, &bytes)?;
-        // The cache is only an optimization here: the bytes are already in
-        // hand, so a cache that cannot be written must not fail the fetch.
+        // Best-effort: the bytes are already in hand.
         let _ = self.write_package_cache(url, extension, &bytes);
         Ok(bytes)
     }
@@ -419,11 +418,7 @@ impl Evaluator {
         }
     }
 
-    /// Cache `bytes` for `url`.
-    ///
-    /// Callers that treat the cache as an optimization ignore the error; one
-    /// that treats the entry as the only copy of a package needs to know it
-    /// was actually stored.
+    /// Cache `bytes` for `url`. The fetch path ignores the error; preloading does not.
     fn write_package_cache(&self, url: &str, extension: &str, bytes: &[u8]) -> Result<()> {
         let Some(cache_dir) = &self.package_cache_dir else {
             return Ok(());
@@ -439,19 +434,10 @@ impl Evaluator {
 
     /// Seed the persistent package cache with `bytes` for `url`.
     ///
-    /// Lets a host embed a package it already ships and evaluate configs that
-    /// import it without a network round trip. `extension` is `"zip"` for
-    /// archive packages and `"pkl"` for direct file downloads.
-    ///
-    /// A cache entry that is already present and valid wins, so preloading
-    /// never overrides content fetched from the network. Like the rest of the
-    /// cache this check is not synchronized across processes: an evaluator
-    /// racing a download of the same URL can still replace it, which is
-    /// harmless because both hold that URL's version of the package.
-    ///
-    /// Does nothing when no package cache directory is configured. Returns an
-    /// error when the bytes are not a valid package or could not be stored, so
-    /// a host cannot mistake a failed seed for a usable cache entry.
+    /// `extension` is `"zip"` for archive packages and `"pkl"` for direct file
+    /// downloads. A valid cache entry already present wins, so preloading never
+    /// overrides content fetched from the network. Does nothing when no package
+    /// cache directory is configured.
     pub fn preload_package(&self, url: &str, extension: &str, bytes: &[u8]) -> Result<()> {
         if self.package_cache_dir.is_none() {
             return Ok(());

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -393,7 +393,9 @@ impl Evaluator {
         let fetch_url = self.rewrite_url(url).into_owned();
         let bytes = self.capabilities.fetch_bytes(&fetch_url).await?;
         validate_package_bytes(url, extension, &bytes)?;
-        self.write_package_cache(url, extension, &bytes);
+        // The cache is only an optimization here: the bytes are already in
+        // hand, so a cache that cannot be written must not fail the fetch.
+        let _ = self.write_package_cache(url, extension, &bytes);
         Ok(bytes)
     }
 
@@ -417,19 +419,12 @@ impl Evaluator {
         }
     }
 
-    /// Cache `bytes` for `url`, ignoring failures.
+    /// Cache `bytes` for `url`.
     ///
-    /// The cache is an optimization for downloads, so a cache that cannot be
-    /// written must not fail an evaluation that already has the bytes.
-    fn write_package_cache(&self, url: &str, extension: &str, bytes: &[u8]) {
-        let _ = self.write_package_cache_checked(url, extension, bytes);
-    }
-
-    /// Cache `bytes` for `url`, reporting why the write failed.
-    ///
-    /// Callers that treat a cache entry as the only copy of a package need to
-    /// know it was actually stored.
-    fn write_package_cache_checked(&self, url: &str, extension: &str, bytes: &[u8]) -> Result<()> {
+    /// Callers that treat the cache as an optimization ignore the error; one
+    /// that treats the entry as the only copy of a package needs to know it
+    /// was actually stored.
+    fn write_package_cache(&self, url: &str, extension: &str, bytes: &[u8]) -> Result<()> {
         let Some(cache_dir) = &self.package_cache_dir else {
             return Ok(());
         };
@@ -461,13 +456,13 @@ impl Evaluator {
         if self.package_cache_dir.is_none() {
             return Ok(());
         }
-        if matches!(self.read_package_cache(url, extension), Ok(Some(cached))
-            if validate_package_bytes(url, extension, &cached).is_ok())
+        if let Ok(Some(cached)) = self.read_package_cache(url, extension)
+            && validate_package_bytes(url, extension, &cached).is_ok()
         {
             return Ok(());
         }
         validate_package_bytes(url, extension, bytes)?;
-        self.write_package_cache_checked(url, extension, bytes)
+        self.write_package_cache(url, extension, bytes)
     }
 
     fn remove_package_cache(&self, url: &str, extension: &str) {

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -434,6 +434,29 @@ impl Evaluator {
         let _ = write_atomic(&url_path, url.as_bytes());
     }
 
+    /// Seed the persistent package cache with `bytes` for `url`.
+    ///
+    /// Lets a host embed a package it already ships and evaluate configs that
+    /// import it without a network round trip. `extension` is `"zip"` for
+    /// archive packages and `"pkl"` for direct file downloads.
+    ///
+    /// A cache entry that is already present and valid wins, so preloading
+    /// never overrides content fetched from the network. Does nothing when no
+    /// package cache directory is configured.
+    pub fn preload_package(&self, url: &str, extension: &str, bytes: &[u8]) -> Result<()> {
+        if self.package_cache_dir.is_none() {
+            return Ok(());
+        }
+        if matches!(self.read_package_cache(url, extension), Ok(Some(cached))
+            if validate_package_bytes(url, extension, &cached).is_ok())
+        {
+            return Ok(());
+        }
+        validate_package_bytes(url, extension, bytes)?;
+        self.write_package_cache(url, extension, bytes);
+        Ok(())
+    }
+
     fn remove_package_cache(&self, url: &str, extension: &str) {
         let Some(cache_dir) = &self.package_cache_dir else {
             return;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,6 +66,15 @@ pub struct EvaluatorBuilder {
     http_rewrites: Vec<String>,
     package_cache_dir: Option<std::path::PathBuf>,
     offline: bool,
+    preloaded_packages: Vec<PreloadedPackage>,
+}
+
+/// Package content a host supplies up front instead of fetching it.
+#[cfg(feature = "native-io")]
+struct PreloadedPackage {
+    url: String,
+    extension: String,
+    bytes: std::borrow::Cow<'static, [u8]>,
 }
 
 #[cfg(feature = "native-io")]
@@ -99,7 +108,33 @@ impl EvaluatorBuilder {
         self
     }
 
+    /// Seed the package cache with content the host already has.
+    ///
+    /// Lets a host that ships a copy of a package evaluate configs importing
+    /// it without a network round trip. `extension` is `"zip"` for archive
+    /// packages and `"pkl"` for direct file downloads. Requires
+    /// [`package_cache_dir`](Self::package_cache_dir).
+    ///
+    /// Cached content already on disk wins, so this never overrides a package
+    /// fetched from the network.
+    pub fn preload_package(
+        mut self,
+        url: impl Into<String>,
+        extension: impl Into<String>,
+        bytes: impl Into<std::borrow::Cow<'static, [u8]>>,
+    ) -> Self {
+        self.preloaded_packages.push(PreloadedPackage {
+            url: url.into(),
+            extension: extension.into(),
+            bytes: bytes.into(),
+        });
+        self
+    }
+
     /// Build a configured evaluator for direct source evaluation.
+    ///
+    /// A preloaded package that fails to seed is skipped rather than reported:
+    /// evaluation then fetches it the usual way.
     pub fn build(self) -> Evaluator {
         let mut evaluator = Evaluator::new();
         #[cfg(feature = "http")]
@@ -111,6 +146,9 @@ impl EvaluatorBuilder {
             evaluator.set_package_cache_dir(cache_dir);
         }
         evaluator.set_offline(self.offline);
+        for package in &self.preloaded_packages {
+            let _ = evaluator.preload_package(&package.url, &package.extension, &package.bytes);
+        }
         evaluator
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -108,15 +108,8 @@ impl EvaluatorBuilder {
         self
     }
 
-    /// Seed the package cache with content the host already has.
-    ///
-    /// Lets a host that ships a copy of a package evaluate configs importing
-    /// it without a network round trip. `extension` is `"zip"` for archive
-    /// packages and `"pkl"` for direct file downloads. Requires
-    /// [`package_cache_dir`](Self::package_cache_dir).
-    ///
-    /// Cached content already on disk wins, so this never overrides a package
-    /// fetched from the network.
+    /// Seed the package cache with content the host already has, instead of
+    /// fetching it. Requires [`package_cache_dir`](Self::package_cache_dir).
     pub fn preload_package(
         mut self,
         url: impl Into<String>,
@@ -133,8 +126,7 @@ impl EvaluatorBuilder {
 
     /// Build a configured evaluator for direct source evaluation.
     ///
-    /// A preloaded package that fails to seed is skipped rather than reported:
-    /// evaluation then fetches it the usual way.
+    /// A package that fails to preload is skipped and fetched normally.
     pub fn build(self) -> Evaluator {
         let mut evaluator = Evaluator::new();
         #[cfg(feature = "http")]

--- a/tests/pkl_features.rs
+++ b/tests/pkl_features.rs
@@ -5523,6 +5523,30 @@ fn preloading_invalid_package_bytes_is_rejected() {
 }
 
 #[test]
+fn preloading_reports_a_cache_write_failure() {
+    let temp = TestTempDir::new("pklr_test_preload_write_failure");
+    // A file where the cache directory belongs: the seed cannot be stored, and
+    // reporting success would leave the host expecting a usable cache entry.
+    let cache_path = temp.path().join("cache");
+    std::fs::write(&cache_path, b"not a directory").unwrap();
+
+    let mut evaluator = pklr::Evaluator::new();
+    evaluator.set_package_cache_dir(&cache_path);
+    let error = evaluator
+        .preload_package(
+            "https://example.com/pkg@1.0.0.zip",
+            "zip",
+            &package_zip("Config.pkl", "answer = 42\n"),
+        )
+        .unwrap_err()
+        .to_string();
+    assert!(
+        error.contains(&cache_path.display().to_string()),
+        "error should name the cache path: {error}"
+    );
+}
+
+#[test]
 fn direct_package_relatives_survive_across_offline_evaluators() {
     use std::io::{Read, Write};
     use std::net::TcpListener;

--- a/tests/pkl_features.rs
+++ b/tests/pkl_features.rs
@@ -5371,6 +5371,157 @@ fn package_cache_survives_across_offline_evaluators() {
     assert_eq!(second["answer"], 42);
 }
 
+/// Build a single-entry package zip holding `contents` at `name`.
+#[cfg(feature = "package-zip")]
+fn package_zip(name: &str, contents: &str) -> Vec<u8> {
+    use std::io::Write;
+
+    let mut bytes = Vec::new();
+    {
+        let cursor = std::io::Cursor::new(&mut bytes);
+        let mut zip = zip::ZipWriter::new(cursor);
+        zip.start_file(name, zip::write::SimpleFileOptions::default())
+            .unwrap();
+        zip.write_all(contents.as_bytes()).unwrap();
+        zip.finish().unwrap();
+    }
+    bytes
+}
+
+#[test]
+fn preloaded_package_evaluates_offline_without_a_cold_start() {
+    let temp = TestTempDir::new("pklr_test_preloaded_package");
+    let config_path = temp.path().join("config.pkl");
+    std::fs::write(
+        &config_path,
+        "amends \"package://example.com/pkg@1.0.0#/Config.pkl\"\n",
+    )
+    .unwrap();
+
+    // No server is ever started: the preloaded zip is the only source.
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    let json = rt
+        .block_on(
+            pklr::EvaluatorBuilder::new()
+                .package_cache_dir(temp.path().join("cache"))
+                .offline(true)
+                .preload_package(
+                    "https://example.com/pkg@1.0.0.zip",
+                    "zip",
+                    package_zip("Config.pkl", "answer = 42\n"),
+                )
+                .eval_to_json(&config_path),
+        )
+        .unwrap();
+    assert_eq!(json["answer"], 42);
+}
+
+#[test]
+fn preloaded_package_does_not_override_a_cached_download() {
+    use std::io::{Read, Write};
+    use std::net::TcpListener;
+    use std::thread;
+
+    let temp = TestTempDir::new("pklr_test_preload_precedence");
+    let cache_dir = temp.path().join("cache");
+    let fetched = package_zip("Config.pkl", "answer = 42\n");
+
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let addr = listener.local_addr().unwrap();
+    let server = thread::spawn(move || {
+        let (mut stream, _) = listener.accept().unwrap();
+        let mut request = [0_u8; 1024];
+        let _ = stream.read(&mut request).unwrap();
+        write!(
+            stream,
+            "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+            fetched.len()
+        )
+        .unwrap();
+        stream.write_all(&fetched).unwrap();
+    });
+
+    let config_path = temp.path().join("config.pkl");
+    std::fs::write(
+        &config_path,
+        "amends \"package://example.com/pkg@1.0.0#/Config.pkl\"\n",
+    )
+    .unwrap();
+    let rewrite = format!("https://example.com/=http://{addr}/");
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    rt.block_on(
+        pklr::EvaluatorBuilder::new()
+            .http_rewrites([rewrite])
+            .package_cache_dir(cache_dir.clone())
+            .eval_to_json(&config_path),
+    )
+    .unwrap();
+    server.join().unwrap();
+
+    // The downloaded package is already cached, so the preloaded copy is ignored.
+    let json = rt
+        .block_on(
+            pklr::EvaluatorBuilder::new()
+                .package_cache_dir(cache_dir)
+                .offline(true)
+                .preload_package(
+                    "https://example.com/pkg@1.0.0.zip",
+                    "zip",
+                    package_zip("Config.pkl", "answer = 7\n"),
+                )
+                .eval_to_json(&config_path),
+        )
+        .unwrap();
+    assert_eq!(json["answer"], 42);
+}
+
+#[test]
+fn preloading_a_package_for_another_version_is_a_cache_miss() {
+    let temp = TestTempDir::new("pklr_test_preload_version_mismatch");
+    let config_path = temp.path().join("config.pkl");
+    // The config pins 2.0.0 while the preloaded package is 1.0.0.
+    std::fs::write(
+        &config_path,
+        "amends \"package://example.com/pkg@2.0.0#/Config.pkl\"\n",
+    )
+    .unwrap();
+
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    let error = rt
+        .block_on(
+            pklr::EvaluatorBuilder::new()
+                .package_cache_dir(temp.path().join("cache"))
+                .offline(true)
+                .preload_package(
+                    "https://example.com/pkg@1.0.0.zip",
+                    "zip",
+                    package_zip("Config.pkl", "answer = 42\n"),
+                )
+                .eval_to_json(&config_path),
+        )
+        .unwrap_err()
+        .to_string();
+    assert!(
+        error.contains("package is not cached and offline mode is enabled"),
+        "unexpected error: {error}"
+    );
+}
+
+#[test]
+fn preloading_invalid_package_bytes_is_rejected() {
+    let temp = TestTempDir::new("pklr_test_preload_invalid");
+    let mut evaluator = pklr::Evaluator::new();
+    evaluator.set_package_cache_dir(temp.path().join("cache"));
+    let error = evaluator
+        .preload_package("https://example.com/pkg@1.0.0.zip", "zip", b"not a zip")
+        .unwrap_err()
+        .to_string();
+    assert!(
+        error.contains("package archive is invalid"),
+        "unexpected error: {error}"
+    );
+}
+
 #[test]
 fn direct_package_relatives_survive_across_offline_evaluators() {
     use std::io::{Read, Write};


### PR DESCRIPTION
## Summary

Adds `preload_package` so a host that already ships a copy of a package can seed the persistent cache with it instead of fetching it.

pklr can already reuse a cache and evaluate offline, but both still need one online cold start to populate that cache. A host holding the bytes has no reason to fetch them.

Preloading is the lowest-precedence source: an existing valid cache entry wins, so seeding never masks a real download, and a preload for a version the config does not pin stays a cache miss.

## Validation

- `cargo test` (379 passed), `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`
- `cargo semver-checks check-release` (223/223, no semver update required)
- new tests: offline evaluation from a preload with no server running; a preload ignored when the package is already cached; a non-pinned version staying a miss; invalid bytes and failed cache writes both reported

## Context

The pklr half of [jdx/hk discussion #1216](https://github.com/jdx/hk/discussions/1216). [jdx/hk#1218](https://github.com/jdx/hk/pull/1218) adopts this API and stays red until a pklr release carries it.

*AI-assisted — Tool: Claude Code; model: anthropic/claude-opus-5; version: unavailable.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for preloading package content before evaluation, enabling offline use and reducing network requests.
  * Existing cached packages retain precedence, with version resolution behavior unchanged.
  * Invalid preloaded package data is rejected, allowing normal retrieval to continue when needed.

* **Bug Fixes**
  * Improved handling and reporting of package cache write failures without discarding successfully fetched content.

* **Documentation**
  * Added Rust usage guidance and an example for preloading bundled package data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->