### PR TITLE
chore: release v1.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.5.0](https://github.com/jdx/pklr/compare/v1.4.0...v1.5.0) - 2026-08-23
+
+### Added
+
+- add preload_package to seed the package cache ([#157](https://github.com/jdx/pklr/pull/157))
+
 ## [1.4.0](https://github.com/jdx/pklr/compare/v1.3.0...v1.4.0) - 2026-08-12
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -677,7 +677,7 @@ checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "pklr"
-version = "1.4.0"
+version = "1.5.0"
 dependencies = [
  "async-recursion",
  "indexmap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "pklr"
-version     = "1.4.0"
+version     = "1.5.0"
 edition      = "2024"
 rust-version = "1.88"
 description = "Pure Rust pkl configuration language parser and evaluator"


### PR DESCRIPTION



## 🤖 New release

* `pklr`: 1.4.0 -> 1.5.0 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [1.5.0](https://github.com/jdx/pklr/compare/v1.4.0...v1.5.0) - 2026-08-23

### Added

- add preload_package to seed the package cache ([#157](https://github.com/jdx/pklr/pull/157))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version and changelog only; no functional or security-sensitive code changes.
> 
> **Overview**
> Bumps `pklr` from **1.4.0** to **1.5.0** and records the release in `CHANGELOG.md`.
> 
> The 1.5.0 notes cover adding `preload_package` to seed the package cache (#157). No runtime code changes in this PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0c3a18e1077cbaab24dde50c57c76107de079ef4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->