### PR TITLE
fix(eval): complete class-as-function semantics

### DIFF
--- a/src/eval.rs
+++ b/src/eval.rs
@@ -1413,7 +1413,8 @@ impl Evaluator {
                     // calls a lambda local defined just above it).
                     let val = self.eval_expr(expr, &child_scope, depth).await?;
                     child_scope.set(prop.name.clone(), val);
-                    if matches!(expr, Expr::Ident(name) if name == "this") {
+                    if matches!(expr, Expr::Ident(name) if name == "this" || this_aliases.contains(name))
+                    {
                         this_aliases.push(prop.name.clone());
                     }
                     if matches!(expr, crate::parser::Expr::Lambda(..)) {
@@ -1911,7 +1912,7 @@ impl Evaluator {
         // Evaluate the merged entries (eval_entries handles locals, classes,
         // and evaluates properties in order with each added to scope)
         let result = self.eval_entries(&merged, &eval_scope, depth + 1).await?;
-        if let Value::Object(map, _) = &result {
+        if let Value::Object(map, source) = &result {
             for entry in base_entries {
                 let Entry::Property(prop) = entry else {
                     continue;
@@ -1919,7 +1920,12 @@ impl Evaluator {
                 let Some(type_ann) = &prop.type_ann else {
                     continue;
                 };
-                let Some(value) = map.get(&prop.name) else {
+                let value = map.get(&prop.name).or_else(|| {
+                    source
+                        .as_ref()
+                        .and_then(|source| source.scope.get(&prop.name))
+                });
+                let Some(value) = value else {
                     continue;
                 };
                 if type_is_runtime_checkable(type_ann, &eval_scope)
@@ -3412,29 +3418,30 @@ impl Evaluator {
                     .collect::<Vec<_>>();
 
                 if !type_names.is_empty() {
-                    for (conv_name, lambda) in converters {
-                        let matches = type_names
-                            .iter()
-                            .any(|type_name| type_names_match(conv_name, type_name));
-                        if matches
-                            && !blocked_root_converters.contains(conv_name)
-                            && let Value::Lambda(params, body, captured) = lambda
-                        {
-                            let mut call_scope = Scope::default();
-                            for (k, v) in captured.iter() {
-                                call_scope.set(k.clone(), v.clone());
+                    for type_name in type_names {
+                        for (conv_name, lambda) in converters {
+                            if type_names_match(conv_name, type_name)
+                                && !blocked_root_converters.contains(conv_name)
+                                && let Value::Lambda(params, body, captured) = lambda
+                            {
+                                let mut call_scope = Scope::default();
+                                for (k, v) in captured.iter() {
+                                    call_scope.set(k.clone(), v.clone());
+                                }
+                                // Bind the object as the first parameter
+                                if let Some(param) = params.first() {
+                                    call_scope.set(
+                                        param.clone(),
+                                        Value::Object(map.clone(), src.clone()),
+                                    );
+                                }
+                                let result = self.eval_expr(body, &call_scope, 0).await?;
+                                let mut blocked = blocked_root_converters;
+                                blocked.push(conv_name.clone());
+                                return self
+                                    .apply_converters_recursive(result, converters, blocked)
+                                    .await;
                             }
-                            // Bind the object as the first parameter
-                            if let Some(param) = params.first() {
-                                call_scope
-                                    .set(param.clone(), Value::Object(map.clone(), src.clone()));
-                            }
-                            let result = self.eval_expr(body, &call_scope, 0).await?;
-                            let mut blocked = blocked_root_converters;
-                            blocked.push(conv_name.clone());
-                            return self
-                                .apply_converters_recursive(result, converters, blocked)
-                                .await;
                         }
                     }
                 }

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -1389,6 +1389,16 @@ impl Evaluator {
         }
         let outer_obj = Value::Object(Arc::new(outer_map), None);
         child_scope.set("outer".into(), outer_obj);
+        // Class-as-a-function definitions commonly use `local self = this` so
+        // output properties can close over the amended instance. Bind `this`
+        // before locals are evaluated, then keep direct aliases synchronized as
+        // properties populate the instance.
+        let mut all_props: IndexMap<String, Value> = IndexMap::new();
+        child_scope.set(
+            "this".into(),
+            Value::Object(Arc::new(all_props.clone()), None),
+        );
+        let mut this_aliases = Vec::new();
         // First pass: collect locals, class definitions, and type aliases in
         // declaration order so they can reference each other correctly.
         // Non-lambda locals are evaluated eagerly; lambda locals are deferred
@@ -1405,6 +1415,9 @@ impl Evaluator {
                     // calls a lambda local defined just above it).
                     let val = self.eval_expr(expr, &child_scope, depth).await?;
                     child_scope.set(prop.name.clone(), val);
+                    if matches!(expr, Expr::Ident(name) if name == "this") {
+                        this_aliases.push(prop.name.clone());
+                    }
                     if matches!(expr, crate::parser::Expr::Lambda(..)) {
                         // Lambda evaluation only captures the current scope; it
                         // does not run the body. Bind once for declaration-order
@@ -1438,13 +1451,6 @@ impl Evaluator {
             .await?;
 
         let mut map: IndexMap<String, Value> = IndexMap::new();
-        // all_props includes hidden properties — used for `this` snapshot
-        let mut all_props: IndexMap<String, Value> = IndexMap::new();
-        // Bind `this` so properties can reference the object being built
-        child_scope.set(
-            "this".into(),
-            Value::Object(Arc::new(all_props.clone()), None),
-        );
         for entry in entries {
             match entry {
                 Entry::Property(prop) => {
@@ -1461,6 +1467,11 @@ impl Evaluator {
                         && prop.body.is_none()
                     {
                         continue; // abstract without value — skip (must be overridden)
+                    }
+                    let snapshot = Value::Object(Arc::new(all_props.clone()), None);
+                    child_scope.set("this".into(), snapshot.clone());
+                    for alias in &this_aliases {
+                        child_scope.set(alias.clone(), snapshot.clone());
                     }
                     if let Some(v) = self.eval_property(prop, &child_scope, depth).await? {
                         child_scope.set(prop.name.clone(), v.clone());

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -1395,11 +1395,8 @@ impl Evaluator {
         // before locals are evaluated, then keep direct aliases synchronized as
         // properties populate the instance.
         let mut all_props: IndexMap<String, Value> = IndexMap::new();
-        child_scope.set(
-            "this".into(),
-            Value::Object(Arc::new(all_props.clone()), None),
-        );
         let mut this_aliases = Vec::new();
+        refresh_this_aliases(&mut child_scope, &this_aliases, &all_props);
         // First pass: collect locals, class definitions, and type aliases in
         // declaration order so they can reference each other correctly.
         // Non-lambda locals are evaluated eagerly; lambda locals are deferred
@@ -1469,22 +1466,14 @@ impl Evaluator {
                     {
                         continue; // abstract without value — skip (must be overridden)
                     }
-                    let snapshot = Value::Object(Arc::new(all_props.clone()), None);
-                    child_scope.set("this".into(), snapshot.clone());
-                    for alias in &this_aliases {
-                        child_scope.set(alias.clone(), snapshot.clone());
-                    }
+                    refresh_this_aliases(&mut child_scope, &this_aliases, &all_props);
                     if let Some(v) = self.eval_property(prop, &child_scope, depth).await? {
                         child_scope.set(prop.name.clone(), v.clone());
                         all_props.insert(prop.name.clone(), v.clone());
                         if !has_modifier(mods, Modifier::Hidden) {
                             map.insert(prop.name.clone(), v);
                         }
-                        // Update `this` with all properties (including hidden)
-                        child_scope.set(
-                            "this".into(),
-                            Value::Object(Arc::new(all_props.clone()), None),
-                        );
+                        refresh_this_aliases(&mut child_scope, &this_aliases, &all_props);
                     }
                 }
                 Entry::DynProperty(key_expr, val_expr) => {
@@ -1537,12 +1526,16 @@ impl Evaluator {
                         val
                     };
                     let key_str = value_to_key(&key)?;
+                    all_props.insert(key_str.clone(), val.clone());
                     map.insert(key_str, val);
+                    refresh_this_aliases(&mut child_scope, &this_aliases, &all_props);
                 }
                 Entry::Spread(expr) => {
                     let val = self.eval_expr(expr, &child_scope, depth).await?;
                     if let Value::Object(m, _) = val {
+                        all_props.extend(m.iter().map(|(k, v)| (k.clone(), v.clone())));
                         map.extend(m.iter().map(|(k, v)| (k.clone(), v.clone())));
+                        refresh_this_aliases(&mut child_scope, &this_aliases, &all_props);
                     }
                 }
                 Entry::ForGenerator(fgen) => {
@@ -1558,7 +1551,9 @@ impl Evaluator {
                         }
                         let body_val = self.eval_entries(&fgen.body, &iter_scope, depth).await?;
                         if let Value::Object(m, _) = body_val {
+                            all_props.extend(m.iter().map(|(k, v)| (k.clone(), v.clone())));
                             map.extend(m.iter().map(|(k, v)| (k.clone(), v.clone())));
+                            refresh_this_aliases(&mut child_scope, &this_aliases, &all_props);
                         }
                     }
                 }
@@ -1567,12 +1562,16 @@ impl Evaluator {
                     if is_truthy(&cond) {
                         let body_val = self.eval_entries(&wgen.body, &child_scope, depth).await?;
                         if let Value::Object(m, _) = body_val {
+                            all_props.extend(m.iter().map(|(k, v)| (k.clone(), v.clone())));
                             map.extend(m.iter().map(|(k, v)| (k.clone(), v.clone())));
+                            refresh_this_aliases(&mut child_scope, &this_aliases, &all_props);
                         }
                     } else if let Some(else_body) = &wgen.else_body {
                         let else_val = self.eval_entries(else_body, &child_scope, depth).await?;
                         if let Value::Object(m, _) = else_val {
+                            all_props.extend(m.iter().map(|(k, v)| (k.clone(), v.clone())));
                             map.extend(m.iter().map(|(k, v)| (k.clone(), v.clone())));
+                            refresh_this_aliases(&mut child_scope, &this_aliases, &all_props);
                         }
                     }
                 }
@@ -1582,6 +1581,7 @@ impl Evaluator {
         }
         // Evaluate deferred local lambdas (function definitions) AFTER all
         // properties so they capture overridden values (late binding).
+        refresh_this_aliases(&mut child_scope, &this_aliases, &all_props);
         for (name, expr) in deferred_lambdas {
             let val = self.eval_expr(expr, &child_scope, depth).await?;
             child_scope.set(name, val);
@@ -3462,6 +3462,18 @@ impl Evaluator {
             }
             other => Ok(other),
         }
+    }
+}
+
+fn refresh_this_aliases(
+    scope: &mut Scope,
+    aliases: &[String],
+    properties: &IndexMap<String, Value>,
+) {
+    let snapshot = Value::Object(Arc::new(properties.clone()), None);
+    scope.set("this".into(), snapshot.clone());
+    for alias in aliases {
+        scope.set(alias.clone(), snapshot.clone());
     }
 }
 

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -1265,6 +1265,7 @@ impl Evaluator {
                 scope: IndexMap::new(),
                 is_open: true,
                 type_name: None,
+                parent_type_names: Vec::new(),
                 mapping_value_types: Vec::new(),
                 deprecated,
             }))
@@ -1352,7 +1353,7 @@ impl Evaluator {
                         body,
                         scope,
                         depth,
-                        base_type_name,
+                        base_type_name.map(|name| (name, src.parent_type_names.clone())),
                     )
                     .await?,
                 ));
@@ -1500,7 +1501,9 @@ impl Evaluator {
                                 body,
                                 &child_scope,
                                 depth,
-                                src.type_name.clone(),
+                                src.type_name
+                                    .clone()
+                                    .map(|name| (name, src.parent_type_names.clone())),
                             )
                             .await?;
                         // Propagate the template's type_name so converters can match.
@@ -1518,6 +1521,7 @@ impl Evaluator {
                                     scope: IndexMap::new(),
                                     is_open: true,
                                     type_name: Some(tn.clone()),
+                                    parent_type_names: Vec::new(),
                                     mapping_value_types: Vec::new(),
                                     deprecated: merge_deprecated(&src.deprecated, body),
                                 },
@@ -1587,6 +1591,7 @@ impl Evaluator {
             scope: child_scope.flatten(),
             is_open: true, // default: allow new properties
             type_name: None,
+            parent_type_names: Vec::new(),
             mapping_value_types: Vec::new(),
             deprecated: collect_deprecated(entries),
         };
@@ -1609,6 +1614,15 @@ impl Evaluator {
         depth: usize,
     ) -> Result<Value> {
         let parent_val = parent_name.and_then(|name| resolve_dotted(scope, name));
+        let parent_type_names = match &parent_val {
+            Some(Value::Object(_, Some(source))) => source
+                .type_name
+                .iter()
+                .cloned()
+                .chain(source.parent_type_names.iter().cloned())
+                .collect(),
+            _ => Vec::new(),
+        };
 
         let mut child_scope = scope.child();
         if let Some(ref pv) = parent_val {
@@ -1699,6 +1713,7 @@ impl Evaluator {
                 let mut new_src = (*src).clone();
                 new_src.is_open = is_open;
                 new_src.type_name = Some(class_name.to_string());
+                new_src.parent_type_names = parent_type_names;
                 Value::Object(map, Some(Arc::new(new_src)))
             } else {
                 val
@@ -1817,7 +1832,7 @@ impl Evaluator {
         overlay_entries: &[Entry],
         current_scope: &Scope,
         depth: usize,
-        base_type_name: Option<String>,
+        base_type: Option<(String, Vec<String>)>,
     ) -> Result<Value> {
         // Build merged entry list preserving base order.
         // Overridden properties are replaced in-place so that later
@@ -1896,13 +1911,39 @@ impl Evaluator {
         // Evaluate the merged entries (eval_entries handles locals, classes,
         // and evaluates properties in order with each added to scope)
         let result = self.eval_entries(&merged, &eval_scope, depth + 1).await?;
+        if let Value::Object(map, _) = &result {
+            for entry in base_entries {
+                let Entry::Property(prop) = entry else {
+                    continue;
+                };
+                let Some(type_ann) = &prop.type_ann else {
+                    continue;
+                };
+                let Some(value) = map.get(&prop.name) else {
+                    continue;
+                };
+                if type_is_runtime_checkable(type_ann, &eval_scope)
+                    && !self
+                        .eval_type_check(value, type_ann, &eval_scope, depth + 1)
+                        .await?
+                {
+                    return Err(Error::Eval(format!(
+                        "property '{}' expected {}, got {}",
+                        prop.name,
+                        display_type_expr(type_ann),
+                        value_type_name(value)
+                    )));
+                }
+            }
+        }
         // Amending an object preserves its class identity (so `is Foo` and
         // output converters still match). eval_entries does not know the base
         // type, so re-tag the result here.
-        match (base_type_name, result) {
-            (Some(tn), Value::Object(map, Some(src))) => {
+        match (base_type, result) {
+            (Some((type_name, parent_type_names)), Value::Object(map, Some(src))) => {
                 let mut new_src = (*src).clone();
-                new_src.type_name = Some(tn);
+                new_src.type_name = Some(type_name);
+                new_src.parent_type_names = parent_type_names;
                 Ok(Value::Object(map, Some(Arc::new(new_src))))
             }
             (_, other) => Ok(other),
@@ -2058,6 +2099,7 @@ impl Evaluator {
                             scope: source_scope,
                             is_open: true,
                             type_name: None,
+                            parent_type_names: Vec::new(),
                             mapping_value_types: generic_params.iter().skip(1).cloned().collect(),
                             deprecated,
                         };
@@ -2126,7 +2168,10 @@ impl Evaluator {
                                     entries,
                                     scope,
                                     depth,
-                                    base_src.type_name.clone(),
+                                    base_src
+                                        .type_name
+                                        .clone()
+                                        .map(|name| (name, base_src.parent_type_names.clone())),
                                 )
                                 .await?;
                             // Preserve the base class's is_open flag and tag the
@@ -2139,6 +2184,7 @@ impl Evaluator {
                                         s.is_open = is_open;
                                     }
                                     s.type_name = tn;
+                                    s.parent_type_names = base_src.parent_type_names.clone();
                                     s
                                 } else {
                                     ObjectSource {
@@ -2146,6 +2192,7 @@ impl Evaluator {
                                         scope: IndexMap::new(),
                                         is_open,
                                         type_name: tn,
+                                        parent_type_names: Vec::new(),
                                         mapping_value_types: Vec::new(),
                                         deprecated: merge_deprecated(&base_src.deprecated, entries),
                                     }
@@ -2176,6 +2223,7 @@ impl Evaluator {
                                 scope: IndexMap::new(),
                                 is_open: true,
                                 type_name: type_name.clone(),
+                                parent_type_names: Vec::new(),
                                 mapping_value_types: Vec::new(),
                                 deprecated,
                             };
@@ -2881,7 +2929,10 @@ impl Evaluator {
                         overlay_entries,
                         scope,
                         depth,
-                        base_src.type_name.clone(),
+                        base_src
+                            .type_name
+                            .clone()
+                            .map(|name| (name, base_src.parent_type_names.clone())),
                     )
                     .await;
             }
@@ -3155,7 +3206,9 @@ impl Evaluator {
                                         &overlay_entries,
                                         &entry_scope,
                                         depth,
-                                        src.type_name.clone(),
+                                        src.type_name
+                                            .clone()
+                                            .map(|name| (name, src.parent_type_names.clone())),
                                     )
                                     .await?
                                 } else if explicit_default.is_some() && type_default.is_some() {
@@ -3174,7 +3227,9 @@ impl Evaluator {
                                         body,
                                         &entry_scope,
                                         depth,
-                                        src.type_name.clone(),
+                                        src.type_name
+                                            .clone()
+                                            .map(|name| (name, src.parent_type_names.clone())),
                                     )
                                     .await?
                                 };
@@ -3193,6 +3248,7 @@ impl Evaluator {
                                         scope: IndexMap::new(),
                                         is_open: true,
                                         type_name: Some(tn.to_string()),
+                                        parent_type_names: Vec::new(),
                                         mapping_value_types: Vec::new(),
                                         deprecated: merge_deprecated(&src.deprecated, body),
                                     },
@@ -3262,6 +3318,16 @@ impl Evaluator {
         let Some(output_body) = &output_prop.body else {
             return;
         };
+        let mut converter_scope = scope.child();
+        for entry in output_body {
+            if let Entry::Property(prop) = entry
+                && has_modifier(&prop.modifiers, Modifier::Local)
+                && let Some(expr) = &prop.value
+                && let Ok(value) = self.eval_expr(expr, &converter_scope, depth).await
+            {
+                converter_scope.set(prop.name.clone(), value);
+            }
+        }
         // Find `renderer { converters { ... } }` inside output
         let Some(renderer_body) = output_body.iter().find_map(|entry| {
             if let Entry::Property(p) = entry
@@ -3274,6 +3340,15 @@ impl Evaluator {
         }) else {
             return;
         };
+        for entry in renderer_body {
+            if let Entry::Property(prop) = entry
+                && has_modifier(&prop.modifiers, Modifier::Local)
+                && let Some(expr) = &prop.value
+                && let Ok(value) = self.eval_expr(expr, &converter_scope, depth).await
+            {
+                converter_scope.set(prop.name.clone(), value);
+            }
+        }
         let Some(converters_body) = renderer_body.iter().find_map(|entry| {
             if let Entry::Property(p) = entry
                 && p.name == "converters"
@@ -3296,7 +3371,7 @@ impl Evaluator {
                     _ => continue,
                 };
                 // Evaluate the lambda value
-                if let Ok(lambda) = self.eval_expr(val_expr, scope, depth).await
+                if let Ok(lambda) = self.eval_expr(val_expr, &converter_scope, depth).await
                     && matches!(lambda, Value::Lambda(..))
                 {
                     self.converters.push((class_name, lambda));
@@ -3326,19 +3401,21 @@ impl Evaluator {
         match value {
             Value::Object(map, ref src) => {
                 // Check if this object has a type_name that matches a converter
-                let type_name = src.as_ref().and_then(|s| s.type_name.as_deref());
+                let type_names = src
+                    .iter()
+                    .flat_map(|source| {
+                        source
+                            .type_name
+                            .iter()
+                            .chain(source.parent_type_names.iter())
+                    })
+                    .collect::<Vec<_>>();
 
-                if let Some(tn) = type_name {
+                if !type_names.is_empty() {
                     for (conv_name, lambda) in converters {
-                        // Match exact name, or as a dotted suffix
-                        // (e.g., converter "Step" matches type "Step" or "Config.Step")
-                        let matches = conv_name == tn
-                            || (tn.len() > conv_name.len()
-                                && tn.ends_with(conv_name.as_str())
-                                && tn.as_bytes()[tn.len() - conv_name.len() - 1] == b'.')
-                            || (conv_name.len() > tn.len()
-                                && conv_name.ends_with(tn)
-                                && conv_name.as_bytes()[conv_name.len() - tn.len() - 1] == b'.');
+                        let matches = type_names
+                            .iter()
+                            .any(|type_name| type_names_match(conv_name, type_name));
                         if matches
                             && !blocked_root_converters.contains(conv_name)
                             && let Value::Lambda(params, body, captured) = lambda
@@ -3483,6 +3560,7 @@ fn apply_mapping_type_annotation(value: &mut Value, type_ann: Option<&crate::par
             scope: IndexMap::new(),
             is_open: true,
             type_name: None,
+            parent_type_names: Vec::new(),
             mapping_value_types: Vec::new(),
             deprecated: IndexMap::new(),
         });
@@ -3535,6 +3613,7 @@ fn collect_mapping_value_type_names(type_ann: &crate::parser::TypeExpr, names: &
                 collect_mapping_value_type_names(variant, names);
             }
         }
+        TypeExpr::StringLiteral(_) => {}
     }
 }
 
@@ -3839,6 +3918,7 @@ fn collect_type_import_field_uses(
             record_type_name_import_use(uses, shadows, name);
             collect_expr_import_field_uses(expr, uses, shadows);
         }
+        crate::parser::TypeExpr::StringLiteral(_) => {}
     }
 }
 
@@ -4180,6 +4260,7 @@ fn collect_type_refs(
             collect_name_root(name, refs, shadows);
             collect_expr_refs(expr, refs, shadows);
         }
+        crate::parser::TypeExpr::StringLiteral(_) => {}
     }
 }
 
@@ -4559,6 +4640,7 @@ fn display_type_expr(ty: &crate::parser::TypeExpr) -> String {
             format!("{}<{}>", name, args_str.join(", "))
         }
         TypeExpr::Constrained(name, _) => format!("{name}(...)"),
+        TypeExpr::StringLiteral(value) => format!("\"{value}\""),
     }
 }
 
@@ -4593,9 +4675,49 @@ fn value_is_type(val: &Value, ty: &crate::parser::TypeExpr) -> bool {
                 _ => matches!(val, Value::Object(..)),
             }
         }
+        TypeExpr::StringLiteral(expected) => {
+            matches!(val, Value::String(actual) if actual == expected)
+        }
         TypeExpr::Constrained(base_name, _) => {
             // Just check the base type; constraint requires async eval
             value_is_type(val, &TypeExpr::Named(base_name.clone()))
+        }
+    }
+}
+
+fn type_is_runtime_checkable(ty: &crate::parser::TypeExpr, scope: &Scope) -> bool {
+    use crate::parser::TypeExpr;
+    match ty {
+        TypeExpr::Named(name) => {
+            matches!(
+                name.as_str(),
+                "Null"
+                    | "Boolean"
+                    | "Bool"
+                    | "Int"
+                    | "Float"
+                    | "Number"
+                    | "String"
+                    | "List"
+                    | "Listing"
+                    | "Set"
+                    | "Map"
+                    | "Mapping"
+                    | "Object"
+                    | "Dynamic"
+                    | "Function"
+                    | "Any"
+            ) || scope.get_type_alias(name).is_some()
+                || resolve_dotted(scope, name).is_some()
+        }
+        TypeExpr::StringLiteral(_) => true,
+        TypeExpr::Nullable(inner) => type_is_runtime_checkable(inner, scope),
+        TypeExpr::Union(variants) => variants
+            .iter()
+            .all(|variant| type_is_runtime_checkable(variant, scope)),
+        TypeExpr::Generic(_, _) => true,
+        TypeExpr::Constrained(name, _) => {
+            type_is_runtime_checkable(&TypeExpr::Named(name.clone()), scope)
         }
     }
 }

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -3606,11 +3606,14 @@ fn collect_mapping_value_type_names(type_ann: &crate::parser::TypeExpr, names: &
     use crate::parser::TypeExpr;
 
     match type_ann {
-        TypeExpr::Named(name) | TypeExpr::Constrained(name, _) => {
+        TypeExpr::Named(name) | TypeExpr::Constrained(name, _)
+            if string_literal_type_value(name).is_none() =>
+        {
             if !names.contains(name) {
                 names.push(name.clone());
             }
         }
+        TypeExpr::Named(_) | TypeExpr::Constrained(_, _) => {}
         // Keep only the top-level value type. For example,
         // Mapping<String, Mapping<String, Step>> needs a structured Mapping
         // default, not Step as the default for the outer mapping's entries.
@@ -3625,7 +3628,6 @@ fn collect_mapping_value_type_names(type_ann: &crate::parser::TypeExpr, names: &
                 collect_mapping_value_type_names(variant, names);
             }
         }
-        TypeExpr::StringLiteral(_) => {}
     }
 }
 
@@ -3910,7 +3912,9 @@ fn collect_type_import_field_uses(
 ) {
     match ty {
         crate::parser::TypeExpr::Named(name) => {
-            record_type_name_import_use(uses, shadows, name);
+            if string_literal_type_value(name).is_none() {
+                record_type_name_import_use(uses, shadows, name);
+            }
         }
         crate::parser::TypeExpr::Nullable(inner) => {
             collect_type_import_field_uses(inner, uses, shadows);
@@ -3930,7 +3934,6 @@ fn collect_type_import_field_uses(
             record_type_name_import_use(uses, shadows, name);
             collect_expr_import_field_uses(expr, uses, shadows);
         }
-        crate::parser::TypeExpr::StringLiteral(_) => {}
     }
 }
 
@@ -4255,7 +4258,11 @@ fn collect_type_refs(
     shadows: &HashSet<String>,
 ) {
     match ty {
-        crate::parser::TypeExpr::Named(name) => collect_name_root(name, refs, shadows),
+        crate::parser::TypeExpr::Named(name) => {
+            if string_literal_type_value(name).is_none() {
+                collect_name_root(name, refs, shadows);
+            }
+        }
         crate::parser::TypeExpr::Nullable(inner) => collect_type_refs(inner, refs, shadows),
         crate::parser::TypeExpr::Union(types) => {
             for ty in types {
@@ -4272,7 +4279,6 @@ fn collect_type_refs(
             collect_name_root(name, refs, shadows);
             collect_expr_refs(expr, refs, shadows);
         }
-        crate::parser::TypeExpr::StringLiteral(_) => {}
     }
 }
 
@@ -4636,6 +4642,10 @@ fn value_to_display(v: &Value) -> String {
     }
 }
 
+fn string_literal_type_value(name: &str) -> Option<&str> {
+    name.strip_prefix('"')?.strip_suffix('"')
+}
+
 /// Format a TypeExpr for user-facing error messages.
 fn display_type_expr(ty: &crate::parser::TypeExpr) -> String {
     use crate::parser::TypeExpr;
@@ -4652,7 +4662,6 @@ fn display_type_expr(ty: &crate::parser::TypeExpr) -> String {
             format!("{}<{}>", name, args_str.join(", "))
         }
         TypeExpr::Constrained(name, _) => format!("{name}(...)"),
-        TypeExpr::StringLiteral(value) => format!("\"{value}\""),
     }
 }
 
@@ -4661,22 +4670,30 @@ fn display_type_expr(ty: &crate::parser::TypeExpr) -> String {
 fn value_is_type(val: &Value, ty: &crate::parser::TypeExpr) -> bool {
     use crate::parser::TypeExpr;
     match ty {
-        TypeExpr::Named(name) => match name.as_str() {
-            "Null" => matches!(val, Value::Null),
-            "Boolean" | "Bool" => matches!(val, Value::Bool(_)),
-            "Int" => matches!(val, Value::Int(_)),
-            "Float" => matches!(val, Value::Float(_)),
-            "Number" => matches!(val, Value::Int(_) | Value::Float(_)),
-            "String" => matches!(val, Value::String(_)),
-            "List" | "Listing" | "Set" => matches!(val, Value::List(_)),
-            "Map" | "Mapping" | "Object" | "Dynamic" => matches!(val, Value::Object(..)),
-            "Function" => matches!(val, Value::Lambda(..)),
-            "Any" => true,
-            _ => {
-                // Unknown type name -- could be a class; treat objects as matching
-                matches!(val, Value::Object(..))
+        TypeExpr::Named(name) => {
+            if let Some(expected) = string_literal_type_value(name) {
+                matches!(val, Value::String(actual) if actual == expected)
+            } else {
+                match name.as_str() {
+                    "Null" => matches!(val, Value::Null),
+                    "Boolean" | "Bool" => matches!(val, Value::Bool(_)),
+                    "Int" => matches!(val, Value::Int(_)),
+                    "Float" => matches!(val, Value::Float(_)),
+                    "Number" => matches!(val, Value::Int(_) | Value::Float(_)),
+                    "String" => matches!(val, Value::String(_)),
+                    "List" | "Listing" | "Set" => matches!(val, Value::List(_)),
+                    "Map" | "Mapping" | "Object" | "Dynamic" => {
+                        matches!(val, Value::Object(..))
+                    }
+                    "Function" => matches!(val, Value::Lambda(..)),
+                    "Any" => true,
+                    _ => {
+                        // Unknown type name -- could be a class; treat objects as matching
+                        matches!(val, Value::Object(..))
+                    }
+                }
             }
-        },
+        }
         TypeExpr::Nullable(inner) => matches!(val, Value::Null) || value_is_type(val, inner),
         TypeExpr::Union(variants) => variants.iter().any(|v| value_is_type(val, v)),
         TypeExpr::Generic(name, _) => {
@@ -4686,9 +4703,6 @@ fn value_is_type(val: &Value, ty: &crate::parser::TypeExpr) -> bool {
                 "Map" | "Mapping" => matches!(val, Value::Object(..)),
                 _ => matches!(val, Value::Object(..)),
             }
-        }
-        TypeExpr::StringLiteral(expected) => {
-            matches!(val, Value::String(actual) if actual == expected)
         }
         TypeExpr::Constrained(base_name, _) => {
             // Just check the base type; constraint requires async eval
@@ -4701,28 +4715,29 @@ fn type_is_runtime_checkable(ty: &crate::parser::TypeExpr, scope: &Scope) -> boo
     use crate::parser::TypeExpr;
     match ty {
         TypeExpr::Named(name) => {
-            matches!(
-                name.as_str(),
-                "Null"
-                    | "Boolean"
-                    | "Bool"
-                    | "Int"
-                    | "Float"
-                    | "Number"
-                    | "String"
-                    | "List"
-                    | "Listing"
-                    | "Set"
-                    | "Map"
-                    | "Mapping"
-                    | "Object"
-                    | "Dynamic"
-                    | "Function"
-                    | "Any"
-            ) || scope.get_type_alias(name).is_some()
+            string_literal_type_value(name).is_some()
+                || matches!(
+                    name.as_str(),
+                    "Null"
+                        | "Boolean"
+                        | "Bool"
+                        | "Int"
+                        | "Float"
+                        | "Number"
+                        | "String"
+                        | "List"
+                        | "Listing"
+                        | "Set"
+                        | "Map"
+                        | "Mapping"
+                        | "Object"
+                        | "Dynamic"
+                        | "Function"
+                        | "Any"
+                )
+                || scope.get_type_alias(name).is_some()
                 || resolve_dotted(scope, name).is_some()
         }
-        TypeExpr::StringLiteral(_) => true,
         TypeExpr::Nullable(inner) => type_is_runtime_checkable(inner, scope),
         TypeExpr::Union(variants) => variants
             .iter()

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -1912,6 +1912,15 @@ impl Evaluator {
         // Evaluate the merged entries (eval_entries handles locals, classes,
         // and evaluates properties in order with each added to scope)
         let result = self.eval_entries(&merged, &eval_scope, depth + 1).await?;
+        let assigned_property_names = merged
+            .iter()
+            .filter_map(|entry| match entry {
+                Entry::Property(prop) if prop.value.is_some() || prop.body.is_some() => {
+                    Some(prop.name.as_str())
+                }
+                _ => None,
+            })
+            .collect::<HashSet<_>>();
         if let Value::Object(map, source) = &result {
             for entry in base_entries {
                 let Entry::Property(prop) = entry else {
@@ -1921,9 +1930,14 @@ impl Evaluator {
                     continue;
                 };
                 let value = map.get(&prop.name).or_else(|| {
-                    source
-                        .as_ref()
-                        .and_then(|source| source.scope.get(&prop.name))
+                    assigned_property_names
+                        .contains(prop.name.as_str())
+                        .then(|| {
+                            source
+                                .as_ref()
+                                .and_then(|source| source.scope.get(&prop.name))
+                        })
+                        .flatten()
                 });
                 let Some(value) = value else {
                     continue;

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -80,7 +80,6 @@ pub enum Modifier {
 #[derive(Debug, Clone, PartialEq)]
 pub enum TypeExpr {
     Named(String),
-    StringLiteral(String),
     Nullable(Box<TypeExpr>),
     Union(Vec<TypeExpr>),
     Generic(String, Vec<TypeExpr>),
@@ -935,7 +934,7 @@ impl<'a> Parser<'a> {
             }
             TokenKind::StringLit(s) => {
                 self.advance();
-                TypeExpr::StringLiteral(s)
+                TypeExpr::Named(format!("\"{s}\""))
             }
             TokenKind::Null => {
                 self.advance();

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -80,6 +80,7 @@ pub enum Modifier {
 #[derive(Debug, Clone, PartialEq)]
 pub enum TypeExpr {
     Named(String),
+    StringLiteral(String),
     Nullable(Box<TypeExpr>),
     Union(Vec<TypeExpr>),
     Generic(String, Vec<TypeExpr>),
@@ -934,7 +935,7 @@ impl<'a> Parser<'a> {
             }
             TokenKind::StringLit(s) => {
                 self.advance();
-                TypeExpr::Named(s)
+                TypeExpr::StringLiteral(s)
             }
             TokenKind::Null => {
                 self.advance();

--- a/src/value.rs
+++ b/src/value.rs
@@ -18,6 +18,9 @@ pub struct ObjectSource {
     /// The pkl class name this object was instantiated from (e.g., "Step", "Group").
     /// Used by `output.renderer.converters` to apply type-specific transforms.
     pub type_name: Option<String>,
+    /// Parent class names, nearest first. Converters declared for a base class
+    /// also apply to instances of its subclasses.
+    pub parent_type_names: Vec<String>,
     /// Possible value type names for mapping entries, e.g. `Step | Group` from
     /// `Mapping<String, Step | Group>`. Used when amending mappings so bare
     /// entries inherit the right class template.

--- a/tests/pkl_features.rs
+++ b/tests/pkl_features.rs
@@ -1172,6 +1172,43 @@ beta_val = Items["items/beta.pkl"].value
 }
 
 #[tokio::test]
+async fn import_glob_value_is_available_to_class_output() {
+    let temp = TestTempDir::new("pklr_test_import_glob_class_output");
+    let dir = temp.path();
+    std::fs::create_dir_all(dir.join("builtins")).unwrap();
+    std::fs::write(
+        dir.join("builtins/prettier.pkl"),
+        r#"
+prettier { check = "prettier --check" }
+prettier_stdin { check = "prettier --stdin-filepath" }
+"#,
+    )
+    .unwrap();
+    std::fs::write(
+        dir.join("main.pkl"),
+        r#"
+import* "builtins/*.pkl" as Raw
+
+class Factory {
+    stdin: Boolean = false
+    fixed step = if (stdin)
+        Raw["builtins/prettier.pkl"].prettier_stdin
+    else
+        Raw["builtins/prettier.pkl"].prettier
+}
+
+factory = new Factory {}
+amended = (factory) { stdin = true }
+"#,
+    )
+    .unwrap();
+
+    let val = pklr::eval_to_json(&dir.join("main.pkl")).await.unwrap();
+    assert_eq!(val["factory"]["step"]["check"], "prettier --check");
+    assert_eq!(val["amended"]["step"]["check"], "prettier --stdin-filepath");
+}
+
+#[tokio::test]
 async fn import_glob_double_star_crosses_directories() {
     let temp = TestTempDir::new("pklr_test_import_glob_double_star");
     let dir = temp.path();
@@ -1473,12 +1510,20 @@ async fn import_used_only_by_annotation_does_not_create_builtin_cycle() {
     std::fs::write(
         dir.join("Builtins.pkl"),
         r#"
+import* "builtins/*.pkl" as RawBuiltins
+
 class meta extends Annotation {
     description: String?
 }
 
-import* "builtins/*.pkl" as Builtins
-prettier = Builtins["builtins/prettier.pkl"].prettier
+class PrettierFactory {
+    stdin: Boolean = false
+    fixed step = if (stdin)
+        RawBuiltins["builtins/prettier.pkl"].prettier_stdin
+    else
+        RawBuiltins["builtins/prettier.pkl"].prettier
+}
+prettier = new PrettierFactory {}
 "#,
     )
     .unwrap();
@@ -1489,14 +1534,16 @@ import "../Builtins.pkl"
 
 @Builtins.meta { description = "formatter" }
 prettier = "ok"
+prettier_stdin = "stdin"
 "#,
     )
     .unwrap();
     std::fs::write(
         dir.join("main.pkl"),
         r#"
-import "builtins/prettier.pkl"
-result = prettier.prettier
+import "Builtins.pkl"
+result = Builtins.prettier.step
+amended = ((Builtins.prettier) { stdin = true }).step
 "#,
     )
     .unwrap();
@@ -1504,6 +1551,7 @@ result = prettier.prettier
     let path = dir.join("main.pkl");
     let val = pklr::eval_to_json(&path).await.unwrap();
     assert_eq!(val["result"], "ok");
+    assert_eq!(val["amended"], "stdin");
 }
 
 #[tokio::test]
@@ -4192,6 +4240,36 @@ fn rewrite_url_no_rules_is_identity() {
     );
 }
 
+#[test]
+fn class_instance_rejects_wrong_property_type() {
+    let message = eval_fails(
+        r#"
+class Factory {
+    enabled: Boolean = false
+}
+
+factory = new Factory { enabled = "yes" }
+"#,
+    );
+    assert!(message.contains("enabled"), "{message}");
+    assert!(message.contains("Boolean"), "{message}");
+}
+
+#[test]
+fn class_instance_rejects_value_outside_string_literal_union() {
+    let message = eval_fails(
+        r#"
+class Factory {
+    version: "3" | "4" = "4"
+}
+
+factory = new Factory { version = "5" }
+"#,
+    );
+    assert!(message.contains("version"), "{message}");
+    assert!(message.contains("\"3\"|\"4\""), "{message}");
+}
+
 // ============================================================
 // output.renderer.converters
 // ============================================================
@@ -4251,6 +4329,163 @@ myStep = (base) { check = "b" }
     );
     assert_eq!(json["myStep"]["_type"], "step");
     assert_eq!(json["myStep"]["check"], "b");
+}
+
+#[test]
+fn converter_applies_to_subclass_instance() {
+    let json = eval_with_converters(
+        r#"
+class Factory {
+    fixed output = new { check = "base" }
+}
+class Prettier extends Factory {}
+
+output {
+    renderer {
+        converters {
+            [Factory] = (factory) -> factory.output
+        }
+    }
+}
+
+step = new Prettier {}
+"#,
+    );
+    assert_eq!(json["step"]["check"], "base");
+    assert!(json["step"].get("output").is_none());
+}
+
+#[test]
+fn converter_can_call_module_local_helper() {
+    let json = eval_with_converters(
+        r#"
+class Step {
+    check: String = ""
+}
+
+local function renderStep(step) = new Dynamic {
+    _type = "step"
+    ...step.toMap().toDynamic()
+}
+
+output {
+    renderer {
+        converters {
+            [Step] = (step) -> renderStep(step)
+        }
+    }
+}
+
+step = new Step { check = "cargo test" }
+"#,
+    );
+    assert_eq!(json["step"]["_type"], "step");
+    assert_eq!(json["step"]["check"], "cargo test");
+}
+
+#[test]
+fn converter_can_call_output_local_helper() {
+    let json = eval_with_converters(
+        r#"
+class Step {
+    check: String = ""
+}
+
+output {
+    local function renderStep(step) = new Dynamic {
+        _type = "step"
+        ...step.toMap().toDynamic()
+    }
+    renderer {
+        converters {
+            [Step] = (step) -> renderStep(step)
+        }
+    }
+}
+
+step = new Step { check = "cargo test" }
+"#,
+    );
+    assert_eq!(json["step"]["_type"], "step");
+    assert_eq!(json["step"]["check"], "cargo test");
+}
+
+#[test]
+fn hk_style_factories_support_options_step_amendments_and_containers() {
+    let json = eval_with_converters(
+        r#"
+open class Step {
+    check: String = ""
+    batch: Boolean = false
+}
+
+abstract class BuiltinFactory {
+    step: Step
+}
+
+class Gitleaks extends BuiltinFactory {
+    staged: Boolean = false
+    local factory = this
+    step = new Step {
+        check = if (factory.staged) "gitleaks --staged" else "gitleaks"
+    }
+}
+
+local gitleaks = new Gitleaks {}
+
+plain = gitleaks
+configured = (gitleaks) {
+    staged = true
+    step { batch = true }
+}
+steps: Mapping<String, BuiltinFactory | Step> = new Mapping {
+    ["factory"] = (gitleaks) { staged = true }
+    ["manual"] = new Step { check = "cargo test" }
+}
+all: Mapping<String, BuiltinFactory> = new Mapping {
+    ["gitleaks"] = gitleaks
+}
+
+output {
+    local function renderStep(step) = new Dynamic {
+        _type = "step"
+        ...step.toMap().toDynamic()
+    }
+    renderer {
+        converters {
+            [BuiltinFactory] = (factory) -> renderStep(factory.step)
+            [Step] = (step) -> renderStep(step)
+        }
+    }
+}
+"#,
+    );
+
+    assert_eq!(json["plain"]["check"], "gitleaks");
+    assert_eq!(json["plain"]["batch"], false);
+    assert_eq!(json["plain"]["_type"], "step");
+    assert_eq!(json["configured"]["check"], "gitleaks --staged");
+    assert_eq!(json["configured"]["batch"], true);
+    assert_eq!(json["configured"]["_type"], "step");
+    assert_eq!(json["steps"]["factory"]["check"], "gitleaks --staged");
+    assert_eq!(json["steps"]["manual"]["check"], "cargo test");
+    assert_eq!(json["all"]["gitleaks"]["check"], "gitleaks");
+    assert!(json["configured"].get("staged").is_none());
+    assert!(json["configured"].get("step").is_none());
+}
+
+#[test]
+fn hk_style_factory_rejects_unknown_input() {
+    let message = eval_fails(
+        r#"
+class Step {}
+abstract class BuiltinFactory { step: Step }
+class Prettier extends BuiltinFactory { step = new Step {} }
+prettier = new Prettier { futureOption = true }
+"#,
+    );
+    assert!(message.contains("futureOption"), "{message}");
+    assert!(message.contains("non-open"), "{message}");
 }
 
 #[test]

--- a/tests/pkl_features.rs
+++ b/tests/pkl_features.rs
@@ -2428,9 +2428,10 @@ fn class_local_this_alias_is_complete_for_deferred_methods() {
         r#"
 class Factory {
     local factory = this
+    local secondAlias = factory
     first: String = "first"
     last: String = "last"
-    function lastValue(): String = factory.last
+    function lastValue(): String = secondAlias.last
 }
 
 local factory = new Factory {}
@@ -4288,6 +4289,21 @@ factory = new Factory { version = "5" }
     assert!(message.contains("\"3\"|\"4\""), "{message}");
 }
 
+#[test]
+fn class_instance_validates_hidden_property_types() {
+    let message = eval_fails(
+        r#"
+class Factory {
+    hidden enabled: Boolean = false
+}
+
+factory = new Factory { enabled = "yes" }
+"#,
+    );
+    assert!(message.contains("enabled"), "{message}");
+    assert!(message.contains("Boolean"), "{message}");
+}
+
 // ============================================================
 // output.renderer.converters
 // ============================================================
@@ -4371,6 +4387,28 @@ step = new Prettier {}
     );
     assert_eq!(json["step"]["check"], "base");
     assert!(json["step"].get("output").is_none());
+}
+
+#[test]
+fn converter_prefers_most_specific_class() {
+    let json = eval_with_converters(
+        r#"
+abstract class Factory {}
+class Prettier extends Factory {}
+
+output {
+    renderer {
+        converters {
+            [Factory] = (_) -> "factory"
+            [Prettier] = (_) -> "prettier"
+        }
+    }
+}
+
+value = new Prettier {}
+"#,
+    );
+    assert_eq!(json["value"], "prettier");
 }
 
 #[test]

--- a/tests/pkl_features.rs
+++ b/tests/pkl_features.rs
@@ -4304,6 +4304,22 @@ factory = new Factory { enabled = "yes" }
     assert!(message.contains("Boolean"), "{message}");
 }
 
+#[test]
+fn class_instance_does_not_validate_missing_property_against_enclosing_scope() {
+    let json = eval(
+        r#"
+local enabled = "not a boolean"
+
+class Factory {
+    hidden enabled: Boolean
+}
+
+factory = new Factory {}
+"#,
+    );
+    assert_eq!(json["factory"], serde_json::json!({}));
+}
+
 // ============================================================
 // output.renderer.converters
 // ============================================================

--- a/tests/pkl_features.rs
+++ b/tests/pkl_features.rs
@@ -2423,6 +2423,24 @@ x = new Factory {
 }
 
 #[test]
+fn class_local_this_alias_is_complete_for_deferred_methods() {
+    let json = eval(
+        r#"
+class Factory {
+    local factory = this
+    first: String = "first"
+    last: String = "last"
+    function lastValue(): String = factory.last
+}
+
+local factory = new Factory {}
+result = factory.lastValue()
+"#,
+    );
+    assert_eq!(json["result"], "last");
+}
+
+#[test]
 fn class_with_type_params() {
     let json = eval(
         r#"

--- a/tests/pkl_features.rs
+++ b/tests/pkl_features.rs
@@ -2355,6 +2355,26 @@ x = new Config {}
 }
 
 #[test]
+fn class_local_this_alias_tracks_amended_inputs() {
+    let json = eval(
+        r#"
+class Factory {
+    local factory = this
+    staged: Boolean = false
+    fixed step = (new { staged = false }) {
+        staged = factory.staged
+    }
+}
+x = new Factory {
+    staged = true
+}
+"#,
+    );
+    assert_eq!(json["x"]["step"]["staged"], true);
+    assert!(json["x"].get("factory").is_none());
+}
+
+#[test]
 fn class_with_type_params() {
     let json = eval(
         r#"


### PR DESCRIPTION
## Summary

- keep class-local `this` aliases synchronized through amendments, dynamic entries, spreads, generators, and deferred methods
- apply output converters registered for a base class to subclass instances while preserving type ancestry through amendments and containers
- allow output converter lambdas to capture helpers local to the `output` or `renderer` body
- validate runtime-checkable class property types, including singleton-string unions used for factory options
- cover import-glob-backed factories and an hk-shaped class-as-a-function matrix

This completes the evaluator behavior hk v2 needs for stable builtin factory values such as `(Builtins.gitleaks) { staged = true }`, including amendable `step { ... }` output customization.

## Validation

- compared the hk-shaped fixture with Apple Pkl 0.31.1
- `cargo test --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`

*AI-assisted — Tool: Codex; model: unavailable/unavailable; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core object evaluation, amendment merging, and converter matching; behavior changes are broad but covered by many integration tests.
> 
> **Overview**
> Completes **class-as-function** evaluation so `local factory = this` (and chained aliases) stay aligned with the instance as properties, spreads, generators, and amendments are applied—supporting patterns like amendable `step { ... }` on factories.
> 
> Adds **`ObjectSource.parent_type_names`** and threads it through class inheritance and **`eval_amended_object`**, so **`output.renderer.converters`** can match base-class converters on subclasses (with existing specificity rules). Converter lambdas are evaluated in a scope that includes **locals from `output` and `renderer`**.
> 
> Introduces **runtime validation** for checkable property types on amended/instantiated objects, including **string-literal union types** (parser now represents `"3"` types as quoted names). Import/type-ref collection ignores those literal type names.
> 
> Extensive tests cover glob-import factories, hk-style factories, converter inheritance, and validation edge cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a09da66485c44f236b1078aa6e79e85f0da18a9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->