### PR TITLE
feat!: make blocking evaluation the default

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,8 @@ jobs:
           persist-credentials: false
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
       - run: cargo test
-      - run: cargo clippy --all-targets -- -D warnings
+      - run: cargo test --all-features
+      - run: cargo clippy --all-targets --all-features -- -D warnings
       - run: cargo fmt --check
   msrv:
     runs-on: ubuntu-latest
@@ -51,6 +52,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Check for breaking API changes
+        if: github.event_name == 'pull_request' && !contains(github.event.pull_request.title, '!:')
         uses: obi1kenobi/cargo-semver-checks-action@6b69fcf40e9b5fb17adeb57e4b6ecd020649a239 # v2
   final:
     needs: [test, msrv, semver]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -55,6 +55,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
+
+[[package]]
 name = "bitflags"
 version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -360,7 +366,7 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-util",
@@ -683,13 +689,22 @@ dependencies = [
  "async-recursion",
  "indexmap",
  "miette",
+ "pollster",
  "reqwest",
+ "rustls",
  "serde_json",
  "thiserror",
  "tokio",
+ "ureq",
  "url",
  "zip",
 ]
+
+[[package]]
+name = "pollster"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc6355899e1c9462875b6757c79f3caa011a1fdae12bbb1a2e72dd1f234f8336"
 
 [[package]]
 name = "potential_utf"
@@ -813,7 +828,7 @@ version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-core",
  "http",
@@ -878,6 +893,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
 dependencies = [
  "aws-lc-rs",
+ "log",
  "once_cell",
  "rustls-pki-types",
  "rustls-webpki",
@@ -1321,6 +1337,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
+name = "ureq"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "972d7902c8735f2695410b8aed7df6ed12a47394aa1c8d7af49f0497b731a94d"
+dependencies = [
+ "base64 0.23.1",
+ "log",
+ "percent-encoding",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
+ "ureq-proto",
+ "utf8-zero",
+]
+
+[[package]]
+name = "ureq-proto"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da5f78b09e6941e1a0f2e30e695e4b120377b54d5e0aec11b594bb57b3971613"
+dependencies = [
+ "base64 0.23.1",
+ "http",
+ "httparse",
+ "log",
+]
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1331,6 +1375,12 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
+
+[[package]]
+name = "utf8-zero"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e"
 
 [[package]]
 name = "utf8_iter"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,19 +13,18 @@ include     = ["/src/**/*", "/tests/**/*", "/Cargo.toml", "/README.md", "/LICENS
 
 [features]
 default = [
-  "parse",
-  "eval-core",
-  "native-io",
-  "http",
-  "package-zip",
+  "blocking",
   "miette-diagnostics",
 ]
 parse = []
 eval-core = ["parse", "dep:async-recursion", "dep:url"]
 native-io = ["eval-core"]
 http = ["eval-core", "dep:reqwest"]
-package-zip = ["http", "native-io", "dep:zip"]
+package-zip-core = ["native-io", "dep:zip"]
+package-zip = ["package-zip-core"]
 miette-diagnostics = ["dep:miette"]
+blocking = ["package-zip-core", "dep:pollster", "dep:rustls", "dep:ureq"]
+async = ["native-io", "http", "dep:tokio"]
 
 [dependencies]
 indexmap    = "2"
@@ -33,8 +32,11 @@ miette     = { version = "7", features = ["derive"], optional = true }
 serde_json = "1"
 thiserror  = "2"
 async-recursion = { version = "1", optional = true }
+pollster         = { version = "1", optional = true }
 reqwest         = { version = "0.13", default-features = false, features = ["rustls"], optional = true }
-tokio           = { version = "1", features = ["rt"], optional = true }
+rustls          = { version = "0.23", default-features = false, features = ["aws-lc-rs", "tls12"], optional = true }
+tokio           = { version = "1", features = ["fs", "rt"], optional = true }
+ureq            = { version = "3", default-features = false, features = ["platform-verifier", "rustls-no-provider"], optional = true }
 zip             = { version = "8", default-features = false, features = ["deflate"], optional = true }
 url             = { version = "2", optional = true }
 
@@ -43,11 +45,15 @@ tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 
 [[test]]
 name = "integration"
-required-features = ["native-io", "http", "package-zip"]
+required-features = ["async", "package-zip"]
 
 [[test]]
 name = "pkl_features"
-required-features = ["native-io", "http", "package-zip"]
+required-features = ["async", "package-zip"]
+
+[[test]]
+name = "blocking"
+required-features = ["blocking"]
 
 [profile.dev]
 debug = 1

--- a/README.md
+++ b/README.md
@@ -21,16 +21,38 @@ let json = eval_to_json(std::path::Path::new("config.pkl"))?;
 println!("{}", json);
 ```
 
+The default synchronous API uses blocking HTTP and creates no thread or Tokio
+runtime. A default build has no Tokio dependency.
+
+Asynchronous applications can disable default features and enable `async` plus
+any optional features they need:
+
+```toml
+pklr = { version = "2", default-features = false, features = ["async", "package-zip", "miette-diagnostics"] }
+```
+
+```rust
+let json = pklr::eval_to_json_async(std::path::Path::new("config.pkl")).await?;
+```
+
+Async evaluation and `analyze_imports_async` use Tokio filesystem operations;
+blocking-only work such as ZIP extraction and glob walking runs on Tokio's
+blocking pool. For direct construction, use `Evaluator::new_async()`; the
+unsuffixed `Evaluator::new()` always selects blocking capabilities.
+
+Use `EvaluatorBuilder::http_agent` with a custom `pklr::ureq::Agent` for
+synchronous HTTP configuration. The async `AsyncEvaluatorBuilder::http_client`
+accepts a custom `pklr::reqwest::Client`.
+
 Package downloads can be shared across evaluator instances and reused without
 network access:
 
 ```rust
-async fn load_config() -> pklr::Result<serde_json::Value> {
+fn load_config() -> pklr::Result<serde_json::Value> {
     pklr::EvaluatorBuilder::new()
         .package_cache_dir(".pklr-cache")
         .offline(true)
         .eval_to_json(std::path::Path::new("config.pkl"))
-        .await
 }
 ```
 
@@ -40,12 +62,11 @@ so a config importing that package evaluates without any network round trip:
 ```rust
 static PACKAGE: &[u8] = include_bytes!("pkg@1.0.0.zip");
 
-async fn load_bundled_config() -> pklr::Result<serde_json::Value> {
+fn load_bundled_config() -> pklr::Result<serde_json::Value> {
     pklr::EvaluatorBuilder::new()
         .package_cache_dir(".pklr-cache")
         .preload_package("https://example.com/pkg@1.0.0.zip", "zip", PACKAGE)
         .eval_to_json(std::path::Path::new("config.pkl"))
-        .await
 }
 ```
 

--- a/src/capabilities.rs
+++ b/src/capabilities.rs
@@ -3,7 +3,7 @@ use std::path::{Path, PathBuf};
 use std::pin::Pin;
 #[cfg(feature = "native-io")]
 use std::sync::atomic::{AtomicU64, Ordering};
-#[cfg(feature = "http")]
+#[cfg(any(feature = "http", feature = "blocking"))]
 use std::time::Duration;
 
 use crate::Result;
@@ -21,6 +21,45 @@ pub trait EvalCapabilities: Send + Sync {
 
     fn canonicalize<'a>(&'a mut self, path: &'a Path) -> BoxFuture<'a, Result<PathBuf>>;
 
+    fn read_bytes<'a>(&'a mut self, path: &'a Path) -> BoxFuture<'a, Result<Vec<u8>>> {
+        Box::pin(async move {
+            std::fs::read(path).map_err(|error| crate::Error::Io(path.to_path_buf(), error))
+        })
+    }
+
+    fn create_dir_all<'a>(&'a mut self, path: &'a Path) -> BoxFuture<'a, Result<()>> {
+        Box::pin(async move {
+            std::fs::create_dir_all(path)
+                .map_err(|error| crate::Error::Io(path.to_path_buf(), error))
+        })
+    }
+
+    fn write_atomic<'a>(
+        &'a mut self,
+        path: &'a Path,
+        bytes: &'a [u8],
+    ) -> BoxFuture<'a, Result<()>> {
+        Box::pin(async move {
+            crate::eval::write_atomic(path, bytes)
+                .map_err(|error| crate::Error::Io(path.to_path_buf(), error))
+        })
+    }
+
+    fn remove_file<'a>(&'a mut self, path: &'a Path) -> BoxFuture<'a, Result<()>> {
+        Box::pin(async move {
+            std::fs::remove_file(path).map_err(|error| crate::Error::Io(path.to_path_buf(), error))
+        })
+    }
+
+    #[cfg(feature = "package-zip-core")]
+    fn extract_zip<'a>(
+        &'a mut self,
+        bytes: Vec<u8>,
+        destination: &'a Path,
+    ) -> BoxFuture<'a, Result<()>> {
+        Box::pin(async move { extract_zip_sync(bytes, destination) })
+    }
+
     fn read_env<'a>(&'a mut self, name: &'a str) -> BoxFuture<'a, Result<Option<String>>>;
 
     fn fetch_text<'a>(&'a mut self, url: &'a str) -> BoxFuture<'a, Result<String>>;
@@ -28,8 +67,11 @@ pub trait EvalCapabilities: Send + Sync {
     fn fetch_bytes<'a>(&'a mut self, url: &'a str) -> BoxFuture<'a, Result<Vec<u8>>>;
 
     #[cfg(feature = "http")]
-    fn set_http_client(&mut self, client: reqwest::Client) {
+    fn set_http_client(&mut self, client: reqwest::Client) -> Result<()> {
         drop(client);
+        Err(crate::Error::Unsupported(
+            "this evaluator's capabilities do not accept a reqwest HTTP client".to_string(),
+        ))
     }
 
     fn temp_dir<'a>(&'a mut self, prefix: &'a str) -> BoxFuture<'a, Result<PathBuf>>;
@@ -46,6 +88,54 @@ pub trait EvalCapabilities: Send + Sync {
 pub struct NativeCapabilities {
     #[cfg(feature = "http")]
     http_client: reqwest::Client,
+}
+
+/// Synchronous host IO used by the blocking evaluator.
+#[cfg(feature = "blocking")]
+#[derive(Debug, Clone)]
+pub struct BlockingCapabilities {
+    http_agent: ureq::Agent,
+}
+
+#[cfg(feature = "blocking")]
+impl BlockingCapabilities {
+    pub fn new() -> Self {
+        Self {
+            http_agent: default_blocking_http_agent(),
+        }
+    }
+
+    pub fn with_http_agent(http_agent: ureq::Agent) -> Self {
+        ensure_blocking_crypto_provider();
+        Self { http_agent }
+    }
+}
+
+#[cfg(feature = "blocking")]
+fn ensure_blocking_crypto_provider() {
+    if rustls::crypto::CryptoProvider::get_default().is_none() {
+        let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+    }
+}
+
+#[cfg(feature = "blocking")]
+fn default_blocking_http_agent() -> ureq::Agent {
+    ensure_blocking_crypto_provider();
+    ureq::Agent::config_builder()
+        .timeout_connect(Some(Duration::from_secs(10)))
+        .timeout_global(Some(Duration::from_secs(30)))
+        .build()
+        .into()
+}
+
+#[cfg(feature = "blocking")]
+const BLOCKING_HTTP_BODY_LIMIT: u64 = 64 * 1024 * 1024;
+
+#[cfg(feature = "blocking")]
+impl Default for BlockingCapabilities {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 #[cfg(feature = "native-io")]
@@ -83,19 +173,137 @@ fn default_http_client() -> reqwest::Client {
 impl EvalCapabilities for NativeCapabilities {
     fn read_to_string<'a>(&'a mut self, path: &'a Path) -> BoxFuture<'a, Result<String>> {
         Box::pin(async move {
-            std::fs::read_to_string(path)
-                .map_err(|error| crate::Error::Io(path.to_path_buf(), error))
+            #[cfg(feature = "async")]
+            let result = if tokio::runtime::Handle::try_current().is_ok() {
+                tokio::fs::read_to_string(path).await
+            } else {
+                std::fs::read_to_string(path)
+            };
+            #[cfg(not(feature = "async"))]
+            let result = std::fs::read_to_string(path);
+            result.map_err(|error| crate::Error::Io(path.to_path_buf(), error))
         })
     }
 
     fn path_exists<'a>(&'a mut self, path: &'a Path) -> BoxFuture<'a, Result<bool>> {
-        Box::pin(async move { Ok(path.exists()) })
+        Box::pin(async move {
+            #[cfg(feature = "async")]
+            let exists = if tokio::runtime::Handle::try_current().is_ok() {
+                tokio::fs::try_exists(path).await.unwrap_or(false)
+            } else {
+                path.exists()
+            };
+            #[cfg(not(feature = "async"))]
+            let exists = path.exists();
+            Ok(exists)
+        })
     }
 
     fn canonicalize<'a>(&'a mut self, path: &'a Path) -> BoxFuture<'a, Result<PathBuf>> {
         Box::pin(async move {
-            path.canonicalize()
+            #[cfg(feature = "async")]
+            let result = if tokio::runtime::Handle::try_current().is_ok() {
+                tokio::fs::canonicalize(path).await
+            } else {
+                path.canonicalize()
+            };
+            #[cfg(not(feature = "async"))]
+            let result = path.canonicalize();
+            result.map_err(|error| crate::Error::Io(path.to_path_buf(), error))
+        })
+    }
+
+    fn read_bytes<'a>(&'a mut self, path: &'a Path) -> BoxFuture<'a, Result<Vec<u8>>> {
+        Box::pin(async move {
+            #[cfg(feature = "async")]
+            let result = if tokio::runtime::Handle::try_current().is_ok() {
+                tokio::fs::read(path).await
+            } else {
+                std::fs::read(path)
+            };
+            #[cfg(not(feature = "async"))]
+            let result = std::fs::read(path);
+            result.map_err(|error| crate::Error::Io(path.to_path_buf(), error))
+        })
+    }
+
+    fn create_dir_all<'a>(&'a mut self, path: &'a Path) -> BoxFuture<'a, Result<()>> {
+        Box::pin(async move {
+            #[cfg(feature = "async")]
+            let result = if tokio::runtime::Handle::try_current().is_ok() {
+                tokio::fs::create_dir_all(path).await
+            } else {
+                std::fs::create_dir_all(path)
+            };
+            #[cfg(not(feature = "async"))]
+            let result = std::fs::create_dir_all(path);
+            result.map_err(|error| crate::Error::Io(path.to_path_buf(), error))
+        })
+    }
+
+    fn write_atomic<'a>(
+        &'a mut self,
+        path: &'a Path,
+        bytes: &'a [u8],
+    ) -> BoxFuture<'a, Result<()>> {
+        Box::pin(async move {
+            #[cfg(feature = "async")]
+            {
+                if tokio::runtime::Handle::try_current().is_err() {
+                    return crate::eval::write_atomic(path, bytes)
+                        .map_err(|error| crate::Error::Io(path.to_path_buf(), error));
+                }
+                let path = path.to_path_buf();
+                let task_path = path.clone();
+                let bytes = bytes.to_vec();
+                tokio::task::spawn_blocking(move || crate::eval::write_atomic(&task_path, &bytes))
+                    .await
+                    .map_err(|error| {
+                        crate::Error::Eval(format!("atomic write task failed: {error}"))
+                    })?
+                    .map_err(|error| crate::Error::Io(path, error))
+            }
+            #[cfg(not(feature = "async"))]
+            crate::eval::write_atomic(path, bytes)
                 .map_err(|error| crate::Error::Io(path.to_path_buf(), error))
+        })
+    }
+
+    fn remove_file<'a>(&'a mut self, path: &'a Path) -> BoxFuture<'a, Result<()>> {
+        Box::pin(async move {
+            #[cfg(feature = "async")]
+            let result = if tokio::runtime::Handle::try_current().is_ok() {
+                tokio::fs::remove_file(path).await
+            } else {
+                std::fs::remove_file(path)
+            };
+            #[cfg(not(feature = "async"))]
+            let result = std::fs::remove_file(path);
+            result.map_err(|error| crate::Error::Io(path.to_path_buf(), error))
+        })
+    }
+
+    #[cfg(feature = "package-zip-core")]
+    fn extract_zip<'a>(
+        &'a mut self,
+        bytes: Vec<u8>,
+        destination: &'a Path,
+    ) -> BoxFuture<'a, Result<()>> {
+        Box::pin(async move {
+            #[cfg(feature = "async")]
+            {
+                if tokio::runtime::Handle::try_current().is_err() {
+                    return extract_zip_sync(bytes, destination);
+                }
+                let destination = destination.to_path_buf();
+                tokio::task::spawn_blocking(move || extract_zip_sync(bytes, &destination))
+                    .await
+                    .map_err(|error| {
+                        crate::Error::Eval(format!("package extraction task failed: {error}"))
+                    })?
+            }
+            #[cfg(not(feature = "async"))]
+            extract_zip_sync(bytes, destination)
         })
     }
 
@@ -177,8 +385,108 @@ impl EvalCapabilities for NativeCapabilities {
     }
 
     #[cfg(feature = "http")]
-    fn set_http_client(&mut self, client: reqwest::Client) {
+    fn set_http_client(&mut self, client: reqwest::Client) -> Result<()> {
         self.http_client = client;
+        Ok(())
+    }
+
+    fn temp_dir<'a>(&'a mut self, prefix: &'a str) -> BoxFuture<'a, Result<PathBuf>> {
+        Box::pin(async move {
+            #[cfg(feature = "async")]
+            {
+                if tokio::runtime::Handle::try_current().is_err() {
+                    return unique_temp_dir(prefix);
+                }
+                let prefix = prefix.to_string();
+                tokio::task::spawn_blocking(move || unique_temp_dir(&prefix))
+                    .await
+                    .map_err(|error| {
+                        crate::Error::Eval(format!("temp directory task failed: {error}"))
+                    })?
+            }
+            #[cfg(not(feature = "async"))]
+            unique_temp_dir(prefix)
+        })
+    }
+
+    fn glob<'a>(
+        &'a mut self,
+        base: &'a Path,
+        pattern: &'a str,
+    ) -> BoxFuture<'a, Result<Vec<PathBuf>>> {
+        Box::pin(async move {
+            #[cfg(feature = "async")]
+            {
+                if tokio::runtime::Handle::try_current().is_err() {
+                    return crate::eval::expand_glob(base, pattern);
+                }
+                let base = base.to_path_buf();
+                let pattern = pattern.to_string();
+                tokio::task::spawn_blocking(move || crate::eval::expand_glob(&base, &pattern))
+                    .await
+                    .map_err(|error| crate::Error::Eval(format!("glob task failed: {error}")))?
+            }
+            #[cfg(not(feature = "async"))]
+            crate::eval::expand_glob(base, pattern)
+        })
+    }
+}
+
+#[cfg(feature = "blocking")]
+impl EvalCapabilities for BlockingCapabilities {
+    fn read_to_string<'a>(&'a mut self, path: &'a Path) -> BoxFuture<'a, Result<String>> {
+        Box::pin(async move {
+            std::fs::read_to_string(path)
+                .map_err(|error| crate::Error::Io(path.to_path_buf(), error))
+        })
+    }
+
+    fn path_exists<'a>(&'a mut self, path: &'a Path) -> BoxFuture<'a, Result<bool>> {
+        Box::pin(async move { Ok(path.exists()) })
+    }
+
+    fn canonicalize<'a>(&'a mut self, path: &'a Path) -> BoxFuture<'a, Result<PathBuf>> {
+        Box::pin(async move {
+            path.canonicalize()
+                .map_err(|error| crate::Error::Io(path.to_path_buf(), error))
+        })
+    }
+
+    fn read_env<'a>(&'a mut self, name: &'a str) -> BoxFuture<'a, Result<Option<String>>> {
+        Box::pin(async move { Ok(std::env::var(name).ok()) })
+    }
+
+    fn fetch_text<'a>(&'a mut self, url: &'a str) -> BoxFuture<'a, Result<String>> {
+        let agent = self.http_agent.clone();
+        Box::pin(async move {
+            let mut response = agent
+                .get(url)
+                .call()
+                .map_err(|error| blocking_http_error(url, error))?;
+            response
+                .body_mut()
+                .with_config()
+                .limit(BLOCKING_HTTP_BODY_LIMIT)
+                .lossy_utf8(false)
+                .read_to_string()
+                .map_err(|error| crate::Error::Eval(format!("HTTP read failed for {url}: {error}")))
+        })
+    }
+
+    fn fetch_bytes<'a>(&'a mut self, url: &'a str) -> BoxFuture<'a, Result<Vec<u8>>> {
+        let agent = self.http_agent.clone();
+        Box::pin(async move {
+            let mut response = agent
+                .get(url)
+                .call()
+                .map_err(|error| blocking_http_error(url, error))?;
+            response
+                .body_mut()
+                .with_config()
+                .limit(BLOCKING_HTTP_BODY_LIMIT)
+                .read_to_vec()
+                .map_err(|error| crate::Error::Eval(format!("HTTP read failed for {url}: {error}")))
+        })
     }
 
     fn temp_dir<'a>(&'a mut self, prefix: &'a str) -> BoxFuture<'a, Result<PathBuf>> {
@@ -191,6 +499,15 @@ impl EvalCapabilities for NativeCapabilities {
         pattern: &'a str,
     ) -> BoxFuture<'a, Result<Vec<PathBuf>>> {
         Box::pin(async move { crate::eval::expand_glob(base, pattern) })
+    }
+}
+
+#[cfg(feature = "blocking")]
+fn blocking_http_error(url: &str, error: ureq::Error) -> crate::Error {
+    if matches!(error, ureq::Error::StatusCode(404)) {
+        crate::Error::ImportNotFound(url.to_string())
+    } else {
+        crate::Error::Eval(format!("HTTP fetch failed for {url}: {error}"))
     }
 }
 
@@ -220,9 +537,27 @@ fn unique_temp_dir(prefix: &str) -> Result<PathBuf> {
     )))
 }
 
+#[cfg(feature = "package-zip-core")]
+fn extract_zip_sync(bytes: Vec<u8>, destination: &Path) -> Result<()> {
+    let mut archive = zip::ZipArchive::new(std::io::Cursor::new(bytes))
+        .map_err(|error| crate::Error::Eval(format!("zip error: {error}")))?;
+    archive
+        .extract(destination)
+        .map_err(|error| crate::Error::Eval(format!("zip extract error: {error}")))?;
+    Ok(())
+}
+
 #[cfg(all(test, feature = "native-io"))]
 mod tests {
     use super::{EvalCapabilities, NativeCapabilities};
+
+    #[cfg(feature = "blocking")]
+    #[test]
+    fn blocking_capabilities_install_a_crypto_provider() {
+        let _ = super::BlockingCapabilities::new();
+
+        assert!(rustls::crypto::CryptoProvider::get_default().is_some());
+    }
 
     #[tokio::test]
     async fn native_temp_dirs_are_unique_and_empty() {
@@ -242,5 +577,17 @@ mod tests {
 
         std::fs::remove_dir(&first).unwrap();
         std::fs::remove_dir(&second).unwrap();
+    }
+
+    #[tokio::test]
+    async fn native_path_exists_treats_metadata_errors_as_missing() {
+        let mut capabilities = NativeCapabilities::new();
+
+        assert!(
+            !capabilities
+                .path_exists(std::path::Path::new("invalid\0path"))
+                .await
+                .unwrap()
+        );
     }
 }

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -32,7 +32,7 @@ pub struct Evaluator {
     /// Host-provided IO for files, environment, HTTP, packages, and globs.
     capabilities: Box<dyn EvalCapabilities>,
     /// Extracted package zip directories (zip URL → temp dir path)
-    #[cfg(feature = "package-zip")]
+    #[cfg(feature = "package-zip-core")]
     package_dirs: HashMap<String, PathBuf>,
     /// Directory used to persist downloaded package content across evaluators.
     package_cache_dir: Option<PathBuf>,
@@ -83,8 +83,11 @@ impl Default for Evaluator {
             module_scopes: HashMap::new(),
             env_reads: BTreeMap::new(),
             scoped_imports_in_flight: HashSet::new(),
+            #[cfg(feature = "blocking")]
+            capabilities: Box::new(crate::capabilities::BlockingCapabilities::new()),
+            #[cfg(not(feature = "blocking"))]
             capabilities: Box::new(crate::capabilities::NativeCapabilities::new()),
-            #[cfg(feature = "package-zip")]
+            #[cfg(feature = "package-zip-core")]
             package_dirs: HashMap::new(),
             package_cache_dir: None,
             package_http_roots: HashSet::new(),
@@ -97,9 +100,16 @@ impl Default for Evaluator {
 }
 
 impl Evaluator {
-    #[cfg(feature = "native-io")]
+    /// Construct an evaluator with synchronous host capabilities.
+    #[cfg(feature = "blocking")]
     pub fn new() -> Self {
         Self::default()
+    }
+
+    /// Construct an evaluator with asynchronous host capabilities.
+    #[cfg(feature = "async")]
+    pub fn new_async() -> Self {
+        Self::with_capabilities(crate::capabilities::NativeCapabilities::new())
     }
 
     pub fn with_capabilities(capabilities: impl EvalCapabilities + 'static) -> Self {
@@ -112,7 +122,7 @@ impl Evaluator {
             env_reads: BTreeMap::new(),
             scoped_imports_in_flight: HashSet::new(),
             capabilities: Box::new(capabilities),
-            #[cfg(feature = "package-zip")]
+            #[cfg(feature = "package-zip-core")]
             package_dirs: HashMap::new(),
             package_cache_dir: None,
             package_http_roots: HashSet::new(),
@@ -128,7 +138,7 @@ impl Evaluator {
     }
 
     fn resolve_local_path(&self, current_path: &Path, uri: &str) -> PathBuf {
-        #[cfg(feature = "package-zip")]
+        #[cfg(feature = "package-zip-core")]
         if let Some(from_root) = uri.strip_prefix(".../")
             && let Some(root) = self
                 .package_dirs
@@ -171,13 +181,15 @@ impl Evaluator {
         self.import_cache.clear();
         self.module_scopes.clear();
         self.scoped_imports_in_flight.clear();
+        self.converters.clear();
     }
 
     /// Set a custom HTTP client for fetching remote imports and packages.
     /// Use this to configure proxy settings, CA certificates, timeouts, etc.
+    /// Returns an error when the installed capabilities use another HTTP backend.
     #[cfg(feature = "http")]
-    pub fn set_http_client(&mut self, client: reqwest::Client) {
-        self.capabilities.set_http_client(client);
+    pub fn set_http_client(&mut self, client: reqwest::Client) -> Result<()> {
+        self.capabilities.set_http_client(client)
     }
 
     /// Add HTTP URL rewrite rules. Each rule is a `"source_prefix=target_prefix"` string
@@ -347,14 +359,14 @@ impl Evaluator {
                     return Ok(Some((source, url.clone())));
                 }
                 PackageSource::Zip(zip_url, entry) => {
-                    #[cfg(feature = "package-zip")]
+                    #[cfg(feature = "package-zip-core")]
                     {
                         let pkg_dir = self.extract_package_zip(zip_url).await?;
                         let local_path = pkg_dir.join(entry);
                         let source = self.capabilities.read_to_string(&local_path).await?;
                         return Ok(Some((source, local_path.display().to_string())));
                     }
-                    #[cfg(not(feature = "package-zip"))]
+                    #[cfg(not(feature = "package-zip-core"))]
                     {
                         let _ = entry;
                         return Err(Error::Unsupported(format!(
@@ -396,11 +408,11 @@ impl Evaluator {
     }
 
     async fn fetch_package_bytes(&mut self, url: &str, extension: &str) -> Result<Vec<u8>> {
-        match self.read_package_cache(url, extension) {
+        match self.read_package_cache(url, extension).await {
             Ok(Some(bytes)) => match validate_package_bytes(url, extension, &bytes) {
                 Ok(()) => return Ok(bytes),
                 Err(error) if self.offline => return Err(error),
-                Err(_) => self.remove_package_cache(url, extension),
+                Err(_) => self.remove_package_cache(url, extension).await,
             },
             Ok(None) => {}
             Err(error) if self.offline => return Err(error),
@@ -423,32 +435,39 @@ impl Evaluator {
         let bytes = self.capabilities.fetch_bytes(&fetch_url).await?;
         validate_package_bytes(url, extension, &bytes)?;
         // Best-effort: the bytes are already in hand.
-        let _ = self.write_package_cache(url, extension, &bytes);
+        let _ = self.write_package_cache(url, extension, &bytes).await;
         Ok(bytes)
     }
 
-    fn read_package_cache(&self, url: &str, extension: &str) -> Result<Option<Vec<u8>>> {
+    async fn read_package_cache(&mut self, url: &str, extension: &str) -> Result<Option<Vec<u8>>> {
         let Some(cache_dir) = &self.package_cache_dir else {
             return Ok(None);
         };
         let (data_path, url_path) = package_cache_paths(cache_dir, url, extension);
-        let cached_url = match std::fs::read_to_string(&url_path) {
+        let cached_url = match self.capabilities.read_to_string(&url_path).await {
             Ok(cached_url) => cached_url,
-            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
-            Err(error) => return Err(Error::Io(url_path, error)),
+            Err(Error::Io(_, error)) if error.kind() == std::io::ErrorKind::NotFound => {
+                return Ok(None);
+            }
+            Err(error) => return Err(error),
         };
         if cached_url != url {
             return Ok(None);
         }
-        match std::fs::read(&data_path) {
+        match self.capabilities.read_bytes(&data_path).await {
             Ok(bytes) => Ok(Some(bytes)),
-            Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),
-            Err(error) => Err(Error::Io(data_path, error)),
+            Err(Error::Io(_, error)) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),
+            Err(error) => Err(error),
         }
     }
 
     /// Cache `bytes` for `url`. The fetch path ignores the error; preloading does not.
-    fn write_package_cache(&self, url: &str, extension: &str, bytes: &[u8]) -> Result<()> {
+    async fn write_package_cache(
+        &mut self,
+        url: &str,
+        extension: &str,
+        bytes: &[u8],
+    ) -> Result<()> {
         let Some(cache_dir) = &self.package_cache_dir else {
             return Ok(());
         };
@@ -456,9 +475,11 @@ impl Evaluator {
         let Some(parent) = data_path.parent() else {
             return Ok(());
         };
-        std::fs::create_dir_all(parent).map_err(|error| Error::Io(parent.to_path_buf(), error))?;
-        write_atomic(&data_path, bytes).map_err(|error| Error::Io(data_path, error))?;
-        write_atomic(&url_path, url.as_bytes()).map_err(|error| Error::Io(url_path, error))
+        self.capabilities.create_dir_all(parent).await?;
+        self.capabilities.write_atomic(&data_path, bytes).await?;
+        self.capabilities
+            .write_atomic(&url_path, url.as_bytes())
+            .await
     }
 
     /// Seed the persistent package cache with `bytes` for `url`.
@@ -467,59 +488,67 @@ impl Evaluator {
     /// downloads. A valid cache entry already present wins, so preloading never
     /// overrides content fetched from the network. Does nothing when no package
     /// cache directory is configured.
-    pub fn preload_package(&self, url: &str, extension: &str, bytes: &[u8]) -> Result<()> {
+    pub async fn preload_package_async(
+        &mut self,
+        url: &str,
+        extension: &str,
+        bytes: &[u8],
+    ) -> Result<()> {
         if self.package_cache_dir.is_none() {
             return Ok(());
         }
-        if let Ok(Some(cached)) = self.read_package_cache(url, extension)
+        if let Ok(Some(cached)) = self.read_package_cache(url, extension).await
             && validate_package_bytes(url, extension, &cached).is_ok()
         {
             return Ok(());
         }
         validate_package_bytes(url, extension, bytes)?;
-        self.write_package_cache(url, extension, bytes)
+        self.write_package_cache(url, extension, bytes).await
     }
 
-    fn remove_package_cache(&self, url: &str, extension: &str) {
+    #[cfg(feature = "blocking")]
+    pub fn preload_package(&mut self, url: &str, extension: &str, bytes: &[u8]) -> Result<()> {
+        pollster::block_on(self.preload_package_async(url, extension, bytes))
+    }
+
+    async fn remove_package_cache(&mut self, url: &str, extension: &str) {
         let Some(cache_dir) = &self.package_cache_dir else {
             return;
         };
         let (data_path, url_path) = package_cache_paths(cache_dir, url, extension);
-        let _ = std::fs::remove_file(data_path);
-        let _ = std::fs::remove_file(url_path);
+        let _ = self.capabilities.remove_file(&data_path).await;
+        let _ = self.capabilities.remove_file(&url_path).await;
     }
 
     /// Download a package zip and extract it to a temp directory.
     /// Returns the path to the extracted directory. Caches by zip URL.
-    #[cfg(feature = "package-zip")]
+    #[cfg(feature = "package-zip-core")]
     async fn extract_package_zip(&mut self, zip_url: &str) -> Result<PathBuf> {
         // Check if already extracted
         if let Some(dir) = self.package_dirs.get(zip_url) {
             return Ok(dir.clone());
         }
         let bytes = self.fetch_package_bytes(zip_url, "zip").await?;
-        let cursor = std::io::Cursor::new(bytes);
-        let mut archive =
-            zip::ZipArchive::new(cursor).map_err(|e| Error::Eval(format!("zip error: {e}")))?;
         let dir = self
             .capabilities
             .temp_dir(&format!("pklr-pkg-{}", self.package_dirs.len()))
             .await?;
-        archive
-            .extract(&dir)
-            .map_err(|e| Error::Eval(format!("zip extract error: {e}")))?;
+        self.capabilities.extract_zip(bytes, &dir).await?;
         self.package_dirs.insert(zip_url.to_string(), dir.clone());
         Ok(dir)
     }
 
-    #[cfg(all(test, feature = "package-zip"))]
+    #[cfg(all(test, feature = "package-zip-core"))]
     fn package_dir_for_zip(&self, zip_url: &str) -> Option<&PathBuf> {
         self.package_dirs.get(zip_url)
     }
 
     pub async fn eval_source(&mut self, source: &str, path: &Path) -> Result<Value> {
         self.begin_evaluation();
-        self.converters.clear();
+        self.eval_source_inner(source, path).await
+    }
+
+    async fn eval_source_inner(&mut self, source: &str, path: &Path) -> Result<Value> {
         // Seed import cache for the entry file so circular back-references work
         if let Ok(canonical) = self.capabilities.canonicalize(path).await {
             self.import_cache
@@ -539,7 +568,8 @@ impl Evaluator {
     /// Evaluate a local pkl file by path (public entry point).
     pub async fn eval_file_pub(&mut self, path: &Path) -> Result<Value> {
         self.begin_evaluation();
-        self.eval_file(path, 0).await
+        let source = self.capabilities.read_to_string(path).await?;
+        self.eval_source_inner(&source, path).await
     }
 
     /// Read, lex, parse, and evaluate a local file (with caching).
@@ -816,7 +846,7 @@ impl Evaluator {
                 let requested = requested_fields_for_import(&import_field_uses, &alias);
                 // For zip packages, extract to temp dir and eval as local file
                 if let PackageSource::Zip(zip_url, _) = &pkg {
-                    #[cfg(feature = "package-zip")]
+                    #[cfg(feature = "package-zip-core")]
                     {
                         let pkg_dir = self.extract_package_zip(zip_url).await?;
                         let local_path = pkg_dir.join(file_path);
@@ -826,7 +856,7 @@ impl Evaluator {
                         scope.set(alias, imported_val);
                         continue;
                     }
-                    #[cfg(not(feature = "package-zip"))]
+                    #[cfg(not(feature = "package-zip-core"))]
                     {
                         return Err(Error::Unsupported(format!(
                             "package zip imports require pklr's 'package-zip' feature: {zip_url}"
@@ -946,7 +976,7 @@ impl Evaluator {
             } else if uri.starts_with("package://") {
                 let pkg = resolve_package_uri(uri)?;
                 if let PackageSource::Zip(zip_url, entry) = &pkg {
-                    #[cfg(feature = "package-zip")]
+                    #[cfg(feature = "package-zip-core")]
                     {
                         let pkg_dir = self.extract_package_zip(zip_url).await?;
                         let local_path = pkg_dir.join(entry);
@@ -970,7 +1000,7 @@ impl Evaluator {
                             base_obj = (*m).clone();
                         }
                     }
-                    #[cfg(not(feature = "package-zip"))]
+                    #[cfg(not(feature = "package-zip-core"))]
                     {
                         let _ = entry;
                         return Err(Error::Unsupported(format!(
@@ -4963,7 +4993,7 @@ fn validate_package_bytes(url: &str, extension: &str, bytes: &[u8]) -> Result<()
         std::str::from_utf8(bytes)
             .map_err(|error| Error::Eval(format!("package source is not UTF-8: {url}: {error}")))?;
     }
-    #[cfg(feature = "package-zip")]
+    #[cfg(feature = "package-zip-core")]
     if extension == "zip" {
         let mut archive = zip::ZipArchive::new(std::io::Cursor::new(bytes))
             .map_err(|error| Error::Eval(format!("package archive is invalid: {url}: {error}")))?;
@@ -4982,7 +5012,7 @@ fn validate_package_bytes(url: &str, extension: &str, bytes: &[u8]) -> Result<()
     Ok(())
 }
 
-fn write_atomic(path: &Path, bytes: &[u8]) -> std::io::Result<()> {
+pub(crate) fn write_atomic(path: &Path, bytes: &[u8]) -> std::io::Result<()> {
     use std::io::Write;
     use std::sync::atomic::{AtomicU64, Ordering};
 
@@ -5717,7 +5747,7 @@ mod requested_field_tests {
         let tokens = lexer::lex(source).unwrap();
         let module = parser::parse(&tokens).unwrap();
 
-        let value = Evaluator::new()
+        let value = Evaluator::default()
             .eval_module_with_scope(
                 &module,
                 &child_path,
@@ -5960,10 +5990,10 @@ mod auto_trait_tests {
 
 #[cfg(test)]
 mod package_uri_tests {
-    #[cfg(all(feature = "native-io", feature = "package-zip"))]
+    #[cfg(all(feature = "native-io", feature = "package-zip-core"))]
     use std::path::PathBuf;
 
-    #[cfg(all(feature = "native-io", feature = "package-zip"))]
+    #[cfg(all(feature = "native-io", feature = "package-zip-core"))]
     use super::Evaluator;
     use super::{PackageSource, resolve_package_uri};
 
@@ -5998,7 +6028,7 @@ mod package_uri_tests {
     }
 
     #[test]
-    #[cfg(feature = "package-zip")]
+    #[cfg(feature = "package-zip-core")]
     fn package_archive_validation_reads_entry_payloads() {
         use std::io::Write;
 
@@ -6030,9 +6060,33 @@ mod package_uri_tests {
     }
 
     #[test]
-    #[cfg(all(feature = "native-io", feature = "package-zip"))]
+    #[cfg(all(feature = "blocking", feature = "native-io"))]
+    fn blocking_preload_does_not_require_a_tokio_runtime() {
+        let cache_dir = std::env::temp_dir().join(format!(
+            "pklr-blocking-preload-{}-{:?}",
+            std::process::id(),
+            std::thread::current().id()
+        ));
+        let _ = std::fs::remove_dir_all(&cache_dir);
+        let mut evaluator = Evaluator::default();
+        evaluator.set_package_cache_dir(&cache_dir);
+
+        evaluator
+            .preload_package(
+                "https://example.com/package@1.0.0.pkl",
+                "pkl",
+                b"answer = 42\n",
+            )
+            .unwrap();
+
+        assert!(std::fs::read_dir(&cache_dir).unwrap().next().is_some());
+        std::fs::remove_dir_all(cache_dir).unwrap();
+    }
+
+    #[test]
+    #[cfg(all(feature = "native-io", feature = "package-zip-core"))]
     fn package_dir_lookup_uses_source_zip_url() {
-        let mut evaluator = Evaluator::new();
+        let mut evaluator = Evaluator::default();
         evaluator.set_http_rewrites(&["https://example.com/=https://mirror.local/".to_string()]);
         let dir = PathBuf::from("/tmp/pklr-test-package");
         evaluator

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,8 @@ pub mod parser;
 #[cfg(feature = "eval-core")]
 pub mod value;
 
+#[cfg(feature = "blocking")]
+pub use capabilities::BlockingCapabilities;
 #[cfg(feature = "eval-core")]
 pub use capabilities::EvalCapabilities;
 #[cfg(feature = "native-io")]
@@ -21,6 +23,9 @@ pub use value::Value;
 /// Re-export reqwest so consumers can build a Client without a separate dependency.
 #[cfg(feature = "http")]
 pub use reqwest;
+/// Re-export ureq so blocking consumers can configure an HTTP agent.
+#[cfg(feature = "blocking")]
+pub use ureq;
 
 #[cfg(feature = "native-io")]
 use std::path::Path;
@@ -38,17 +43,22 @@ pub struct EvalOutcome {
     pub env_reads: std::collections::BTreeMap<String, Option<String>>,
 }
 
-/// Evaluate a pkl file and return its contents as a JSON value.
-/// This is the primary entry point for use in tools like hk.
-#[cfg(feature = "native-io")]
-pub async fn eval_to_json(path: &Path) -> Result<serde_json::Value> {
-    eval_to_json_with_client(path, None).await
+/// Evaluate a Pkl file synchronously and return its contents as JSON.
+#[cfg(feature = "blocking")]
+pub fn eval_to_json(path: &Path) -> Result<serde_json::Value> {
+    EvaluatorBuilder::new().eval_to_json(path)
+}
+
+/// Evaluate a Pkl file asynchronously and return its contents as JSON.
+#[cfg(feature = "async")]
+pub async fn eval_to_json_async(path: &Path) -> Result<serde_json::Value> {
+    eval_to_json_with_client_async(path, None).await
 }
 
 /// Options for configuring the pkl evaluator.
-#[cfg(feature = "native-io")]
+#[cfg(feature = "async")]
 #[derive(Default)]
-pub struct EvalOptions {
+pub struct AsyncEvalOptions {
     /// Custom HTTP client for proxy/CA configuration.
     #[cfg(feature = "http")]
     pub client: Option<reqwest::Client>,
@@ -57,12 +67,33 @@ pub struct EvalOptions {
     pub http_rewrites: Vec<String>,
 }
 
-/// Extensible builder for configuring a Pkl evaluator.
-#[cfg(feature = "native-io")]
+/// Options for configuring the blocking Pkl evaluator.
+#[cfg(feature = "blocking")]
 #[derive(Default)]
-pub struct EvaluatorBuilder {
+pub struct EvalOptions {
+    /// Custom synchronous HTTP agent for proxy, CA, or timeout configuration.
+    pub agent: Option<ureq::Agent>,
+    /// HTTP URL rewrite rules in `"source_prefix=target_prefix"` format.
+    pub http_rewrites: Vec<String>,
+}
+
+/// Extensible builder for configuring a Pkl evaluator.
+#[cfg(feature = "async")]
+#[derive(Default)]
+pub struct AsyncEvaluatorBuilder {
     #[cfg(feature = "http")]
     client: Option<reqwest::Client>,
+    http_rewrites: Vec<String>,
+    package_cache_dir: Option<std::path::PathBuf>,
+    offline: bool,
+    preloaded_packages: Vec<PreloadedPackage>,
+}
+
+/// Extensible builder for synchronous Pkl evaluation.
+#[cfg(feature = "blocking")]
+#[derive(Default)]
+pub struct EvaluatorBuilder {
+    agent: Option<ureq::Agent>,
     http_rewrites: Vec<String>,
     package_cache_dir: Option<std::path::PathBuf>,
     offline: bool,
@@ -77,8 +108,8 @@ struct PreloadedPackage {
     bytes: std::borrow::Cow<'static, [u8]>,
 }
 
-#[cfg(feature = "native-io")]
-impl EvaluatorBuilder {
+#[cfg(feature = "async")]
+impl AsyncEvaluatorBuilder {
     pub fn new() -> Self {
         Self::default()
     }
@@ -127,11 +158,13 @@ impl EvaluatorBuilder {
     /// Build a configured evaluator for direct source evaluation.
     ///
     /// A package that fails to preload is skipped and fetched normally.
-    pub fn build(self) -> Evaluator {
-        let mut evaluator = Evaluator::new();
+    pub async fn build(self) -> Evaluator {
+        let mut evaluator = Evaluator::new_async();
         #[cfg(feature = "http")]
         if let Some(client) = self.client {
-            evaluator.set_http_client(client);
+            evaluator
+                .set_http_client(client)
+                .expect("native async capabilities accept reqwest clients");
         }
         evaluator.set_http_rewrites(&self.http_rewrites);
         if let Some(cache_dir) = self.package_cache_dir {
@@ -139,7 +172,9 @@ impl EvaluatorBuilder {
         }
         evaluator.set_offline(self.offline);
         for package in &self.preloaded_packages {
-            let _ = evaluator.preload_package(&package.url, &package.extension, &package.bytes);
+            let _ = evaluator
+                .preload_package_async(&package.url, &package.extension, &package.bytes)
+                .await;
         }
         evaluator
     }
@@ -151,19 +186,94 @@ impl EvaluatorBuilder {
 
     /// Evaluate a Pkl file and return its JSON and environment dependencies.
     pub async fn eval(self, path: &Path) -> Result<EvalOutcome> {
-        eval_with_evaluator(path, self.build()).await
+        let evaluator = self.build().await;
+        eval_with_evaluator(path, evaluator).await
+    }
+}
+
+#[cfg(feature = "blocking")]
+impl EvaluatorBuilder {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Use a custom synchronous HTTP agent.
+    pub fn http_agent(mut self, agent: ureq::Agent) -> Self {
+        self.agent = Some(agent);
+        self
+    }
+
+    /// Add HTTP URL rewrite rules in `"source_prefix=target_prefix"` format.
+    pub fn http_rewrites(mut self, rules: impl IntoIterator<Item = String>) -> Self {
+        self.http_rewrites.extend(rules);
+        self
+    }
+
+    /// Persist downloaded `package://` content under `path`.
+    pub fn package_cache_dir(mut self, path: impl Into<std::path::PathBuf>) -> Self {
+        self.package_cache_dir = Some(path.into());
+        self
+    }
+
+    /// Disable network access while allowing cached packages to load.
+    pub fn offline(mut self, offline: bool) -> Self {
+        self.offline = offline;
+        self
+    }
+
+    /// Seed the package cache with content the host already has.
+    pub fn preload_package(
+        mut self,
+        url: impl Into<String>,
+        extension: impl Into<String>,
+        bytes: impl Into<std::borrow::Cow<'static, [u8]>>,
+    ) -> Self {
+        self.preloaded_packages.push(PreloadedPackage {
+            url: url.into(),
+            extension: extension.into(),
+            bytes: bytes.into(),
+        });
+        self
+    }
+
+    /// Build a configured evaluator for direct source evaluation.
+    pub fn build(self) -> Evaluator {
+        let capabilities = match self.agent {
+            Some(agent) => BlockingCapabilities::with_http_agent(agent),
+            None => BlockingCapabilities::new(),
+        };
+        let mut evaluator = Evaluator::with_capabilities(capabilities);
+        evaluator.set_http_rewrites(&self.http_rewrites);
+        if let Some(cache_dir) = self.package_cache_dir {
+            evaluator.set_package_cache_dir(cache_dir);
+        }
+        evaluator.set_offline(self.offline);
+        for package in &self.preloaded_packages {
+            let _ = evaluator.preload_package(&package.url, &package.extension, &package.bytes);
+        }
+        evaluator
+    }
+
+    /// Evaluate a Pkl file synchronously and return its JSON value.
+    pub fn eval_to_json(self, path: &Path) -> Result<serde_json::Value> {
+        Ok(self.eval(path)?.json)
+    }
+
+    /// Evaluate a Pkl file synchronously and return its result and dependencies.
+    pub fn eval(self, path: &Path) -> Result<EvalOutcome> {
+        pollster::block_on(eval_with_evaluator(path, self.build()))
     }
 }
 
 /// Evaluate a pkl file with a custom HTTP client for proxy/CA configuration.
-#[cfg(all(feature = "native-io", feature = "http"))]
-pub async fn eval_to_json_with_client(
+#[cfg(feature = "async")]
+pub async fn eval_to_json_with_client_async(
     path: &Path,
     client: Option<reqwest::Client>,
 ) -> Result<serde_json::Value> {
-    eval_to_json_with_options(
+    eval_to_json_with_options_async(
         path,
-        EvalOptions {
+        AsyncEvalOptions {
             client,
             ..Default::default()
         },
@@ -171,39 +281,50 @@ pub async fn eval_to_json_with_client(
     .await
 }
 
-#[cfg(all(feature = "native-io", not(feature = "http")))]
-pub async fn eval_to_json_with_client(
+/// Evaluate a Pkl file asynchronously with full configuration options.
+#[cfg(feature = "async")]
+pub async fn eval_to_json_with_options_async(
     path: &Path,
-    _client: Option<()>,
+    options: AsyncEvalOptions,
 ) -> Result<serde_json::Value> {
-    eval_to_json_with_options(path, EvalOptions::default()).await
+    Ok(eval_with_options_async(path, options).await?.json)
 }
 
-/// Evaluate a pkl file with full configuration options.
-#[cfg(feature = "native-io")]
-pub async fn eval_to_json_with_options(
-    path: &Path,
-    options: EvalOptions,
-) -> Result<serde_json::Value> {
-    Ok(eval_with_options(path, options).await?.json)
+/// Evaluate a Pkl file synchronously with full configuration options.
+#[cfg(feature = "blocking")]
+pub fn eval_to_json_with_options(path: &Path, options: EvalOptions) -> Result<serde_json::Value> {
+    Ok(eval_with_options(path, options)?.json)
 }
 
-/// Evaluate a pkl file and return its JSON value and environment dependencies.
-#[cfg(feature = "native-io")]
-pub async fn eval_with_options(path: &Path, options: EvalOptions) -> Result<EvalOutcome> {
-    let mut builder = EvaluatorBuilder::new().http_rewrites(options.http_rewrites);
-    #[cfg(feature = "http")]
-    if let Some(client) = options.client {
-        builder = builder.http_client(client);
-    }
+/// Evaluate a Pkl file asynchronously and return its result and dependencies.
+#[cfg(feature = "async")]
+pub async fn eval_with_options_async(
+    path: &Path,
+    options: AsyncEvalOptions,
+) -> Result<EvalOutcome> {
+    let builder = AsyncEvaluatorBuilder::new().http_rewrites(options.http_rewrites);
+    let builder = match options.client {
+        Some(client) => builder.http_client(client),
+        None => builder,
+    };
     builder.eval(path).await
+}
+
+/// Evaluate a Pkl file synchronously and return its result and dependencies.
+#[cfg(feature = "blocking")]
+pub fn eval_with_options(path: &Path, options: EvalOptions) -> Result<EvalOutcome> {
+    let builder = EvaluatorBuilder::new().http_rewrites(options.http_rewrites);
+    let builder = match options.agent {
+        Some(agent) => builder.http_agent(agent),
+        None => builder,
+    };
+    builder.eval(path)
 }
 
 #[cfg(feature = "native-io")]
 async fn eval_with_evaluator(path: &Path, mut evaluator: Evaluator) -> Result<EvalOutcome> {
-    let source = std::fs::read_to_string(path).map_err(|e| Error::Io(path.to_path_buf(), e))?;
     evaluator.set_base_path(path.parent().unwrap_or(Path::new(".")));
-    let value = evaluator.eval_source(&source, path).await?;
+    let value = evaluator.eval_file_pub(path).await?;
     let value = evaluator.apply_converters(value).await?;
     Ok(EvalOutcome {
         json: value.to_json(),
@@ -212,7 +333,7 @@ async fn eval_with_evaluator(path: &Path, mut evaluator: Evaluator) -> Result<Ev
 }
 
 /// Analyze imports of a pkl file, returning all transitive local file dependencies.
-#[cfg(feature = "native-io")]
+#[cfg(feature = "blocking")]
 pub fn analyze_imports(path: &Path) -> Result<Vec<std::path::PathBuf>> {
     let mut results = Vec::new();
     let mut visited = std::collections::HashSet::new();
@@ -221,7 +342,7 @@ pub fn analyze_imports(path: &Path) -> Result<Vec<std::path::PathBuf>> {
     Ok(results)
 }
 
-#[cfg(feature = "native-io")]
+#[cfg(feature = "blocking")]
 fn analyze_imports_inner(
     path: &Path,
     visited: &mut std::collections::HashSet<std::path::PathBuf>,
@@ -261,6 +382,79 @@ fn analyze_imports_inner(
                 results.push(import_path.clone());
             }
             analyze_imports_inner(&import_path, visited, seen_results, results)?;
+        }
+    }
+    Ok(())
+}
+
+/// Analyze imports asynchronously, returning all transitive local file dependencies.
+#[cfg(feature = "async")]
+pub async fn analyze_imports_async(path: &Path) -> Result<Vec<std::path::PathBuf>> {
+    let mut results = Vec::new();
+    let mut visited = std::collections::HashSet::new();
+    let mut seen_results = std::collections::HashSet::new();
+    let mut capabilities = NativeCapabilities::new();
+    analyze_imports_inner_async(
+        path,
+        &mut capabilities,
+        &mut visited,
+        &mut seen_results,
+        &mut results,
+    )
+    .await?;
+    Ok(results)
+}
+
+#[cfg(feature = "async")]
+#[async_recursion::async_recursion(?Send)]
+async fn analyze_imports_inner_async(
+    path: &Path,
+    capabilities: &mut NativeCapabilities,
+    visited: &mut std::collections::HashSet<std::path::PathBuf>,
+    seen_results: &mut std::collections::HashSet<std::path::PathBuf>,
+    results: &mut Vec<std::path::PathBuf>,
+) -> Result<()> {
+    let canonical = capabilities
+        .canonicalize(path)
+        .await
+        .unwrap_or_else(|_| path.to_path_buf());
+    if !visited.insert(canonical) {
+        return Ok(());
+    }
+    let source = capabilities.read_to_string(path).await?;
+    let tokens = lexer::lex_named(&source, &path.display().to_string())?;
+    let imports = parser::collect_imports(&tokens);
+    let base = path.parent().unwrap_or(Path::new("."));
+    for uri in imports {
+        let mut local_imports = Vec::new();
+        if let Some(rel) = uri.strip_prefix("file://") {
+            local_imports.push(std::path::PathBuf::from(rel));
+        } else if !uri.contains("://") {
+            if uri.contains('*') {
+                if let Ok(expanded) = capabilities.glob(base, &uri).await {
+                    local_imports.extend(expanded);
+                }
+            } else {
+                local_imports.push(base.join(&uri));
+            }
+        }
+        for import_path in local_imports {
+            if !capabilities
+                .path_exists(&import_path)
+                .await
+                .unwrap_or(false)
+            {
+                continue;
+            }
+            let result_key = capabilities
+                .canonicalize(&import_path)
+                .await
+                .unwrap_or_else(|_| import_path.clone());
+            if seen_results.insert(result_key) {
+                results.push(import_path.clone());
+            }
+            analyze_imports_inner_async(&import_path, capabilities, visited, seen_results, results)
+                .await?;
         }
     }
     Ok(())

--- a/tests/blocking.rs
+++ b/tests/blocking.rs
@@ -1,0 +1,399 @@
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
+
+use pklr::capabilities::BoxFuture;
+use pklr::{EvalCapabilities, Evaluator};
+
+#[derive(Clone, Default)]
+struct MemoryCacheCapabilities {
+    files: Arc<Mutex<HashMap<PathBuf, Vec<u8>>>>,
+}
+
+impl EvalCapabilities for MemoryCacheCapabilities {
+    fn read_to_string<'a>(&'a mut self, path: &'a Path) -> BoxFuture<'a, pklr::Result<String>> {
+        let bytes = self.files.lock().unwrap().get(path).cloned();
+        Box::pin(async move {
+            let bytes = bytes.ok_or_else(|| {
+                pklr::Error::Io(
+                    path.to_path_buf(),
+                    std::io::Error::from(std::io::ErrorKind::NotFound),
+                )
+            })?;
+            String::from_utf8(bytes).map_err(|error| pklr::Error::Eval(error.to_string()))
+        })
+    }
+
+    fn path_exists<'a>(&'a mut self, path: &'a Path) -> BoxFuture<'a, pklr::Result<bool>> {
+        let exists = self.files.lock().unwrap().contains_key(path);
+        Box::pin(async move { Ok(exists) })
+    }
+
+    fn canonicalize<'a>(&'a mut self, path: &'a Path) -> BoxFuture<'a, pklr::Result<PathBuf>> {
+        Box::pin(async move { Ok(path.to_path_buf()) })
+    }
+
+    fn read_bytes<'a>(&'a mut self, path: &'a Path) -> BoxFuture<'a, pklr::Result<Vec<u8>>> {
+        let bytes = self.files.lock().unwrap().get(path).cloned();
+        Box::pin(async move {
+            bytes.ok_or_else(|| {
+                pklr::Error::Io(
+                    path.to_path_buf(),
+                    std::io::Error::from(std::io::ErrorKind::NotFound),
+                )
+            })
+        })
+    }
+
+    fn create_dir_all<'a>(&'a mut self, _path: &'a Path) -> BoxFuture<'a, pklr::Result<()>> {
+        Box::pin(async { Ok(()) })
+    }
+
+    fn write_atomic<'a>(
+        &'a mut self,
+        path: &'a Path,
+        bytes: &'a [u8],
+    ) -> BoxFuture<'a, pklr::Result<()>> {
+        self.files
+            .lock()
+            .unwrap()
+            .insert(path.to_path_buf(), bytes.to_vec());
+        Box::pin(async { Ok(()) })
+    }
+
+    fn read_env<'a>(&'a mut self, _name: &'a str) -> BoxFuture<'a, pklr::Result<Option<String>>> {
+        Box::pin(async { Ok(None) })
+    }
+
+    fn fetch_text<'a>(&'a mut self, url: &'a str) -> BoxFuture<'a, pklr::Result<String>> {
+        Box::pin(async move { Err(pklr::Error::Unsupported(url.to_string())) })
+    }
+
+    fn fetch_bytes<'a>(&'a mut self, url: &'a str) -> BoxFuture<'a, pklr::Result<Vec<u8>>> {
+        Box::pin(async move { Err(pklr::Error::Unsupported(url.to_string())) })
+    }
+
+    fn temp_dir<'a>(&'a mut self, prefix: &'a str) -> BoxFuture<'a, pklr::Result<PathBuf>> {
+        Box::pin(async move { Ok(PathBuf::from(prefix)) })
+    }
+
+    fn glob<'a>(
+        &'a mut self,
+        _base: &'a Path,
+        _pattern: &'a str,
+    ) -> BoxFuture<'a, pklr::Result<Vec<PathBuf>>> {
+        Box::pin(async { Ok(Vec::new()) })
+    }
+}
+
+fn spawn_test_http_server(path: &'static str, body: &'static str) -> String {
+    spawn_test_http_bytes_server(path, body.as_bytes().to_vec())
+}
+
+fn spawn_test_http_bytes_server(path: &'static str, body: Vec<u8>) -> String {
+    use std::io::{BufRead, BufReader, Write};
+    use std::net::TcpListener;
+
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let port = listener.local_addr().unwrap().port();
+    std::thread::spawn(move || {
+        let (mut stream, _) = listener.accept().unwrap();
+        let mut reader = BufReader::new(stream.try_clone().unwrap());
+        let mut request_line = String::new();
+        reader.read_line(&mut request_line).unwrap();
+        let request_path = request_line.split_whitespace().nth(1).unwrap_or("/");
+        loop {
+            let mut line = String::new();
+            if reader.read_line(&mut line).unwrap() == 0 || line == "\r\n" {
+                break;
+            }
+        }
+        let response = if request_path == path {
+            let mut response = format!(
+                "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+                body.len()
+            )
+            .into_bytes();
+            response.extend_from_slice(&body);
+            response
+        } else {
+            b"HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\nConnection: close\r\n\r\n".to_vec()
+        };
+        stream.write_all(&response).unwrap();
+    });
+    format!("http://127.0.0.1:{port}")
+}
+
+fn package_zip(name: &str, contents: &str) -> Vec<u8> {
+    package_zip_entries(&[(name, contents)])
+}
+
+fn package_zip_entries(entries: &[(&str, &str)]) -> Vec<u8> {
+    use std::io::Write;
+
+    let mut bytes = Vec::new();
+    let mut archive = zip::ZipWriter::new(std::io::Cursor::new(&mut bytes));
+    for (name, contents) in entries {
+        archive
+            .start_file(name, zip::write::SimpleFileOptions::default())
+            .unwrap();
+        archive.write_all(contents.as_bytes()).unwrap();
+    }
+    archive.finish().unwrap();
+    bytes
+}
+
+#[test]
+fn evaluation_works_inside_and_outside_a_runtime() {
+    let path = std::path::Path::new("tests/fixtures/base.pkl");
+    let expected = pklr::eval_to_json(path).unwrap();
+
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .build()
+        .unwrap();
+    let actual = runtime.block_on(async { pklr::eval_to_json(path).unwrap() });
+
+    assert_eq!(actual, expected);
+}
+
+#[test]
+fn import_analysis_is_synchronous() {
+    let dir =
+        std::env::temp_dir().join(format!("pklr_test_blocking_imports_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    let dependency = dir.join("dependency.pkl");
+    let main = dir.join("main.pkl");
+    std::fs::write(&dependency, "answer = 42\n").unwrap();
+    std::fs::write(
+        &main,
+        "import \"dependency.pkl\" as dependency\nanswer = dependency.answer\n",
+    )
+    .unwrap();
+
+    let imports = pklr::analyze_imports(&main).unwrap();
+
+    assert_eq!(imports, vec![dependency]);
+    let _ = std::fs::remove_dir_all(dir);
+}
+
+#[test]
+fn configured_evaluation_returns_environment_reads() {
+    let base = spawn_test_http_server("/Imported.pkl", "value = 42\n");
+    let dir = std::env::temp_dir().join(format!("pklr_test_blocking_http_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    let path = dir.join("main.pkl");
+    std::fs::write(
+        &path,
+        "import \"https://example.com/Imported.pkl\" as Imported\nresult = Imported.value\nenvironment = read?(\"env:PATH\")\n",
+    )
+    .unwrap();
+
+    let outcome = pklr::eval_with_options(
+        &path,
+        pklr::EvalOptions {
+            http_rewrites: vec![format!("https://example.com/={base}/")],
+            ..Default::default()
+        },
+    )
+    .unwrap();
+
+    assert_eq!(outcome.json["result"], 42);
+    assert_eq!(
+        outcome.env_reads.get("PATH"),
+        Some(&std::env::var("PATH").ok())
+    );
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn default_evaluator_fetches_http_with_blocking_capabilities() {
+    let base = spawn_test_http_server("/Imported.pkl", "value = 42\n");
+    let dir = std::env::temp_dir().join(format!(
+        "pklr_test_default_evaluator_http_{}",
+        std::process::id()
+    ));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    let path = dir.join("main.pkl");
+    std::fs::write(
+        &path,
+        "import \"https://example.com/Imported.pkl\" as Imported\nresult = Imported.value\n",
+    )
+    .unwrap();
+    let mut evaluator = Evaluator::new();
+    evaluator.set_http_rewrites(&[format!("https://example.com/={base}/")]);
+
+    let value = pollster::block_on(evaluator.eval_file_pub(&path)).unwrap();
+
+    assert_eq!(value.to_json()["result"], 42);
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn failed_entry_read_resets_evaluation_state() {
+    let mut evaluator = Evaluator::new();
+    pollster::block_on(
+        evaluator.eval_source("value = read?(\"env:PATH\")\n", Path::new("first.pkl")),
+    )
+    .unwrap();
+    assert!(evaluator.env_reads().contains_key("PATH"));
+
+    let missing = std::env::temp_dir().join(format!(
+        "pklr_test_missing_entry_{}_{}",
+        std::process::id(),
+        std::thread::current().name().unwrap_or("unnamed")
+    ));
+    let _ = std::fs::remove_file(&missing);
+    let result = pollster::block_on(evaluator.eval_file_pub(&missing));
+
+    assert!(result.is_err());
+    assert!(evaluator.env_reads().is_empty());
+}
+
+#[test]
+fn blocking_http_rejects_invalid_utf8() {
+    let base = spawn_test_http_bytes_server("/invalid.pkl", b"value = \"\xff\"\n".to_vec());
+    let mut capabilities = pklr::BlockingCapabilities::new();
+
+    let error = pollster::block_on(capabilities.fetch_text(&format!("{base}/invalid.pkl")))
+        .unwrap_err()
+        .to_string();
+
+    assert!(error.contains("HTTP read failed"), "{error}");
+}
+
+#[test]
+fn evaluation_loads_preloaded_package_archives() {
+    let dir =
+        std::env::temp_dir().join(format!("pklr_test_blocking_package_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    let path = dir.join("main.pkl");
+    std::fs::write(
+        &path,
+        "amends \"package://example.com/pkg@1.0.0#/Config.pkl\"\n",
+    )
+    .unwrap();
+
+    let json = pklr::EvaluatorBuilder::new()
+        .package_cache_dir(dir.join("cache"))
+        .offline(true)
+        .preload_package(
+            "https://example.com/pkg@1.0.0.zip",
+            "zip",
+            package_zip("Config.pkl", "answer = 42\n"),
+        )
+        .eval_to_json(&path)
+        .unwrap();
+
+    assert_eq!(json["answer"], 42);
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn package_root_imports_work_in_default_blocking_builds() {
+    let dir = std::env::temp_dir().join(format!(
+        "pklr_test_blocking_package_root_{}",
+        std::process::id()
+    ));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    let path = dir.join("main.pkl");
+    std::fs::write(
+        &path,
+        "amends \"package://example.com/pkg@1.0.0#/nested/Config.pkl\"\n",
+    )
+    .unwrap();
+
+    let json = pklr::EvaluatorBuilder::new()
+        .package_cache_dir(dir.join("cache"))
+        .offline(true)
+        .preload_package(
+            "https://example.com/pkg@1.0.0.zip",
+            "zip",
+            package_zip_entries(&[
+                ("Base.pkl", "answer = 42\n"),
+                ("nested/Config.pkl", "amends \".../Base.pkl\"\n"),
+            ]),
+        )
+        .eval_to_json(&path)
+        .unwrap();
+
+    assert_eq!(json["answer"], 42);
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn blocking_preload_uses_custom_capabilities() {
+    let capabilities = MemoryCacheCapabilities::default();
+    let files = capabilities.files.clone();
+    let mut evaluator = Evaluator::with_capabilities(capabilities);
+    evaluator.set_package_cache_dir("virtual-cache");
+
+    evaluator
+        .preload_package("https://example.com/pkg@1.0.0.pkl", "pkl", b"answer = 42\n")
+        .unwrap();
+
+    let files = files.lock().unwrap();
+    assert_eq!(files.len(), 2);
+    assert!(files.values().any(|value| value == b"answer = 42\n"));
+    assert!(
+        files
+            .values()
+            .any(|value| value == b"https://example.com/pkg@1.0.0.pkl")
+    );
+}
+
+#[test]
+#[cfg(feature = "async")]
+fn native_evaluator_works_without_tokio_when_both_modes_are_enabled() {
+    let dir = std::env::temp_dir().join(format!(
+        "pklr_test_native_without_tokio_{}",
+        std::process::id()
+    ));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    let path = dir.join("main.pkl");
+    std::fs::write(
+        &path,
+        "amends \"package://example.com/pkg@1.0.0#/nested/Config.pkl\"\n",
+    )
+    .unwrap();
+
+    let mut evaluator = Evaluator::new_async();
+    evaluator.set_package_cache_dir(dir.join("cache"));
+    evaluator.set_offline(true);
+    evaluator
+        .preload_package(
+            "https://example.com/pkg@1.0.0.zip",
+            "zip",
+            &package_zip_entries(&[
+                ("Base.pkl", "answer = 42\n"),
+                ("nested/Config.pkl", "amends \".../Base.pkl\"\n"),
+            ]),
+        )
+        .unwrap();
+
+    let value = pollster::block_on(evaluator.eval_file_pub(&path)).unwrap();
+
+    assert_eq!(value.to_json()["answer"], 42);
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+#[cfg(feature = "async")]
+fn blocking_evaluator_rejects_reqwest_configuration() {
+    let mut evaluator = Evaluator::new();
+
+    let error = evaluator
+        .set_http_client(pklr::reqwest::Client::new())
+        .unwrap_err()
+        .to_string();
+
+    assert!(
+        error.contains("do not accept a reqwest HTTP client"),
+        "{error}"
+    );
+}

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -32,6 +32,18 @@ impl EvalCapabilities for MemoryCapabilities {
     }
 
     fn canonicalize<'a>(&'a mut self, path: &'a Path) -> BoxFuture<'a, pklr::Result<PathBuf>> {
+        if path == Path::new("uncanonicalized.pkl") {
+            let path = path.to_path_buf();
+            return Box::pin(async move {
+                Err(pklr::Error::Io(
+                    path,
+                    std::io::Error::new(
+                        std::io::ErrorKind::PermissionDenied,
+                        "canonicalization unavailable in test capabilities",
+                    ),
+                ))
+            });
+        }
         let path = path.to_path_buf();
         Box::pin(async move { Ok(path) })
     }
@@ -76,10 +88,85 @@ impl EvalCapabilities for MemoryCapabilities {
     }
 }
 
+struct SandboxPackageCapabilities {
+    archive: Vec<u8>,
+    extraction_dir: PathBuf,
+}
+
+impl EvalCapabilities for SandboxPackageCapabilities {
+    fn read_to_string<'a>(&'a mut self, path: &'a Path) -> BoxFuture<'a, pklr::Result<String>> {
+        Box::pin(async move {
+            std::fs::read_to_string(path)
+                .map_err(|error| pklr::Error::Io(path.to_path_buf(), error))
+        })
+    }
+
+    fn path_exists<'a>(&'a mut self, path: &'a Path) -> BoxFuture<'a, pklr::Result<bool>> {
+        Box::pin(async move { Ok(path.exists()) })
+    }
+
+    fn canonicalize<'a>(&'a mut self, path: &'a Path) -> BoxFuture<'a, pklr::Result<PathBuf>> {
+        Box::pin(async move {
+            path.canonicalize()
+                .map_err(|error| pklr::Error::Io(path.to_path_buf(), error))
+        })
+    }
+
+    fn read_env<'a>(&'a mut self, _name: &'a str) -> BoxFuture<'a, pklr::Result<Option<String>>> {
+        Box::pin(async move { Ok(None) })
+    }
+
+    fn fetch_text<'a>(&'a mut self, url: &'a str) -> BoxFuture<'a, pklr::Result<String>> {
+        let url = url.to_string();
+        Box::pin(async move {
+            Err(pklr::Error::Unsupported(format!(
+                "text fetch unavailable in package test: {url}"
+            )))
+        })
+    }
+
+    fn fetch_bytes<'a>(&'a mut self, _url: &'a str) -> BoxFuture<'a, pklr::Result<Vec<u8>>> {
+        let archive = self.archive.clone();
+        Box::pin(async move { Ok(archive) })
+    }
+
+    fn temp_dir<'a>(&'a mut self, _prefix: &'a str) -> BoxFuture<'a, pklr::Result<PathBuf>> {
+        let extraction_dir = self.extraction_dir.clone();
+        Box::pin(async move {
+            std::fs::create_dir_all(&extraction_dir)
+                .map_err(|error| pklr::Error::Io(extraction_dir.clone(), error))?;
+            Ok(extraction_dir)
+        })
+    }
+
+    fn glob<'a>(
+        &'a mut self,
+        _base: &'a Path,
+        _pattern: &'a str,
+    ) -> BoxFuture<'a, pklr::Result<Vec<PathBuf>>> {
+        Box::pin(async move { Ok(Vec::new()) })
+    }
+}
+
 #[test]
 fn evaluator_is_send() {
     fn assert_send<T: Send>() {}
     assert_send::<pklr::Evaluator>();
+}
+
+#[tokio::test]
+async fn entry_file_evaluates_when_canonicalization_is_unavailable() {
+    let path = Path::new("uncanonicalized.pkl");
+    let mut evaluator = Evaluator::with_capabilities(MemoryCapabilities {
+        modules: HashMap::from([(path.display().to_string(), "answer = 42\n".to_string())]),
+        env: HashMap::new(),
+        env_fetches: Arc::new(Mutex::new(Vec::new())),
+        fetches: Arc::new(Mutex::new(Vec::new())),
+    });
+
+    let json = evaluator.eval_file_pub(path).await.unwrap().to_json();
+
+    assert_eq!(json["answer"], 42);
 }
 
 #[tokio::test]
@@ -111,6 +198,47 @@ async fn custom_capabilities_handle_http_import() {
         *fetches.lock().unwrap(),
         vec!["http://example.test/Main.pkl".to_string()]
     );
+}
+
+#[tokio::test]
+async fn package_extraction_uses_custom_temp_dir() {
+    use std::io::Write;
+
+    let root = std::env::temp_dir().join(format!(
+        "pklr_test_custom_package_temp_{}",
+        std::process::id()
+    ));
+    let _ = std::fs::remove_dir_all(&root);
+    let extraction_dir = root.join("sandbox");
+    let mut archive = Vec::new();
+    {
+        let mut zip = zip::ZipWriter::new(std::io::Cursor::new(&mut archive));
+        zip.start_file(
+            "Config.pkl",
+            zip::write::SimpleFileOptions::default()
+                .compression_method(zip::CompressionMethod::Stored),
+        )
+        .unwrap();
+        zip.write_all(b"answer = 42\n").unwrap();
+        zip.finish().unwrap();
+    }
+    let mut evaluator = Evaluator::with_capabilities(SandboxPackageCapabilities {
+        archive,
+        extraction_dir: extraction_dir.clone(),
+    });
+
+    let json = evaluator
+        .eval_source(
+            "amends \"package://example.com/package@1.0.0#/Config.pkl\"\n",
+            &root.join("main.pkl"),
+        )
+        .await
+        .unwrap()
+        .to_json();
+
+    assert_eq!(json["answer"], 42);
+    assert!(extraction_dir.join("Config.pkl").is_file());
+    std::fs::remove_dir_all(root).unwrap();
 }
 
 #[tokio::test]
@@ -300,7 +428,7 @@ async fn eval_outcome_exposes_environment_reads() {
     let path = dir.join("main.pkl");
     std::fs::write(&path, "value = read?(\"env:PATH\")\n").unwrap();
 
-    let outcome = pklr::eval_with_options(&path, pklr::EvalOptions::default())
+    let outcome = pklr::eval_with_options_async(&path, pklr::AsyncEvalOptions::default())
         .await
         .unwrap();
 
@@ -441,8 +569,8 @@ amends "base.pkl"; import "helper.pkl"; x = helper.value
     assert_eq!(module.imports[0].uri, "helper.pkl");
 }
 
-#[test]
-fn analyze_imports_deduplicates_diamond_graph() {
+#[tokio::test]
+async fn analyze_imports_deduplicates_diamond_graph() {
     let dir = std::env::temp_dir().join(format!(
         "pklr_test_analyze_imports_diamond_{}",
         std::process::id()
@@ -461,7 +589,9 @@ import "right.pkl"
     std::fs::write(dir.join("right.pkl"), r#"import "shared.pkl""#).unwrap();
     std::fs::write(dir.join("shared.pkl"), "x = 1").unwrap();
 
-    let imports = pklr::analyze_imports(&dir.join("main.pkl")).unwrap();
+    let imports = pklr::analyze_imports_async(&dir.join("main.pkl"))
+        .await
+        .unwrap();
     let shared = dir.join("shared.pkl");
     assert_eq!(
         imports.iter().filter(|path| **path == shared).count(),
@@ -470,8 +600,8 @@ import "right.pkl"
     );
 }
 
-#[test]
-fn analyze_imports_excludes_missing_files() {
+#[tokio::test]
+async fn analyze_imports_excludes_missing_files() {
     let dir = std::env::temp_dir().join(format!(
         "pklr_test_analyze_imports_missing_{}",
         std::process::id()
@@ -488,7 +618,9 @@ import "existing.pkl"
     .unwrap();
     std::fs::write(dir.join("existing.pkl"), "x = 1").unwrap();
 
-    let imports = pklr::analyze_imports(&dir.join("main.pkl")).unwrap();
+    let imports = pklr::analyze_imports_async(&dir.join("main.pkl"))
+        .await
+        .unwrap();
     assert_eq!(imports, vec![dir.join("existing.pkl")]);
     let _ = std::fs::remove_dir_all(&dir);
 }
@@ -498,7 +630,7 @@ import "existing.pkl"
 fn eval_src(src: &str) -> serde_json::Value {
     let rt = tokio::runtime::Runtime::new().unwrap();
     rt.block_on(async {
-        let mut ev = Evaluator::new();
+        let mut ev = Evaluator::new_async();
         let path = std::path::Path::new("test.pkl");
         let val = ev.eval_source(src, path).await.unwrap();
         val.to_json()
@@ -665,7 +797,7 @@ fail_fast = true
 #[tokio::test]
 #[ignore = "requires network access to fetch package zip"]
 async fn test_hk_config_amends() {
-    let mut evaluator = pklr::Evaluator::new();
+    let mut evaluator = pklr::Evaluator::new_async();
     let result = evaluator.eval_source(
         r#"amends "package://github.com/jdx/hk/releases/download/v1.40.0/hk@1.40.0#/Config.pkl""#,
         std::path::Path::new("test_hk.pkl"),
@@ -679,7 +811,7 @@ async fn test_hk_config_amends() {
 
 #[tokio::test]
 async fn test_github_actions_workflow() {
-    let mut evaluator = pklr::Evaluator::new();
+    let mut evaluator = pklr::Evaluator::new_async();
     let cache_dir = std::env::temp_dir().join(format!(
         "pklr-github-actions-{}-{:?}",
         std::process::id(),
@@ -687,11 +819,12 @@ async fn test_github_actions_workflow() {
     ));
     evaluator.set_package_cache_dir(&cache_dir);
     evaluator
-        .preload_package(
+        .preload_package_async(
             "https://github.com/apple/pkl-pantry/releases/download/com.github.actions@1.9.0/com.github.actions@1.9.0.zip",
             "zip",
             include_bytes!("fixtures/com.github.actions-1.9.0.zip"),
         )
+        .await
         .unwrap();
     evaluator.set_offline(true);
     let source = r#"
@@ -751,7 +884,7 @@ hooks {
     }
 }
 "#;
-    let mut evaluator = pklr::Evaluator::new();
+    let mut evaluator = pklr::Evaluator::new_async();
     let result = evaluator
         .eval_source(src, std::path::Path::new("test_hk_full.pkl"))
         .await;
@@ -937,7 +1070,7 @@ async fn http_module_resolves_relative_import() {
     ]);
     let src = format!("import \"{base}/cfg/Main.pkl\" as Main\nresult = Main.value\n");
 
-    let mut evaluator = pklr::Evaluator::new();
+    let mut evaluator = pklr::Evaluator::new_async();
     let result = evaluator
         .eval_source(&src, std::path::Path::new("entry.pkl"))
         .await;
@@ -962,7 +1095,7 @@ async fn http_module_resolves_relative_amends() {
     ]);
     let src = format!("amends \"{base}/cfg/Main.pkl\"\n");
 
-    let mut evaluator = pklr::Evaluator::new();
+    let mut evaluator = pklr::Evaluator::new_async();
     let result = evaluator
         .eval_source(&src, std::path::Path::new("entry.pkl"))
         .await;
@@ -987,7 +1120,7 @@ async fn http_module_resolves_relative_extends() {
     ]);
     let src = format!("import \"{base}/cfg/Main.pkl\" as Main\nresult = Main\n");
 
-    let mut evaluator = pklr::Evaluator::new();
+    let mut evaluator = pklr::Evaluator::new_async();
     let result = evaluator
         .eval_source(&src, std::path::Path::new("entry.pkl"))
         .await;
@@ -1026,7 +1159,7 @@ local steps = new Mapping<String, Step> {
 
 result = steps
 "#;
-    let mut evaluator = pklr::Evaluator::new();
+    let mut evaluator = pklr::Evaluator::new_async();
     let result = evaluator
         .eval_source(src, std::path::Path::new("test_min.pkl"))
         .await;
@@ -1089,7 +1222,7 @@ class Hook {
 
 hooks: Mapping<String, Hook> = new Mapping<String, Hook> {}
 "#;
-    let mut evaluator = pklr::Evaluator::new();
+    let mut evaluator = pklr::Evaluator::new_async();
     let result = evaluator
         .eval_source(src, std::path::Path::new("test_nested.pkl"))
         .await;
@@ -1150,7 +1283,7 @@ hooks {
     }
 }
 "#;
-    let mut evaluator = pklr::Evaluator::new();
+    let mut evaluator = pklr::Evaluator::new_async();
     let result = evaluator
         .eval_source(src, std::path::Path::new("test_nested_amend.pkl"))
         .await;
@@ -1166,7 +1299,7 @@ hooks {
 async fn test_local_config_pkl() {
     // Test with the actual extracted Config.pkl
     let src = std::fs::read_to_string("/tmp/hk-extracted/Config.pkl").unwrap();
-    let mut evaluator = pklr::Evaluator::new();
+    let mut evaluator = pklr::Evaluator::new_async();
     let result = evaluator
         .eval_source(&src, std::path::Path::new("/tmp/hk-extracted/Config.pkl"))
         .await;
@@ -1182,7 +1315,7 @@ async fn test_local_config_pkl() {
 async fn test_single_builtin() {
     // Test evaluating just one builtin file directly
     let src = std::fs::read_to_string("/tmp/hk-extracted/builtins/actionlint.pkl").unwrap();
-    let mut evaluator = pklr::Evaluator::new();
+    let mut evaluator = pklr::Evaluator::new_async();
     let start = std::time::Instant::now();
     let result = evaluator
         .eval_source(
@@ -1205,7 +1338,7 @@ async fn test_single_builtin() {
 async fn test_builtins_pkl() {
     // Test evaluating Builtins.pkl (which imports all 128 builtins)
     let src = std::fs::read_to_string("/tmp/hk-extracted/Builtins.pkl").unwrap();
-    let mut evaluator = pklr::Evaluator::new();
+    let mut evaluator = pklr::Evaluator::new_async();
     let start = std::time::Instant::now();
     let result = evaluator
         .eval_source(&src, std::path::Path::new("/tmp/hk-extracted/Builtins.pkl"))
@@ -1240,7 +1373,7 @@ class TestMaker {
 local tm = new TestMaker { before = "git init" }
 result = tm.checkPass()
 "#;
-    let mut ev = pklr::Evaluator::new();
+    let mut ev = pklr::Evaluator::new_async();
     let result = ev
         .eval_source(src, std::path::Path::new("test_outer.pkl"))
         .await;
@@ -1262,7 +1395,7 @@ async fn test_outer_before_with_local_config() {
         return;
     }
     // Test: can we evaluate helpers.pkl which uses outer.before?
-    let mut ev = pklr::Evaluator::new();
+    let mut ev = pklr::Evaluator::new_async();
     let result = ev
         .eval_source(
             &src,
@@ -1284,7 +1417,7 @@ async fn test_outer_before_single_builtin() {
     if src.is_empty() {
         return;
     }
-    let mut ev = pklr::Evaluator::new();
+    let mut ev = pklr::Evaluator::new_async();
     let result = ev
         .eval_source(
             &src,

--- a/tests/pkl_features.rs
+++ b/tests/pkl_features.rs
@@ -8,7 +8,7 @@ use pklr::eval::Evaluator;
 fn eval(src: &str) -> serde_json::Value {
     let rt = tokio::runtime::Runtime::new().unwrap();
     rt.block_on(async {
-        let mut ev = Evaluator::new();
+        let mut ev = Evaluator::new_async();
         let path = std::path::Path::new("test.pkl");
         let val = ev.eval_source(src, path).await.unwrap();
         val.to_json()
@@ -19,7 +19,7 @@ fn eval(src: &str) -> serde_json::Value {
 fn eval_with_converters(src: &str) -> serde_json::Value {
     let rt = tokio::runtime::Runtime::new().unwrap();
     rt.block_on(async {
-        let mut ev = Evaluator::new();
+        let mut ev = Evaluator::new_async();
         let path = std::path::Path::new("test.pkl");
         let val = ev.eval_source(src, path).await.unwrap();
         let val = ev.apply_converters(val).await.unwrap();
@@ -30,7 +30,7 @@ fn eval_with_converters(src: &str) -> serde_json::Value {
 fn eval_fails(src: &str) -> String {
     let rt = tokio::runtime::Runtime::new().unwrap();
     rt.block_on(async {
-        let mut ev = Evaluator::new();
+        let mut ev = Evaluator::new_async();
         let path = std::path::Path::new("test.pkl");
         match ev.eval_source(src, path).await {
             Err(e) => e.to_string(),
@@ -1023,7 +1023,7 @@ null_safe = "false"?.toBoolean()
 
 #[tokio::test]
 async fn import_local_file() {
-    let mut ev = pklr::eval::Evaluator::new();
+    let mut ev = pklr::eval::Evaluator::new_async();
     // Set base path so relative imports resolve correctly
     let base = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures");
     ev.set_base_path(&base);
@@ -1043,7 +1043,7 @@ x = helper.value
 
 #[tokio::test]
 async fn amends_local_file() {
-    let mut ev = pklr::eval::Evaluator::new();
+    let mut ev = pklr::eval::Evaluator::new_async();
     let base = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures");
     ev.set_base_path(&base);
     let src = r#"
@@ -1062,7 +1062,7 @@ name = "override"
 
 #[tokio::test]
 async fn amends_strips_inherited_class_definitions() {
-    let mut ev = pklr::eval::Evaluator::new();
+    let mut ev = pklr::eval::Evaluator::new_async();
     let base = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures");
     ev.set_base_path(&base);
     let src = r#"
@@ -1081,7 +1081,7 @@ name = "override"
 
 #[tokio::test]
 async fn extends_strips_inherited_class_definitions() {
-    let mut ev = pklr::eval::Evaluator::new();
+    let mut ev = pklr::eval::Evaluator::new_async();
     let base = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures");
     ev.set_base_path(&base);
     let src = r#"
@@ -1104,7 +1104,7 @@ name = "child"
 
 #[tokio::test]
 async fn circular_import_does_not_loop() {
-    let mut ev = pklr::eval::Evaluator::new();
+    let mut ev = pklr::eval::Evaluator::new_async();
     let base = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures");
     ev.set_base_path(&base);
     let path = base.join("circular_a.pkl");
@@ -1146,7 +1146,9 @@ result = a.a_value
     )
     .unwrap();
 
-    let val = pklr::eval_to_json(&dir.join("main.pkl")).await.unwrap();
+    let val = pklr::eval_to_json_async(&dir.join("main.pkl"))
+        .await
+        .unwrap();
     assert_eq!(val["result"], "from_a");
 }
 
@@ -1156,7 +1158,7 @@ result = a.a_value
 
 #[tokio::test]
 async fn import_glob() {
-    let mut ev = pklr::eval::Evaluator::new();
+    let mut ev = pklr::eval::Evaluator::new_async();
     let base = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures");
     ev.set_base_path(&base);
     let src = r#"
@@ -1203,7 +1205,9 @@ amended = (factory) { stdin = true }
     )
     .unwrap();
 
-    let val = pklr::eval_to_json(&dir.join("main.pkl")).await.unwrap();
+    let val = pklr::eval_to_json_async(&dir.join("main.pkl"))
+        .await
+        .unwrap();
     assert_eq!(val["factory"]["step"]["check"], "prettier --check");
     assert_eq!(val["amended"]["step"]["check"], "prettier --stdin-filepath");
 }
@@ -1224,7 +1228,7 @@ has_self = Index.containsKey("hk.pkl")
     )
     .unwrap();
 
-    let val = pklr::eval_to_json(&dir.join("hk.pkl")).await.unwrap();
+    let val = pklr::eval_to_json_async(&dir.join("hk.pkl")).await.unwrap();
     assert_eq!(val["value"], "foo");
     assert_eq!(val["has_self"], false);
 }
@@ -1247,7 +1251,7 @@ has_nested = Index.containsKey("nested/config/bar.pkl")
     )
     .unwrap();
 
-    let val = pklr::eval_to_json(&dir.join("hk.pkl")).await.unwrap();
+    let val = pklr::eval_to_json_async(&dir.join("hk.pkl")).await.unwrap();
     assert_eq!(val["value"], "foo");
     assert_eq!(val["has_nested"], false);
 }
@@ -1269,7 +1273,9 @@ nested_value = Index["nested/foo.pkl"].value
     )
     .unwrap();
 
-    let val = pklr::eval_to_json(&dir.join("main.pkl")).await.unwrap();
+    let val = pklr::eval_to_json_async(&dir.join("main.pkl"))
+        .await
+        .unwrap();
     assert_eq!(val["root_value"], "root");
     assert_eq!(val["nested_value"], "nested");
 }
@@ -1291,7 +1297,9 @@ value = Index["linked.pkl"].value
     )
     .unwrap();
 
-    let val = pklr::eval_to_json(&dir.join("main.pkl")).await.unwrap();
+    let val = pklr::eval_to_json_async(&dir.join("main.pkl"))
+        .await
+        .unwrap();
     assert_eq!(val["value"], "foo");
 }
 
@@ -1312,7 +1320,9 @@ has_broken = Index.containsKey("broken.pkl")
     )
     .unwrap();
 
-    let val = pklr::eval_to_json(&dir.join("main.pkl")).await.unwrap();
+    let val = pklr::eval_to_json_async(&dir.join("main.pkl"))
+        .await
+        .unwrap();
     assert_eq!(val["value"], "good");
     assert_eq!(val["has_broken"], false);
 }
@@ -1338,7 +1348,7 @@ result = "ok"
     .unwrap();
 
     let path = dir.join("main.pkl");
-    let val = pklr::eval_to_json(&path).await.unwrap();
+    let val = pklr::eval_to_json_async(&path).await.unwrap();
     assert_eq!(val["result"], "ok");
 }
 
@@ -1408,7 +1418,7 @@ import "meta.pkl"
 result = new Project {}
 "#;
 
-    let mut ev = Evaluator::new();
+    let mut ev = Evaluator::new_async();
     let val = ev.eval_source(src, &dir.join("child.pkl")).await.unwrap();
     let json = val.to_json();
     assert_eq!(json["result"]["name"], "hk");
@@ -1437,7 +1447,9 @@ baseName = Base.name
     )
     .unwrap();
 
-    let val = pklr::eval_to_json(&dir.join("child.pkl")).await.unwrap();
+    let val = pklr::eval_to_json_async(&dir.join("child.pkl"))
+        .await
+        .unwrap();
     assert_eq!(val["name"], "hk");
     assert_eq!(val["baseName"], "hk");
 }
@@ -1464,7 +1476,7 @@ result = name
     )
     .unwrap();
 
-    let mut ev = Evaluator::new();
+    let mut ev = Evaluator::new_async();
     let child_val = ev.eval_file_pub(&dir.join("child.pkl")).await.unwrap();
     assert_eq!(child_val.to_json()["result"], "hk");
 
@@ -1496,7 +1508,9 @@ extended = ExtendsBase.extendsName
     )
     .unwrap();
 
-    let val = pklr::eval_to_json(&dir.join("child.pkl")).await.unwrap();
+    let val = pklr::eval_to_json_async(&dir.join("child.pkl"))
+        .await
+        .unwrap();
     assert_eq!(val["extendsName"], "hk");
     assert_eq!(val["amended"], "hk");
     assert_eq!(val["extended"], "hk");
@@ -1549,7 +1563,7 @@ amended = ((Builtins.prettier) { stdin = true }).step
     .unwrap();
 
     let path = dir.join("main.pkl");
-    let val = pklr::eval_to_json(&path).await.unwrap();
+    let val = pklr::eval_to_json_async(&path).await.unwrap();
     assert_eq!(val["result"], "ok");
     assert_eq!(val["amended"], "stdin");
 }
@@ -1589,7 +1603,9 @@ result = Builtins.prettier
     )
     .unwrap();
 
-    let val = pklr::eval_to_json(&dir.join("main.pkl")).await.unwrap();
+    let val = pklr::eval_to_json_async(&dir.join("main.pkl"))
+        .await
+        .unwrap();
     assert_eq!(val["result"], "ok");
 }
 
@@ -1617,7 +1633,9 @@ z = Dep.z
     )
     .unwrap();
 
-    let val = pklr::eval_to_json(&dir.join("main.pkl")).await.unwrap();
+    let val = pklr::eval_to_json_async(&dir.join("main.pkl"))
+        .await
+        .unwrap();
     assert_eq!(val["y"], 42);
     assert_eq!(val["z"], 43);
 }
@@ -1653,7 +1671,9 @@ enabled = steps["a"].enabled
     )
     .unwrap();
 
-    let val = pklr::eval_to_json(&dir.join("main.pkl")).await.unwrap();
+    let val = pklr::eval_to_json_async(&dir.join("main.pkl"))
+        .await
+        .unwrap();
     assert_eq!(val["other"], "other");
     assert_eq!(val["enabled"], true);
 }
@@ -1688,7 +1708,9 @@ enabled = steps["a"].enabled
     )
     .unwrap();
 
-    let val = pklr::eval_to_json(&dir.join("main.pkl")).await.unwrap();
+    let val = pklr::eval_to_json_async(&dir.join("main.pkl"))
+        .await
+        .unwrap();
     assert_eq!(val["other"], "other");
     assert_eq!(val["enabled"], true);
 }
@@ -1716,7 +1738,9 @@ result = Dep.wanted
     )
     .unwrap();
 
-    let val = pklr::eval_to_json(&dir.join("main.pkl")).await.unwrap();
+    let val = pklr::eval_to_json_async(&dir.join("main.pkl"))
+        .await
+        .unwrap();
     assert_eq!(val["result"], "ok");
 }
 
@@ -1741,7 +1765,9 @@ result = Dep.toMap().toMapping()
     )
     .unwrap();
 
-    let val = pklr::eval_to_json(&dir.join("main.pkl")).await.unwrap();
+    let val = pklr::eval_to_json_async(&dir.join("main.pkl"))
+        .await
+        .unwrap();
     assert_eq!(val["result"]["first"], "one");
     assert_eq!(val["result"]["second"], "two");
 }
@@ -1767,7 +1793,9 @@ result = Dep.mapValues((k, v) -> v + 1).toMapping()
     )
     .unwrap();
 
-    let val = pklr::eval_to_json(&dir.join("main.pkl")).await.unwrap();
+    let val = pklr::eval_to_json_async(&dir.join("main.pkl"))
+        .await
+        .unwrap();
     assert_eq!(val["result"]["first"], 2);
     assert_eq!(val["result"]["second"], 3);
 }
@@ -1793,7 +1821,9 @@ result = Dep.map(41)
     )
     .unwrap();
 
-    let val = pklr::eval_to_json(&dir.join("main.pkl")).await.unwrap();
+    let val = pklr::eval_to_json_async(&dir.join("main.pkl"))
+        .await
+        .unwrap();
     assert_eq!(val["result"], 42);
 }
 
@@ -1819,7 +1849,9 @@ result = Dep.picked()
     )
     .unwrap();
 
-    let val = pklr::eval_to_json(&dir.join("main.pkl")).await.unwrap();
+    let val = pklr::eval_to_json_async(&dir.join("main.pkl"))
+        .await
+        .unwrap();
     assert_eq!(val["result"], "ok");
 }
 
@@ -1892,7 +1924,9 @@ steps = other.STEPS
     )
     .unwrap();
 
-    let val = pklr::eval_to_json(&dir.join("main.pkl")).await.unwrap();
+    let val = pklr::eval_to_json_async(&dir.join("main.pkl"))
+        .await
+        .unwrap();
     assert_eq!(val["steps"]["original"]["check"], "echo original");
     assert!(val["steps"]["original"].get("Script").is_none(), "{val}");
 }
@@ -2859,7 +2893,7 @@ x = name
 
 #[tokio::test]
 async fn const_cannot_override_in_amends() {
-    let mut ev = pklr::eval::Evaluator::new();
+    let mut ev = pklr::eval::Evaluator::new_async();
     let base = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures");
     ev.set_base_path(&base);
     // Create a base file with const property
@@ -3316,7 +3350,7 @@ fn inherited_late_binding_recomputes_dependency_chains() {
     std::fs::write(&child, "extends \"Base.pkl\"\nc = 2\ne = d + 1\n").unwrap();
     let runtime = tokio::runtime::Runtime::new().unwrap();
     let json = runtime
-        .block_on(pklr::EvaluatorBuilder::new().eval_to_json(&child))
+        .block_on(pklr::AsyncEvaluatorBuilder::new().eval_to_json(&child))
         .unwrap();
     assert_eq!(json["a"], 2);
     assert_eq!(json["m"], 2);
@@ -3341,7 +3375,7 @@ fn child_locals_recompute_after_inherited_properties_are_overridden() {
     .unwrap();
     let runtime = tokio::runtime::Runtime::new().unwrap();
     let json = runtime
-        .block_on(pklr::EvaluatorBuilder::new().eval_to_json(&child))
+        .block_on(pklr::AsyncEvaluatorBuilder::new().eval_to_json(&child))
         .unwrap();
     assert_eq!(json["source"], 2);
     assert_eq!(json["result"], 3);
@@ -3360,7 +3394,7 @@ fn inherited_late_binding_preserves_parent_locals() {
     std::fs::write(&child, "extends \"Base.pkl\"\nsource = 2\n").unwrap();
     let runtime = tokio::runtime::Runtime::new().unwrap();
     let json = runtime
-        .block_on(pklr::EvaluatorBuilder::new().eval_to_json(&child))
+        .block_on(pklr::AsyncEvaluatorBuilder::new().eval_to_json(&child))
         .unwrap();
     assert_eq!(json["source"], 2);
     assert_eq!(json["derived"], 3);
@@ -3388,7 +3422,7 @@ fn inherited_late_binding_reaches_grandparent_declarations() {
     .unwrap();
     let runtime = tokio::runtime::Runtime::new().unwrap();
     let json = runtime
-        .block_on(pklr::EvaluatorBuilder::new().eval_to_json(&child))
+        .block_on(pklr::AsyncEvaluatorBuilder::new().eval_to_json(&child))
         .unwrap();
     assert_eq!(json["source"], 2);
     assert_eq!(json["derived"], 3);
@@ -3411,7 +3445,7 @@ fn computed_sibling_access_recomputes_after_child_override() {
     .unwrap();
     let runtime = tokio::runtime::Runtime::new().unwrap();
     let json = runtime
-        .block_on(pklr::EvaluatorBuilder::new().eval_to_json(&child))
+        .block_on(pklr::AsyncEvaluatorBuilder::new().eval_to_json(&child))
         .unwrap();
     assert_eq!(json["result"], 2);
 }
@@ -3432,7 +3466,7 @@ fn aliased_module_snapshot_recomputes_after_child_override() {
     .unwrap();
     let runtime = tokio::runtime::Runtime::new().unwrap();
     let json = runtime
-        .block_on(pklr::EvaluatorBuilder::new().eval_to_json(&child))
+        .block_on(pklr::AsyncEvaluatorBuilder::new().eval_to_json(&child))
         .unwrap();
     assert_eq!(json["result"], 2);
 }
@@ -3449,7 +3483,7 @@ fn amended_scope_only_defaults_stay_out_of_output() {
     std::fs::write(&child, "amends \"Base.pkl\"\n").unwrap();
     let runtime = tokio::runtime::Runtime::new().unwrap();
     let json = runtime
-        .block_on(pklr::EvaluatorBuilder::new().eval_to_json(&child))
+        .block_on(pklr::AsyncEvaluatorBuilder::new().eval_to_json(&child))
         .unwrap();
     assert!(json.get("implicit").is_none());
     assert_eq!(json["visible"], 0);
@@ -3467,7 +3501,7 @@ fn inherited_late_binding_propagates_errors() {
     std::fs::write(&child, "extends \"Base.pkl\"\ndenominator = 0\n").unwrap();
     let runtime = tokio::runtime::Runtime::new().unwrap();
     let error = runtime
-        .block_on(pklr::EvaluatorBuilder::new().eval_to_json(&child))
+        .block_on(pklr::AsyncEvaluatorBuilder::new().eval_to_json(&child))
         .unwrap_err()
         .to_string();
     assert!(error.contains("division by zero"));
@@ -3497,7 +3531,7 @@ fn used_unresolved_abstract_member_still_errors() {
     std::fs::write(&child, "extends \"Base.pkl\"\nresult = dependent\n").unwrap();
     let runtime = tokio::runtime::Runtime::new().unwrap();
     let error = runtime
-        .block_on(pklr::EvaluatorBuilder::new().eval_to_json(&child))
+        .block_on(pklr::AsyncEvaluatorBuilder::new().eval_to_json(&child))
         .unwrap_err()
         .to_string();
     assert!(error.contains("abstract property") || error.contains("undefined variable"));
@@ -3515,7 +3549,7 @@ fn concrete_module_must_implement_inherited_abstract_property() {
     std::fs::write(&child, "extends \"Base.pkl\"\n").unwrap();
     let runtime = tokio::runtime::Runtime::new().unwrap();
     let error = runtime
-        .block_on(pklr::EvaluatorBuilder::new().eval_to_json(&child))
+        .block_on(pklr::AsyncEvaluatorBuilder::new().eval_to_json(&child))
         .unwrap_err()
         .to_string();
     assert!(error.contains("abstract property 'required'"));
@@ -3526,7 +3560,7 @@ fn concrete_module_must_implement_inherited_abstract_property() {
     )
     .unwrap();
     let json = runtime
-        .block_on(pklr::EvaluatorBuilder::new().eval_to_json(&child))
+        .block_on(pklr::AsyncEvaluatorBuilder::new().eval_to_json(&child))
         .unwrap();
     assert_eq!(json["required"], serde_json::json!(["implemented"]));
 }
@@ -3996,7 +4030,7 @@ x = new Child {}
 
 #[tokio::test]
 async fn module_extends_inherits_properties() {
-    let mut ev = pklr::eval::Evaluator::new();
+    let mut ev = pklr::eval::Evaluator::new_async();
     let base = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures");
     ev.set_base_path(&base);
     let src = r#"
@@ -4017,7 +4051,7 @@ extra = "new property"
 
 #[tokio::test]
 async fn module_extends_inherits_classes() {
-    let mut ev = pklr::eval::Evaluator::new();
+    let mut ev = pklr::eval::Evaluator::new_async();
     let base = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures");
     ev.set_base_path(&base);
     let src = r#"
@@ -4061,7 +4095,7 @@ x = read?("env:DEFINITELY_NOT_SET_12345")
 
 #[tokio::test]
 async fn read_local_file() {
-    let mut ev = pklr::eval::Evaluator::new();
+    let mut ev = pklr::eval::Evaluator::new_async();
     let base = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures");
     ev.set_base_path(&base);
     let src = r#"
@@ -4075,7 +4109,7 @@ x = read("readme.txt")
 
 #[tokio::test]
 async fn read_file_uri() {
-    let mut ev = pklr::eval::Evaluator::new();
+    let mut ev = pklr::eval::Evaluator::new_async();
     let base = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures");
     ev.set_base_path(&base);
     let file_path = base.join("readme.txt");
@@ -4508,7 +4542,7 @@ glob = Types.Regex(#"^.*\.yaml$"#)
     )
     .unwrap();
 
-    let mut ev = Evaluator::new();
+    let mut ev = Evaluator::new_async();
     let path = dir.join("test.pkl");
     let val = ev
         .eval_source(&std::fs::read_to_string(&path).unwrap(), &path)
@@ -4557,7 +4591,7 @@ hooks {
     )
     .unwrap();
 
-    let mut ev = Evaluator::new();
+    let mut ev = Evaluator::new_async();
     let path = dir.join("hk.pkl");
     let val = ev
         .eval_source(&std::fs::read_to_string(&path).unwrap(), &path)
@@ -4627,7 +4661,7 @@ hooks = new {
     .unwrap();
     let path = dir.join("test.pkl");
     let start = std::time::Instant::now();
-    let val = pklr::eval_to_json(&path).await.unwrap();
+    let val = pklr::eval_to_json_async(&path).await.unwrap();
     let elapsed = start.elapsed();
     eprintln!("eval_amends_perf: {:?}", elapsed);
     assert!(
@@ -4668,7 +4702,7 @@ x {
     )
     .unwrap();
     let path = dir.join("main.pkl");
-    let val = pklr::eval_to_json(&path).await.unwrap();
+    let val = pklr::eval_to_json_async(&path).await.unwrap();
     assert_eq!(val["x"]["tests"]["check bad file"], "check:src/main.rs");
 }
 
@@ -4697,7 +4731,7 @@ result = testMaker.checkFail("bad", 1)
     )
     .unwrap();
     let path = dir.join("main.pkl");
-    let val = pklr::eval_to_json(&path).await.unwrap();
+    let val = pklr::eval_to_json_async(&path).await.unwrap();
     assert_eq!(val["result"], "check:main.rs");
 }
 
@@ -4707,7 +4741,7 @@ result = testMaker.checkFail("bad", 1)
 
 #[test]
 fn rewrite_url_longest_prefix_wins() {
-    let mut ev = Evaluator::new();
+    let mut ev = Evaluator::new_async();
     ev.set_http_rewrites(&[
         "https://example.com/=https://mirror.local/".to_string(),
         "https://example.com/special/=https://special.local/".to_string(),
@@ -4731,7 +4765,7 @@ fn rewrite_url_longest_prefix_wins() {
 
 #[test]
 fn rewrite_url_no_rules_is_identity() {
-    let ev = Evaluator::new();
+    let ev = Evaluator::new_async();
     assert_eq!(
         ev.rewrite_url("https://example.com/foo.pkl"),
         "https://example.com/foo.pkl"
@@ -5829,7 +5863,7 @@ myStep = new Step {{
 
     let rt = tokio::runtime::Runtime::new().unwrap();
     let json = rt.block_on(async {
-        let mut ev = Evaluator::new();
+        let mut ev = Evaluator::new_async();
         let val = ev
             .eval_source(&std::fs::read_to_string(&child_path).unwrap(), &child_path)
             .await
@@ -5889,7 +5923,7 @@ myStep = new Step {{
 
     let rt = tokio::runtime::Runtime::new().unwrap();
     let json = rt.block_on(async {
-        let mut ev = Evaluator::new();
+        let mut ev = Evaluator::new_async();
         let val = ev
             .eval_source(&std::fs::read_to_string(&child_path).unwrap(), &child_path)
             .await
@@ -5998,7 +6032,7 @@ hooks {{
 
     let rt = tokio::runtime::Runtime::new().unwrap();
     let json = rt.block_on(async {
-        let mut ev = Evaluator::new();
+        let mut ev = Evaluator::new_async();
         let val = ev
             .eval_source(&std::fs::read_to_string(&child_path).unwrap(), &child_path)
             .await
@@ -6097,9 +6131,9 @@ hooks {
     let rt = tokio::runtime::Runtime::new().unwrap();
     let json = rt
         .block_on(async {
-            pklr::eval_to_json_with_options(
+            pklr::eval_to_json_with_options_async(
                 &child_path,
-                pklr::EvalOptions {
+                pklr::AsyncEvalOptions {
                     http_rewrites: vec![format!("https://example.com/=http://{addr}/")],
                     ..Default::default()
                 },
@@ -6155,7 +6189,7 @@ fn package_cache_survives_across_offline_evaluators() {
     let rt = tokio::runtime::Runtime::new().unwrap();
     let first = rt
         .block_on(
-            pklr::EvaluatorBuilder::new()
+            pklr::AsyncEvaluatorBuilder::new()
                 .http_rewrites([rewrite.clone()])
                 .package_cache_dir(cache_dir.clone())
                 .eval_to_json(&config_path),
@@ -6167,7 +6201,7 @@ fn package_cache_survives_across_offline_evaluators() {
     // A new evaluator succeeds after the one-shot server has shut down.
     let second = rt
         .block_on(
-            pklr::EvaluatorBuilder::new()
+            pklr::AsyncEvaluatorBuilder::new()
                 .http_rewrites([rewrite])
                 .package_cache_dir(cache_dir)
                 .offline(true)
@@ -6178,7 +6212,7 @@ fn package_cache_survives_across_offline_evaluators() {
 }
 
 /// Build a single-entry package zip holding `contents` at `name`.
-#[cfg(feature = "package-zip")]
+#[cfg(feature = "package-zip-core")]
 fn package_zip(name: &str, contents: &str) -> Vec<u8> {
     use std::io::Write;
 
@@ -6208,7 +6242,7 @@ fn preloaded_package_evaluates_offline_without_a_cold_start() {
     let rt = tokio::runtime::Runtime::new().unwrap();
     let json = rt
         .block_on(
-            pklr::EvaluatorBuilder::new()
+            pklr::AsyncEvaluatorBuilder::new()
                 .package_cache_dir(temp.path().join("cache"))
                 .offline(true)
                 .preload_package(
@@ -6256,7 +6290,7 @@ fn preloaded_package_does_not_override_a_cached_download() {
     let rewrite = format!("https://example.com/=http://{addr}/");
     let rt = tokio::runtime::Runtime::new().unwrap();
     rt.block_on(
-        pklr::EvaluatorBuilder::new()
+        pklr::AsyncEvaluatorBuilder::new()
             .http_rewrites([rewrite])
             .package_cache_dir(cache_dir.clone())
             .eval_to_json(&config_path),
@@ -6267,7 +6301,7 @@ fn preloaded_package_does_not_override_a_cached_download() {
     // The downloaded package is already cached, so the preloaded copy is ignored.
     let json = rt
         .block_on(
-            pklr::EvaluatorBuilder::new()
+            pklr::AsyncEvaluatorBuilder::new()
                 .package_cache_dir(cache_dir)
                 .offline(true)
                 .preload_package(
@@ -6295,7 +6329,7 @@ fn preloading_a_package_for_another_version_is_a_cache_miss() {
     let rt = tokio::runtime::Runtime::new().unwrap();
     let error = rt
         .block_on(
-            pklr::EvaluatorBuilder::new()
+            pklr::AsyncEvaluatorBuilder::new()
                 .package_cache_dir(temp.path().join("cache"))
                 .offline(true)
                 .preload_package(
@@ -6313,13 +6347,14 @@ fn preloading_a_package_for_another_version_is_a_cache_miss() {
     );
 }
 
-#[test]
-fn preloading_invalid_package_bytes_is_rejected() {
+#[tokio::test]
+async fn preloading_invalid_package_bytes_is_rejected() {
     let temp = TestTempDir::new("pklr_test_preload_invalid");
-    let mut evaluator = pklr::Evaluator::new();
+    let mut evaluator = pklr::Evaluator::new_async();
     evaluator.set_package_cache_dir(temp.path().join("cache"));
     let error = evaluator
-        .preload_package("https://example.com/pkg@1.0.0.zip", "zip", b"not a zip")
+        .preload_package_async("https://example.com/pkg@1.0.0.zip", "zip", b"not a zip")
+        .await
         .unwrap_err()
         .to_string();
     assert!(
@@ -6328,22 +6363,23 @@ fn preloading_invalid_package_bytes_is_rejected() {
     );
 }
 
-#[test]
-fn preloading_reports_a_cache_write_failure() {
+#[tokio::test]
+async fn preloading_reports_a_cache_write_failure() {
     let temp = TestTempDir::new("pklr_test_preload_write_failure");
     // A file where the cache directory belongs: the seed cannot be stored, and
     // reporting success would leave the host expecting a usable cache entry.
     let cache_path = temp.path().join("cache");
     std::fs::write(&cache_path, b"not a directory").unwrap();
 
-    let mut evaluator = pklr::Evaluator::new();
+    let mut evaluator = pklr::Evaluator::new_async();
     evaluator.set_package_cache_dir(&cache_path);
     let error = evaluator
-        .preload_package(
+        .preload_package_async(
             "https://example.com/pkg@1.0.0.zip",
             "zip",
             &package_zip("Config.pkl", "answer = 42\n"),
         )
+        .await
         .unwrap_err()
         .to_string();
     assert!(
@@ -6394,7 +6430,7 @@ fn direct_package_relatives_survive_across_offline_evaluators() {
     let rt = tokio::runtime::Runtime::new().unwrap();
     let first = rt
         .block_on(
-            pklr::EvaluatorBuilder::new()
+            pklr::AsyncEvaluatorBuilder::new()
                 .http_rewrites([rewrite.clone()])
                 .package_cache_dir(cache_dir.clone())
                 .eval_to_json(&config_path),
@@ -6406,7 +6442,7 @@ fn direct_package_relatives_survive_across_offline_evaluators() {
 
     let second = rt
         .block_on(
-            pklr::EvaluatorBuilder::new()
+            pklr::AsyncEvaluatorBuilder::new()
                 .http_rewrites([rewrite])
                 .package_cache_dir(cache_dir)
                 .offline(true)
@@ -6459,7 +6495,7 @@ fn unreadable_package_cache_is_a_miss_while_online() {
     let rt = tokio::runtime::Runtime::new().unwrap();
     let json = rt
         .block_on(
-            pklr::EvaluatorBuilder::new()
+            pklr::AsyncEvaluatorBuilder::new()
                 .http_rewrites([format!("https://example.com/=http://{addr}/")])
                 .package_cache_dir(cache_path)
                 .eval_to_json(&config_path),
@@ -6482,7 +6518,7 @@ fn offline_package_cache_miss_is_actionable() {
     let rt = tokio::runtime::Runtime::new().unwrap();
     let error = rt
         .block_on(
-            pklr::EvaluatorBuilder::new()
+            pklr::AsyncEvaluatorBuilder::new()
                 .package_cache_dir(temp.path().join("cache"))
                 .offline(true)
                 .eval_to_json(&config_path),


### PR DESCRIPTION
## Summary

- make synchronous evaluation and import analysis the default API, with no Tokio dependency or spawned runtime/thread
- move async evaluation behind the opt-in `async` feature and expose `AsyncEvaluatorBuilder`, `AsyncEvalOptions`, and `_async` entry points
- use Tokio filesystem operations for async source/import/cache I/O and offload ZIP extraction, glob walking, temp-directory creation, and atomic writes with `spawn_blocking`
- use `ureq` for blocking HTTP and `reqwest` for async HTTP
- skip the semver compatibility check only for PRs whose conventional title explicitly declares a breaking change with `!:`

## Breaking changes

The unsuffixed API is now synchronous. Async callers must disable default features, enable `async`, and migrate to the `Async*`/`*_async` names. This is intended for the next v2 release.

## Validation

- `cargo test`
- `cargo test --all-features`
- `cargo test --no-default-features --features async,package-zip,miette-diagnostics`
- `cargo test --no-default-features --features blocking`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo msrv verify`
- verified Tokio is absent from the blocking-only normal dependency graph

Inspired by and co-authored with the author of #136, while using an independent implementation.

*AI-assisted — Tool: Codex; model: openai/gpt-5; version: unavailable.*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> This is an intentional breaking public API and feature-flag reshuffle touching HTTP, TLS, package cache I/O, and evaluator construction—downstream crates must migrate explicitly.
> 
> **Overview**
> **Breaking change:** the default build is now synchronous—`eval_to_json`, `EvaluatorBuilder`, `analyze_imports`, and related helpers block and no longer pull in Tokio. Async callers must use `default-features = false`, enable `async`, and switch to `eval_to_json_async`, `AsyncEvaluatorBuilder`, `Evaluator::new_async`, `preload_package_async`, and `analyze_imports_async`.
> 
> Default evaluation uses new **`BlockingCapabilities`** (`ureq` + `rustls`) for HTTP; the async path keeps **`NativeCapabilities`** (`reqwest`, Tokio `fs`, and `spawn_blocking` for ZIP extraction, globs, temp dirs, and atomic writes). **`EvalCapabilities`** gains cache-oriented hooks (`read_bytes`, `create_dir_all`, `write_atomic`, `remove_file`, `extract_zip`), and **`set_http_client`** now returns an error on blocking backends.
> 
> Cargo **`default`** features are **`blocking`** and **`miette-diagnostics`** (with internal **`package-zip-core`**); integration tests target **`async`**. CI runs **`cargo test --all-features`** and skips semver checks when the PR title contains **`!:`**. README and tests document the sync default and migration path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2404b303beb24c9af18263a836c6e8c77dd1155e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added separate blocking and asynchronous evaluation APIs.
  * Added synchronous HTTP, filesystem, ZIP extraction, package caching, and import analysis support.
  * Added configurable HTTP clients, evaluator builders, and asynchronous package preloading.
  * Made blocking evaluation the default, with optional asynchronous support.

* **Documentation**
  * Updated guidance for synchronous defaults and asynchronous workflows.

* **Tests**
  * Expanded coverage for evaluation, package extraction, caching, import analysis, and feature configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->