### PR TITLE
chore: release v1.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.5.1](https://github.com/jdx/pklr/compare/v1.5.0...v1.5.1) - 2026-08-26
+
+### Fixed
+
+- *(eval)* complete class-as-function semantics ([#161](https://github.com/jdx/pklr/pull/161))
+
 ## [1.5.0](https://github.com/jdx/pklr/compare/v1.4.0...v1.5.0) - 2026-08-23
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -678,7 +678,7 @@ checksum = "f6b464fbc74e149a392436b17d523f769e057cb6877f6a5c4618bc6f11800548"
 
 [[package]]
 name = "pklr"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "async-recursion",
  "indexmap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "pklr"
-version     = "1.5.0"
+version     = "1.5.1"
 edition      = "2024"
 rust-version = "1.88"
 description = "Pure Rust pkl configuration language parser and evaluator"


### PR DESCRIPTION



## 🤖 New release

* `pklr`: 1.5.0 -> 1.5.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [1.5.1](https://github.com/jdx/pklr/compare/v1.5.0...v1.5.1) - 2026-08-26

### Fixed

- *(eval)* complete class-as-function semantics ([#161](https://github.com/jdx/pklr/pull/161))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version and changelog updates only; no runtime code changes in this PR.
> 
> **Overview**
> **Release-only PR** that publishes **pklr 1.5.1** by bumping the crate version in `Cargo.toml` and `Cargo.lock` from **1.5.0** to **1.5.1**.
> 
> `CHANGELOG.md` gains a **[1.5.1]** section (2026-08-26) under **Fixed**, noting *(eval)* **complete class-as-function semantics** ([#161](https://github.com/jdx/pklr/pull/161)). No evaluator or library source changes appear in this diff—only release metadata aligned with release-plz.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5d7dd95487874b31e954223ade7c9d7281fd959c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->