### PR TITLE
chore: release v2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.0](https://github.com/jdx/pklr/compare/v1.5.1...v2.0.0) - 2026-08-26
+
+### Added
+
+- [**breaking**] make blocking evaluation the default ([#162](https://github.com/jdx/pklr/pull/162))
+
+### Fixed
+
+- *(eval)* support com.github.actions packages ([#164](https://github.com/jdx/pklr/pull/164))
+
 ## [1.5.1](https://github.com/jdx/pklr/compare/v1.5.0...v1.5.1) - 2026-08-26
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -684,7 +684,7 @@ checksum = "f6b464fbc74e149a392436b17d523f769e057cb6877f6a5c4618bc6f11800548"
 
 [[package]]
 name = "pklr"
-version = "1.5.1"
+version = "2.0.0"
 dependencies = [
  "async-recursion",
  "indexmap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "pklr"
-version     = "1.5.1"
+version     = "2.0.0"
 edition      = "2024"
 rust-version = "1.88"
 description = "Pure Rust pkl configuration language parser and evaluator"


### PR DESCRIPTION



## 🤖 New release

* `pklr`: 1.5.1 -> 2.0.0 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [2.0.0](https://github.com/jdx/pklr/compare/v1.5.1...v2.0.0) - 2026-08-26

### Added

- [**breaking**] make blocking evaluation the default ([#162](https://github.com/jdx/pklr/pull/162))

### Fixed

- *(eval)* support com.github.actions packages ([#164](https://github.com/jdx/pklr/pull/164))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> This PR only updates version metadata and changelog; runtime behavior was introduced in earlier merged PRs.
> 
> **Overview**
> **Release v2.0.0** — bumps `pklr` from **1.5.1** to **2.0.0** in `Cargo.toml` / `Cargo.lock` and publishes the **2.0.0** changelog section (moving notes out of `[Unreleased]`).
> 
> The documented user-facing changes in this release (from prior PRs, not new code in this diff) are a **breaking** switch to **blocking evaluation as the default** API/feature set ([#162]) and an **eval** fix to support **`com.github.actions`** packages ([#164]).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9fad965747ec0cf43cb45b890dbe6f7972e042cb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->